### PR TITLE
Add build/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ ltoptions.m4
 ltsugar.m4
 ltversion.m4
 lt~obsolete.m4
+build/


### PR DESCRIPTION
A common cmake build pattern is to use:
```
mkdir build
cd build
cmake
```
This results in an extraneous `build/` directory that could accidentally be committed.

This PR adds `build/` to the `.gitignore` file to prevent this.