### PR TITLE
Don't attempt to write on invalid input

### DIFF
--- a/safileio.c
+++ b/safileio.c
@@ -113,6 +113,7 @@ SAOffset SADFRead( void *p, SAOffset size, SAOffset nmemb, SAFile file )
 SAOffset SADFWrite( void *p, SAOffset size, SAOffset nmemb, SAFile file )
 
 {
+    if (!nmemb || !p) return 0;
     return (SAOffset) fwrite( p, (size_t) size, (size_t) nmemb, 
                               (FILE *) file );
 }


### PR DESCRIPTION
Not sure what exact input causes this, but it's necessary to regress PostGIS on all platforms
