### PR TITLE
Change strncpy to memcpy

### DIFF
--- a/shputils.c
+++ b/shputils.c
@@ -322,9 +322,9 @@ void showitems() {
       printf("          RANGES (MEAN)");
     }
 
-    char stmp[40];
-    char slow[40];
-    char shigh[40];
+    char stmp[40] = {0};
+    char slow[40] = {0};
+    char shigh[40] = {0};
 
     for( int i = 0; i < ti; i++ )
     {
@@ -339,8 +339,8 @@ void showitems() {
             for (int iRecord = 0; iRecord < maxrec; iRecord++) {
                 strncpy(stmp,DBFReadStringAttribute( hDBF, iRecord, i ),39);
                 if (strcmp(stmp,"!!") > 0) {
-                    if (strncasecmp2(stmp,slow,0)  < 0) strncpy(slow, stmp,39);
-                    if (strncasecmp2(stmp,shigh,0) > 0) strncpy(shigh,stmp,39);
+                    if (strncasecmp2(stmp,slow,0)  < 0) memcpy(slow, stmp,39);
+                    if (strncasecmp2(stmp,shigh,0) > 0) memcpy(shigh,stmp,39);
                 }
             }
             char *pt = slow+strlen(slow)-1;


### PR DESCRIPTION
This switch from using `strncpy` to `memcpy`.

A similar switch has already been made [here](https://github.com/OSGeo/shapelib/blob/21ae8fc16afa15a1b723077b6cec3a9abc592f6a/dbfopen.c#L1310-L1311).

Without this fix (or one like it), `strncpy` yields warnings:
```
    shputils.c:403:57: warning: 'strncpy' output may be truncated copying 39 bytes from a string of length 39 [-Wstringop-truncation]
    shputils.c:404:57: warning: 'strncpy' output may be truncated copying 39 bytes from a string of length 39 [-Wstringop-truncation]
```