### PR TITLE
Don't call all records deleted if record count is not set

### DIFF
--- a/dbfopen.c
+++ b/dbfopen.c
@@ -1744,7 +1744,7 @@ int SHPAPI_CALL DBFIsRecordDeleted( DBFHandle psDBF, int iShape )
 /* -------------------------------------------------------------------- */
 /*      Verify selection.                                               */
 /* -------------------------------------------------------------------- */
-    if( iShape < 0 || iShape >= psDBF->nRecords )
+    if( iShape < 0 || (iShape > 0 && iShape >= psDBF->nRecords) )
         return TRUE;
 
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION
Some DBF files are written without a record count (because, say
the SHP file or SHX file already give a record count. In that
case, checking the shape index being > number of records always
returns deleted, which is not correct.