### PR TITLE
Add -Wall -Wextra -pedantic as compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,10 @@ add_library(${PACKAGE} ${lib_SRC})
 target_include_directories (${PACKAGE} INTERFACE
     $<INSTALL_INTERFACE:include>)
 
+if (NOT MSVC)
+  target_compile_options(${PACKAGE} PRIVATE -Wall -Wextra -pedantic)
+endif()
+
 if(WIN32 AND NOT CYGWIN)
   set_target_properties(${PACKAGE}
     PROPERTIES
@@ -218,6 +222,9 @@ foreach(executable ${executables})
     get_target_property(${executable}_LOC ${executable} LOCATION)
     file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/script.sed "s?\\./${executable}?${${executable}_LOC}?\n")
   endif(BUILD_TEST)
+  if (NOT MSVC)
+    target_compile_options(${executable} PRIVATE -Wall -Wextra)
+  endif()
 endforeach(executable ${executables})
 
 install(TARGETS ${executables}


### PR DESCRIPTION
Adds -Wall -Wextra -pedantic compiler flags for non-MSVC builds.

With clang-13 and gcc-11 this does not reveal any new warnings in either cmake's Release or Debug mode.

pedantic yields:
```
/home/rick/projects/contributing/shapelib/safileio.c:46:18: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
   46 | SHP_CVSID("$Id$");
```