### PR TITLE
dbfdump.c: Close the dbf handle if there are no fields

### DIFF
--- a/dbfdump.c
+++ b/dbfdump.c
@@ -91,6 +91,7 @@ int main( int argc, char ** argv ) {
     if( DBFGetFieldCount(hDBF) == 0 )
     {
 	printf( "There are no fields in this table!\n" );
+        DBFClose(hDBF);
 	exit( 3 );
     }
 


### PR DESCRIPTION
Users likely won't care if things aren't cleaned up correctly before returning from main, as the process ending will release all resources.  However, leak checkers flag it.

I hit this when trying to use a stripped down version of dbfdump for fuzzing

Mostly, this or is me trying out GitHub's web editing capabilities from a phone.