### PR TITLE
Prevent no-op FSeeks writing dbf & shp records for network filesystem performance

### DIFF
--- a/dbfopen.c
+++ b/dbfopen.c
@@ -372,16 +372,17 @@ static int DBFFlushRecord( DBFHandle psDBF )
 /*      Guard FSeek with check for whether we're already at position;   */
 /*      no-op FSeeks defeat network filesystems' write buffering.       */
 /* -------------------------------------------------------------------- */
-    if ( psDBF->sHooks.FTell( psDBF->fp ) != nRecordOffset ) {
-      if ( psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 ) != 0 ) {
-        char szMessage[128];
-        snprintf( szMessage, sizeof(szMessage),
-                  "Failure seeking to position before writing DBF record %d.",
-                  psDBF->nCurrentRecord );
-        psDBF->sHooks.Error( szMessage );
-        return FALSE;
-      }
-    }
+        if ( psDBF->bRequireNextWriteSeek ||
+	     psDBF->sHooks.FTell( psDBF->fp ) != nRecordOffset ) {
+            if ( psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 ) != 0 ) {
+                char szMessage[128];
+                snprintf( szMessage, sizeof(szMessage),
+                          "Failure seeking to position before writing DBF record %d.",
+                          psDBF->nCurrentRecord );
+                psDBF->sHooks.Error( szMessage );
+                return FALSE;
+            }
+        }
 
 	if ( psDBF->sHooks.FWrite( psDBF->pszCurrentRecord,
                                psDBF->nRecordLength,
@@ -393,6 +394,11 @@ static int DBFFlushRecord( DBFHandle psDBF )
             psDBF->sHooks.Error( szMessage );
             return FALSE;
         }
+
+/* -------------------------------------------------------------------- */
+/*      If next op is also a write, allow possible skipping of FSeek.   */
+/* -------------------------------------------------------------------- */
+	psDBF->bRequireNextWriteSeek = FALSE;
 
         if( psDBF->nCurrentRecord == psDBF->nRecords - 1 )
         {
@@ -444,6 +450,10 @@ static int DBFLoadRecord( DBFHandle psDBF, int iRecord )
         }
 
 	psDBF->nCurrentRecord = iRecord;
+/* -------------------------------------------------------------------- */
+/*      Require a seek for next write in case of mixed R/W operations.  */
+/* -------------------------------------------------------------------- */
+	psDBF->bRequireNextWriteSeek = TRUE;
     }
 
     return TRUE;
@@ -739,6 +749,8 @@ DBFOpenLL( const char * pszFilename, const char * pszAccess, SAHooks *psHooks )
 
     DBFSetWriteEndOfFileChar( psDBF, TRUE );
 
+    psDBF->bRequireNextWriteSeek = TRUE;
+
     return( psDBF );
 }
 
@@ -923,6 +935,8 @@ DBFCreateLL( const char * pszFilename, const char * pszCodePage, SAHooks *psHook
     DBFSetLastModifiedDate(psDBF, 95, 7, 26); /* dummy date */
 
     DBFSetWriteEndOfFileChar(psDBF, TRUE);
+
+    psDBF->bRequireNextWriteSeek = TRUE;
 
     return( psDBF );
 }

--- a/shapefil.h
+++ b/shapefil.h
@@ -629,6 +629,8 @@ typedef struct
     int         nUpdateDay; /* 1-31 */
 
     int         bWriteEndOfFileChar; /* defaults to TRUE */
+
+    int         bRequireNextWriteSeek;
 } DBFInfo;
 
 typedef DBFInfo * DBFHandle;

--- a/shpopen.c
+++ b/shpopen.c
@@ -1604,7 +1604,8 @@ int SHPAPI_CALL
 SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
 
 {
-    unsigned int	       	nRecordOffset, nRecordSize=0;
+    SAOffset nRecordOffset;
+    unsigned int nRecordSize=0;
     int i;
     uchar	*pabyRec;
     int32	i32;
@@ -1948,18 +1949,25 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
 /* -------------------------------------------------------------------- */
 /*      Write out record.                                               */
 /* -------------------------------------------------------------------- */
-    if( psSHP->sHooks.FSeek( psSHP->fpSHP, nRecordOffset, 0 ) != 0 )
-    {
-        char szErrorMsg[200];
 
-        snprintf( szErrorMsg, sizeof(szErrorMsg),
-                 "Error in psSHP->sHooks.FSeek() while writing object to .shp file: %s",
-                  strerror(errno) );
-        szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-        psSHP->sHooks.Error( szErrorMsg );
+/* -------------------------------------------------------------------- */
+/*      Guard FSeek with check for whether we're already at position;   */
+/*      no-op FSeeks defeat network filesystems' write buffering.       */
+/* -------------------------------------------------------------------- */
+    if ( psSHP->sHooks.FTell( psSHP->fpSHP ) != nRecordOffset ) {
+        if( psSHP->sHooks.FSeek( psSHP->fpSHP, nRecordOffset, 0 ) != 0 )
+        {
+            char szErrorMsg[200];
 
-        free( pabyRec );
-        return -1;
+            snprintf( szErrorMsg, sizeof(szErrorMsg),
+                     "Error in psSHP->sHooks.FSeek() while writing object to .shp file: %s",
+                      strerror(errno) );
+            szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
+            psSHP->sHooks.Error( szErrorMsg );
+
+            free( pabyRec );
+            return -1;
+        }
     }
     if( psSHP->sHooks.FWrite( pabyRec, nRecordSize, 1, psSHP->fpSHP ) < 1 )
     {


### PR DESCRIPTION
Guard DBFFlushRecord and SHPWriteObject FSeek calls with an FTell check for whether we are already at the correct position (a common case). Avoids defeating write buffering on network filesystems; example observed speedups of 2x on NFS and 45x on GlusterFS.