### PR TITLE
Reenable CMake testing by forcing old behavior

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,4 +66,4 @@ jobs:
       run: cmake --build build
 
     - name: Test
-      run: ctest -V build
+      run: cd build && ctest -V .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,4 +65,5 @@ jobs:
     - name: Build with ${{ matrix.compiler }}
       run: cmake --build build
 
-    # No tests configured for CMake
+    - name: Test
+      run: ctest -V .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,4 +66,4 @@ jobs:
       run: cmake --build build
 
     - name: Test
-      run: ctest -V .
+      run: ctest -V build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,8 @@ else(BASH_EXECUTABLE AND SED_EXECUTABLE)
   message(STATUS "WARNING: sed or bash not available so disabling testing")
 endif(BASH_EXECUTABLE AND SED_EXECUTABLE)
 
-set (BUILD_TEST OFF)
+# TODO(schwehr): Temporary work around.
+cmake_policy(SET CMP0026 OLD)
 
 # For the first series of tests, the user needs to have downloaded
 # from http://dl.maptools.org/dl/shapelib/shape_eg_data.zip, unpacked

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ if(MSVC)
 else(MSVC)
   # TODO(schwehr): Temporary work around.
   cmake_policy(SET CMP0026 OLD)
-endif
+endif(MSVC)
 
 # For the first series of tests, the user needs to have downloaded
 # from http://dl.maptools.org/dl/shapelib/shape_eg_data.zip, unpacked

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,8 +173,13 @@ else(BASH_EXECUTABLE AND SED_EXECUTABLE)
   message(STATUS "WARNING: sed or bash not available so disabling testing")
 endif(BASH_EXECUTABLE AND SED_EXECUTABLE)
 
-# TODO(schwehr): Temporary work around.
-cmake_policy(SET CMP0026 OLD)
+if(MSVC)
+  # TODO(schwehr): How to test on Windows?
+  set(BUILD_TEST OFF)
+else(MSVC)
+  # TODO(schwehr): Temporary work around.
+  cmake_policy(SET CMP0026 OLD)
+endif
 
 # For the first series of tests, the user needs to have downloaded
 # from http://dl.maptools.org/dl/shapelib/shape_eg_data.zip, unpacked


### PR DESCRIPTION
Reenable CMake testing by forcing old behavior

This is a temporary solution to get CMake testing working again. With

https://github.com/OSGeo/shapelib/commit/20ce54023f1ed9b320fe5bc06fd746d72de06892 set:

there were several variations of this error:

```
CMake Error at CMakeLists.txt:220 (get_target_property):
  The LOCATION property may not be read from target "shpcreate".  Use the
  target name directly with add_custom_command, or use the generator
  expression $<TARGET_FILE>, as appropriate.
```

See https://github.com/mapserver/mapserver/issues/5646

Skipped getting Windows testing working:

```
test 1
Test not available without configuration.  (Missing "-C <config>"?)
    Start 1: test2
Test not available without configuration.  (Missing "-C <config>"?)
```