### PR TITLE
Code-base reformatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+fe315bace44a770f239cfea6e9d7b9a7b319772b

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+    -   repo: https://github.com/pre-commit/mirrors-clang-format
+        rev: 'v15.0.4'
+        hooks:
+        -   id: clang-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# How to contribute to shapelib
+
+# Commit hooks
+
+shapelib provides pre-commit hooks to run code linters before a commit is made. The
+hooks are cloned with the repository and can be installed using
+[pre-commit](https://pre-commit.com>):
+
+```shell
+    python -m pip install pre-commit
+    pre-commit install
+```
+
+Once installed, the hooks can be run manually via ``pre-commit run --all-files``.
+
+# Blame ignore file
+
+Due to whole-tree code reformatting, ``git blame`` information might be
+misleading. To avoid that, you need to modify your git configuration as following
+to ignore the revision of the whole-tree reformatting:
+
+```shell
+    git config blame.ignoreRevsFile .git-blame-ignore-revs
+```

--- a/contrib/Shape_PointInPoly.cpp
+++ b/contrib/Shape_PointInPoly.cpp
@@ -42,7 +42,8 @@
 
 #define MAXINTERSECTIONPOINTS 255
 
-enum loopDir {
+enum loopDir
+{
     kExterior,
     kInterior,
     kError
@@ -51,26 +52,26 @@ enum loopDir {
 struct DPoint2d
 {
     DPoint2d()
-	{
-            x = y = 0.0;
-	};
+    {
+        x = y = 0.0;
+    };
     DPoint2d(double x, double y)
-	{
-            this->x = x;
-            this->y = y;
-	};
-    double x,y;
+    {
+        this->x = x;
+        this->y = y;
+    };
+    double x, y;
 };
 
 struct IntersectPoint
 {
     IntersectPoint(void)
-	{
-            x = y = 0.0;
-            boundry_nmb = 0;
-            loopdirection = kError;
-	};
-    double x,y;
+    {
+        x = y = 0.0;
+        boundry_nmb = 0;
+        loopdirection = kError;
+    };
+    double x, y;
     int boundry_nmb;
     loopDir loopdirection;
 };
@@ -79,12 +80,13 @@ loopDir LoopDirection(DPoint2d *vertices, int vertsize)
 {
     int i;
     double sum = 0.0;
-    for(i=0;i<vertsize-1;i++)
+    for (i = 0; i < vertsize - 1; i++)
     {
-        sum += (vertices[i].x*vertices[i+1].y)-(vertices[i].y*vertices[i+1].x);
+        sum += (vertices[i].x * vertices[i + 1].y) -
+               (vertices[i].y * vertices[i + 1].x);
     }
 
-    if(sum>0)
+    if (sum > 0)
         return kInterior;
     else
         return kExterior;
@@ -102,64 +104,74 @@ DPoint2d CreatePointInPoly(SHPObject *psShape, int quality)
     ymin = psShape->dfYMin;
     xmax = psShape->dfXMax;
     ymax = psShape->dfYMax;
-    part = (ymax-ymin)/(quality+1);
-    dx = xmax-xmin;
-    for(i=0;i<quality;i++)
+    part = (ymax - ymin) / (quality + 1);
+    dx = xmax - xmin;
+    for (i = 0; i < quality; i++)
     {
-        y = ymin+part*(i+1);
+        y = ymin + part * (i + 1);
         pointpos = 0;
-        for(j=0;j<psShape->nParts;j++)
+        for (j = 0; j < psShape->nParts; j++)
         {
-            if(j==psShape->nParts-1)
+            if (j == psShape->nParts - 1)
                 end = psShape->nVertices;
             else
-                end = psShape->panPartStart[j+1];
-            vertices = new DPoint2d [end-psShape->panPartStart[j]];
-            for(k=psShape->panPartStart[j],vert=0;k<end;k++)
+                end = psShape->panPartStart[j + 1];
+            vertices = new DPoint2d[end - psShape->panPartStart[j]];
+            for (k = psShape->panPartStart[j], vert = 0; k < end; k++)
             {
                 vertices[vert].x = psShape->padfX[k];
                 vertices[vert++].y = psShape->padfY[k];
             }
             direction = LoopDirection(vertices, vert);
-            for(k=0;k<vert-1;k++)
+            for (k = 0; k < vert - 1; k++)
             {
                 y3 = vertices[k].y;
-                y4 = vertices[k+1].y;
-                if((y3 >= y && y4 < y) || (y3 <= y && y4 > y)) //I check >= only once, because if it's not checked now (y3) it will be in the next iteration (which is y4 now)
+                y4 = vertices[k + 1].y;
+                if ((y3 >= y && y4 < y) ||
+                    (y3 <= y &&
+                     y4 >
+                         y))  //I check >= only once, because if it's not checked now (y3) it will be in the next iteration (which is y4 now)
                 {
                     point1.boundry_nmb = j;
                     point1.loopdirection = direction;
                     x3 = vertices[k].x;
-                    x4 = vertices[k+1].x;
-                    if(y3==y)
+                    x4 = vertices[k + 1].x;
+                    if (y3 == y)
                     {
                         point1.y = y3;
                         point1.x = x3;
-                        if(direction == kInterior) //add point 2 times if the direction is interior, so that the final count of points is even
+                        if (direction ==
+                            kInterior)  //add point 2 times if the direction is interior, so that the final count of points is even
                         {
-                            points[pointpos++]=point1;
+                            points[pointpos++] = point1;
                         }
                     }
                     else
                     {
-                        point1.x = xmin+(((((x4-x3)*(y-y3))-((y4-y3)*(xmin-x3)))/((y4-y3)*dx))*dx); //striped down calculation of intersection of 2 lines
+                        point1.x =
+                            xmin +
+                            (((((x4 - x3) * (y - y3)) -
+                               ((y4 - y3) * (xmin - x3))) /
+                              ((y4 - y3) * dx)) *
+                             dx);  //striped down calculation of intersection of 2 lines
                         point1.y = y;
                     }
-                    points[pointpos++]=point1;
+                    points[pointpos++] = point1;
                 }
             }
-            delete [] vertices;
+            delete[] vertices;
         }
 
-        for(j=1;j<pointpos;j++) //sort the found intersection points by x value
+        for (j = 1; j < pointpos;
+             j++)  //sort the found intersection points by x value
         {
-            for(k=j;k>0;k--)
+            for (k = j; k > 0; k--)
             {
-                if(points[k].x < points[k-1].x)
+                if (points[k].x < points[k - 1].x)
                 {
                     point1 = points[k];
-                    points[k] = points[k-1];
-                    points[k-1] = point1;
+                    points[k] = points[k - 1];
+                    points[k - 1] = point1;
                 }
                 else
                 {
@@ -168,21 +180,22 @@ DPoint2d CreatePointInPoly(SHPObject *psShape, int quality)
             }
         }
 
-        for(j=0;j<pointpos-1;j++)
+        for (j = 0; j < pointpos - 1; j++)
         {
             point1 = points[j];
-            point2 = points[j+1];
-            if((point1.loopdirection == kExterior         &&  //some checkings for valid point
-                point2.loopdirection == kExterior         &&
-                point1.boundry_nmb == point2.boundry_nmb  &&
-                j%2==0)                                   ||
-               (point1.loopdirection == kExterior        &&
-                point2.loopdirection == kInterior)        ||
-               (point1.loopdirection == kInterior        &&
-                point2.loopdirection == kExterior))
+            point2 = points[j + 1];
+            if ((point1.loopdirection ==
+                     kExterior &&  //some checkings for valid point
+                 point2.loopdirection == kExterior &&
+                 point1.boundry_nmb == point2.boundry_nmb && j % 2 == 0) ||
+                (point1.loopdirection == kExterior &&
+                 point2.loopdirection == kInterior) ||
+                (point1.loopdirection == kInterior &&
+                 point2.loopdirection == kExterior))
             {
-                len = sqrt(pow(point1.x-point2.x, 2)+pow(point1.y-point2.y, 2));
-                if(len >= maxlen)
+                len = sqrt(pow(point1.x - point2.x, 2) +
+                           pow(point1.y - point2.y, 2));
+                if (len >= maxlen)
                 {
                     maxlen = len;
                     mp1 = point1;
@@ -192,12 +205,12 @@ DPoint2d CreatePointInPoly(SHPObject *psShape, int quality)
         }
     }
 
-    return DPoint2d((mp1.x+mp2.x)*0.5, (mp1.y+mp2.y)*0.5);
+    return DPoint2d((mp1.x + mp2.x) * 0.5, (mp1.y + mp2.y) * 0.5);
 }
 
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
-    if(argc != 3)
+    if (argc != 3)
     {
         printf("Usage: %s shpfile_path quality\n", argv[0]);
         return 1;
@@ -205,22 +218,22 @@ int main(int argc, char* argv[])
 
     int i, nEntities, quality;
     SHPHandle hSHP;
-    SHPObject	*psShape;
+    SHPObject *psShape;
     DPoint2d pt;
     quality = atoi(argv[2]);
     hSHP = SHPOpen(argv[1], "rb");
     SHPGetInfo(hSHP, &nEntities, NULL, NULL, NULL);
 
     printf("PointInPoly v1.0, by Marko Podgorsek\n----------------\n");
-    for( i = 0; i < nEntities; i++ )
+    for (i = 0; i < nEntities; i++)
     {
-        psShape = SHPReadObject( hSHP, i );
-        if(psShape->nSHPType == SHPT_POLYGON)
+        psShape = SHPReadObject(hSHP, i);
+        if (psShape->nSHPType == SHPT_POLYGON)
         {
             pt = CreatePointInPoly(psShape, quality);
-            printf("%d: x=%f y=%f\n",i, pt.x,pt.y);
+            printf("%d: x=%f y=%f\n", i, pt.x, pt.y);
         }
-        SHPDestroyObject( psShape );
+        SHPDestroyObject(psShape);
     }
 
     SHPClose(hSHP);

--- a/contrib/csv2shp.c
+++ b/contrib/csv2shp.c
@@ -60,7 +60,6 @@ Email: <http://springsrescuemission.org/email.php?recipient=webmaster>
 
 */
 
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -70,422 +69,446 @@ Email: <http://springsrescuemission.org/email.php?recipient=webmaster>
 
 #define MAX_COLUMNS 30
 
-typedef struct column_t {
-	DBFFieldType eType;
-	int nWidth;
-	int nDecimals;
+typedef struct column_t
+{
+    DBFFieldType eType;
+    int nWidth;
+    int nDecimals;
 } column;
 
 /* counts the number of occurrences of the character in the string */
 int strnchr(const char *s, char c)
 {
-	int n = 0;
+    int n = 0;
 
-	for (int x = 0; x < strlen(s); x++)
-	{
-		if (c == s[x])
-		{
-			n++;
-		}
-	}
+    for (int x = 0; x < strlen(s); x++)
+    {
+        if (c == s[x])
+        {
+            n++;
+        }
+    }
 
-	return n;
+    return n;
 }
 
 /* Returns a field given by column n (0-based) in a character-
    delimited string s */
-char * delimited_column(char *s, char delim, int n) {
-	if (strnchr(s, delim) < n)
-	{
-		fprintf(stderr, "delimited_column: n is too large\n");
-		return NULL;
-	}
+char *delimited_column(char *s, char delim, int n)
+{
+    if (strnchr(s, delim) < n)
+    {
+        fprintf(stderr, "delimited_column: n is too large\n");
+        return NULL;
+    }
 
-	char szbuffer[4096]; /* a copy of s */
-	strcpy(szbuffer, s);
+    char szbuffer[4096]; /* a copy of s */
+    strcpy(szbuffer, s);
 
-	char szdelimiter[2]; /* delim converted to string */
-	szdelimiter[0] = delim;
-	szdelimiter[1] = '\0';
+    char szdelimiter[2]; /* delim converted to string */
+    szdelimiter[0] = delim;
+    szdelimiter[1] = '\0';
 
-	int x = 0;
-	const char *pchar = strtok(szbuffer, szdelimiter);
-	while (x < n)
-	{
-		pchar = strtok(NULL, szdelimiter);
-		x++;
-	}
+    int x = 0;
+    const char *pchar = strtok(szbuffer, szdelimiter);
+    while (x < n)
+    {
+        pchar = strtok(NULL, szdelimiter);
+        x++;
+    }
 
-	if (NULL == pchar)
-	{
-		return NULL;
-	}
+    if (NULL == pchar)
+    {
+        return NULL;
+    }
 
-	static char szreturn[4096];
-	strcpy(szreturn, pchar);
-	return szreturn;
+    static char szreturn[4096];
+    strcpy(szreturn, pchar);
+    return szreturn;
 }
 
 /* Determines the most specific column type.
    The most specific types from most to least are integer, float, string.  */
 DBFFieldType str_to_fieldtype(const char *s)
 {
-	regex_t regex_i;
-	if (0 != regcomp(&regex_i, "^[0-9]+$", REG_NOSUB|REG_EXTENDED))
-	{
-		fprintf(stderr, "integer regex complication failed\n");
-		exit (EXIT_FAILURE);
-	}
+    regex_t regex_i;
+    if (0 != regcomp(&regex_i, "^[0-9]+$", REG_NOSUB | REG_EXTENDED))
+    {
+        fprintf(stderr, "integer regex complication failed\n");
+        exit(EXIT_FAILURE);
+    }
 
-	if (0 == regexec(&regex_i, s, 0, NULL, 0))
-	{
-		regfree(&regex_i);
-		return FTInteger;
-	}
+    if (0 == regexec(&regex_i, s, 0, NULL, 0))
+    {
+        regfree(&regex_i);
+        return FTInteger;
+    }
 
-	regfree(&regex_i);
+    regfree(&regex_i);
 
-	regex_t regex_d;
-	if (0 != regcomp(&regex_d, "^-?[0-9]+\\.[0-9]+$", REG_NOSUB|REG_EXTENDED))
-	{
-		fprintf(stderr, "integer regex complication failed\n");
-		exit (EXIT_FAILURE);
-	}
+    regex_t regex_d;
+    if (0 != regcomp(&regex_d, "^-?[0-9]+\\.[0-9]+$", REG_NOSUB | REG_EXTENDED))
+    {
+        fprintf(stderr, "integer regex complication failed\n");
+        exit(EXIT_FAILURE);
+    }
 
-	if (0 == regexec(&regex_d, s, 0, NULL, 0))
-	{
-		regfree(&regex_d);
-		return FTDouble;
-	}
+    if (0 == regexec(&regex_d, s, 0, NULL, 0))
+    {
+        regfree(&regex_d);
+        return FTDouble;
+    }
 
-	regfree(&regex_d);
+    regfree(&regex_d);
 
-	return FTString;
+    return FTString;
 }
 
 /* returns the field width */
 int str_to_nwidth(const char *s, DBFFieldType eType)
 {
-	switch (eType)
-	{
-		case FTString:
-		case FTInteger:
-		case FTDouble:
-			return strlen(s);
+    switch (eType)
+    {
+        case FTString:
+        case FTInteger:
+        case FTDouble:
+            return strlen(s);
 
-		default:
-			fprintf(stderr, "str_to_nwidth: unexpected type\n");
-			exit (EXIT_FAILURE);
-	}
+        default:
+            fprintf(stderr, "str_to_nwidth: unexpected type\n");
+            exit(EXIT_FAILURE);
+    }
 }
 
 /* returns the number of decimals in a real number given as a string s */
-int str_to_ndecimals(const char *s) {
-	regex_t regex_d;
-	if (0 != regcomp(&regex_d, "^-?[0-9]+\\.([0-9]+)$", REG_EXTENDED))
-	{
-		fprintf(stderr, "integer regex complication failed\n");
-		exit (EXIT_FAILURE);
-	}
+int str_to_ndecimals(const char *s)
+{
+    regex_t regex_d;
+    if (0 != regcomp(&regex_d, "^-?[0-9]+\\.([0-9]+)$", REG_EXTENDED))
+    {
+        fprintf(stderr, "integer regex complication failed\n");
+        exit(EXIT_FAILURE);
+    }
 
-	regmatch_t pmatch[2];
-	if (0 != regexec(&regex_d, s, 2, &pmatch[0], 0))
-	{
-		return -1;
-	}
+    regmatch_t pmatch[2];
+    if (0 != regexec(&regex_d, s, 2, &pmatch[0], 0))
+    {
+        return -1;
+    }
 
-	char szbuffer[4096];
-	strncpy(szbuffer, &s[pmatch[1].rm_so], pmatch[1].rm_eo - pmatch[1].rm_so);
-	szbuffer[pmatch[1].rm_eo - pmatch[1].rm_so] = '\0';
+    char szbuffer[4096];
+    strncpy(szbuffer, &s[pmatch[1].rm_so], pmatch[1].rm_eo - pmatch[1].rm_so);
+    szbuffer[pmatch[1].rm_eo - pmatch[1].rm_so] = '\0';
 
-	regfree(&regex_d);
+    regfree(&regex_d);
 
-	return strlen(szbuffer);
+    return strlen(szbuffer);
 }
 
 /* returns true if f1 is more general than f2, otherwise false */
-int more_general_field_type(DBFFieldType t1, DBFFieldType t2) {
-	if (FTInteger == t2 && t1 != FTInteger)
-	{
-		return 1;
-	}
-
-	if (FTDouble == t2 && FTString == t1)
-	{
-		return 1;
-	}
-
-	return 0;
-}
-
-void strip_crlf (char *line)
+int more_general_field_type(DBFFieldType t1, DBFFieldType t2)
 {
-  /* remove trailing CR/LF */
-
-  if (strchr (line, 0x0D))
+    if (FTInteger == t2 && t1 != FTInteger)
     {
-      char *pszline = strchr (line, 0x0D);
-      pszline[0] = '\0';
+        return 1;
     }
 
-  if (strchr (line, 0x0A))
+    if (FTDouble == t2 && FTString == t1)
     {
-      char *pszline = strchr (line, 0x0A);
-      pszline[0] = '\0';
+        return 1;
+    }
+
+    return 0;
+}
+
+void strip_crlf(char *line)
+{
+    /* remove trailing CR/LF */
+
+    if (strchr(line, 0x0D))
+    {
+        char *pszline = strchr(line, 0x0D);
+        pszline[0] = '\0';
+    }
+
+    if (strchr(line, 0x0A))
+    {
+        char *pszline = strchr(line, 0x0A);
+        pszline[0] = '\0';
     }
 }
 
-int main( int argc, char ** argv ) {
-	printf("csv2shp version 1, Copyright (C) 2005 Springs Rescue Mission\n");
+int main(int argc, char **argv)
+{
+    printf("csv2shp version 1, Copyright (C) 2005 Springs Rescue Mission\n");
 
-	if (4 != argc)
-	{
-		fprintf(stderr, "csv2shp comes with ABSOLUTELY NO WARRANTY; for details\n");
-		fprintf(stderr, "see csv2shp.c.  This is free software, and you are welcome\n");
-		fprintf(stderr, "to redistribute it under certain conditions; see csv2shp.c\n");
-		fprintf(stderr, "for details\n");
-		fprintf(stderr, "\n");
-		fprintf(stderr, "USAGE\n");
-		fprintf(stderr, "csv2shp csv_filename delimiter_character shp_filename\n");
-		fprintf(stderr, "   csv_filename\n");
-		fprintf(stderr, "     columns named longitude and latitude must exist\n");
-		fprintf(stderr, "   delimiter_character\n");
-		fprintf(stderr, "     one character only\n");
-		fprintf(stderr, "   shp_filename\n");
-		fprintf(stderr, "     base name, do not give the extension\n");
-		return EXIT_FAILURE;
-	}
+    if (4 != argc)
+    {
+        fprintf(stderr,
+                "csv2shp comes with ABSOLUTELY NO WARRANTY; for details\n");
+        fprintf(stderr,
+                "see csv2shp.c.  This is free software, and you are welcome\n");
+        fprintf(stderr,
+                "to redistribute it under certain conditions; see csv2shp.c\n");
+        fprintf(stderr, "for details\n");
+        fprintf(stderr, "\n");
+        fprintf(stderr, "USAGE\n");
+        fprintf(stderr,
+                "csv2shp csv_filename delimiter_character shp_filename\n");
+        fprintf(stderr, "   csv_filename\n");
+        fprintf(stderr,
+                "     columns named longitude and latitude must exist\n");
+        fprintf(stderr, "   delimiter_character\n");
+        fprintf(stderr, "     one character only\n");
+        fprintf(stderr, "   shp_filename\n");
+        fprintf(stderr, "     base name, do not give the extension\n");
+        return EXIT_FAILURE;
+    }
 
-	if (strlen(argv[2]) > 1)
-	{
-		fprintf(stderr, "delimiter must be one character in length\n");
-		return EXIT_FAILURE;
-	}
+    if (strlen(argv[2]) > 1)
+    {
+        fprintf(stderr, "delimiter must be one character in length\n");
+        return EXIT_FAILURE;
+    }
 
-	const char delimiter = argv[2][0];
+    const char delimiter = argv[2][0];
 
-	FILE *csv_f = fopen(argv[1], "r");
-	if (NULL == csv_f)
-	{
-		perror("could not open csv file");
-		exit (EXIT_FAILURE);
-	}
+    FILE *csv_f = fopen(argv[1], "r");
+    if (NULL == csv_f)
+    {
+        perror("could not open csv file");
+        exit(EXIT_FAILURE);
+    }
 
-	char sbuffer[4096];
-	fgets(sbuffer, 4000, csv_f);
+    char sbuffer[4096];
+    fgets(sbuffer, 4000, csv_f);
 
-	/* check first row */
+    /* check first row */
 
-	strip_crlf(sbuffer);
+    strip_crlf(sbuffer);
 
-	if (delimiter == sbuffer[strlen(sbuffer)- 1])
-	{
-		fprintf(stderr, "lines must not end with the delimiter character\n");
-		return EXIT_FAILURE;
+    if (delimiter == sbuffer[strlen(sbuffer) - 1])
+    {
+        fprintf(stderr, "lines must not end with the delimiter character\n");
+        return EXIT_FAILURE;
+    }
 
-	}
+    /* count columns and verify consistency*/
 
-	/* count columns and verify consistency*/
+    /* 1-based */
+    int n_columns = strnchr(sbuffer, delimiter);
+    if (n_columns > MAX_COLUMNS)
+    {
+        fprintf(stderr, "too many columns, maximum is %i\n", MAX_COLUMNS);
+        return EXIT_FAILURE;
+    }
 
-	/* 1-based */
-	int n_columns = strnchr(sbuffer, delimiter);
-	if (n_columns > MAX_COLUMNS)
-	{
-		fprintf(stderr, "too many columns, maximum is %i\n", MAX_COLUMNS);
-		return EXIT_FAILURE;
-	}
+    int n_line = 1;
+    while (!feof(csv_f))
+    {
+        n_line++;
+        fgets(sbuffer, 4000, csv_f);
+        if (n_columns != strnchr(sbuffer, delimiter))
+        {
+            fprintf(stderr,
+                    "Number of columns on row %i does not match number of "
+                    "columns on row 1\n",
+                    n_columns);
+            return EXIT_FAILURE;
+        }
+    }
 
-	int n_line = 1;
-	while (!feof(csv_f))
-	{
-		n_line++;
-		fgets(sbuffer, 4000, csv_f);
-		if (n_columns != strnchr(sbuffer, delimiter))
-		{
-			fprintf(stderr, "Number of columns on row %i does not match number of columns on row 1\n", n_columns);
-			return EXIT_FAILURE;
-		}
-	}
+    /* identify longitude and latitude columns */
 
-	/* identify longitude and latitude columns */
+    fseek(csv_f, 0, SEEK_SET);
+    fgets(sbuffer, 4000, csv_f);
+    strip_crlf(sbuffer);
 
-	fseek(csv_f, 0, SEEK_SET);
-	fgets(sbuffer, 4000, csv_f);
-	strip_crlf(sbuffer);
+    int n_longitude = -1; /* column with x, 0 based */
+    int n_latitude = -1;  /* column with y, 0 based */
+    for (int x = 0; x <= n_columns; x++)
+    {
+        if (0 ==
+            strcasecmp("Longitude", delimited_column(sbuffer, delimiter, x)))
+        {
+            n_longitude = x;
+        }
 
-	int n_longitude = -1; /* column with x, 0 based */
-	int n_latitude = -1; /* column with y, 0 based */
-	for (int x = 0; x <= n_columns; x++)
-	{
-		if (0 == strcasecmp("Longitude", delimited_column(sbuffer, delimiter, x)))
-		{
-			n_longitude = x;
-		}
-
-		if (0 == strcasecmp("Latitude", delimited_column(sbuffer, delimiter, x)))
-		{
-			n_latitude = x;
-		}
-	}
-
-#ifdef DEBUG
-	printf("debug lat/long = %i/%i\n", n_latitude, n_longitude);
-#endif
-
-	if (-1 == n_longitude || -1 == n_latitude)
-	{
-		fprintf(stderr, "The header row must define one each a column named longitude and latitude\n");
-		return EXIT_FAILURE;
-	}
-
-	/* determine best fit for each column */
-
-	printf ("Anaylzing column types...\n");
+        if (0 ==
+            strcasecmp("Latitude", delimited_column(sbuffer, delimiter, x)))
+        {
+            n_latitude = x;
+        }
+    }
 
 #ifdef DEBUG
-	printf("debug: string type = %i\n", FTString);
-	printf("debug: int type = %i\n", FTInteger);
-	printf("debug: double type = %i\n", FTDouble);
+    printf("debug lat/long = %i/%i\n", n_latitude, n_longitude);
 #endif
 
-	column columns[MAX_COLUMNS + 1];
-	for (int x = 0; x <= n_columns; x++)
-	{
-#ifdef DEBUG
-		printf("debug: examining column %i\n", x);
-#endif
-		columns[x].eType = FTInteger;
-		columns[x].nWidth = 2;
-		columns[x].nDecimals = 0;
+    if (-1 == n_longitude || -1 == n_latitude)
+    {
+        fprintf(stderr, "The header row must define one each a column named "
+                        "longitude and latitude\n");
+        return EXIT_FAILURE;
+    }
 
-		fseek(csv_f, 0, SEEK_SET);
-		fgets(sbuffer, 4000, csv_f);
+    /* determine best fit for each column */
 
-		while (!feof(csv_f))
-		{
-#ifdef DEBUG
-			printf ("column %i, type = %i, w = %i, d = %i\n", x, columns[x].eType, columns[x].nWidth, columns[x].nDecimals);
-#endif
-			if (NULL == fgets(sbuffer, 4000, csv_f))
-			{
-				if (!feof(csv_f))
-				{
-					fprintf(stderr, "error during fgets()\n");
-				}
-				continue;
-			}
-
-			char szfield[4096];
-			strcpy(szfield, delimited_column(sbuffer, delimiter, x));
-			if (more_general_field_type(str_to_fieldtype(szfield), columns[x].eType))
-			{
-				columns[x].eType = str_to_fieldtype(szfield);
-				columns[x].nWidth = 2;
-				columns[x].nDecimals = 0;
-				fseek(csv_f, 0, SEEK_SET);
-				fgets(sbuffer, 4000, csv_f);
-				continue;
-			}
-			if (columns[x].nWidth < str_to_nwidth(szfield, columns[x].eType))
-			{
-				columns[x].nWidth = str_to_nwidth(szfield, columns[x].eType);
-			}
-			if (FTDouble == columns[x].eType && columns[x].nDecimals < str_to_ndecimals(szfield))
-			{
-				columns[x].nDecimals = str_to_ndecimals(szfield);
-			}
-
-		}
-	}
-
-	printf ("Initializing output files...\n");
-
-        // TODO(schwehr): Close csv_f, shp_h, and dbf_h before EXIT_FAILURE
-	SHPHandle shp_h = SHPCreate(argv[3], SHPT_POINT);
-	DBFHandle dbf_h = DBFCreate(argv[3]);
-	if (NULL == dbf_h)
-	{
-		fprintf(stderr, "DBFCreate failed\n");
-		exit (EXIT_FAILURE);
-	}
-
-	fseek(csv_f, 0, SEEK_SET);
-	fgets(sbuffer, 4000, csv_f);
-	strip_crlf(sbuffer);
-
-	for (int x = 0; x <= n_columns; x++)
-	{
-#ifdef DEBUG
-		printf ("debug: final: column %i, type = %i, w = %i, d = %i, name=|%s|\n", x, columns[x].eType, columns[x].nWidth, columns[x].nDecimals, delimited_column(sbuffer, delimiter, x));
-#endif
-		if (-1 == DBFAddField(dbf_h, delimited_column(sbuffer, delimiter, x), columns[x].eType, columns[x].nWidth, columns[x].nDecimals))
-		{
-			fprintf(stderr, "DBFFieldAdd failed column %i\n", x + 1);
-			exit (EXIT_FAILURE);
-		}
-
-	}
-
-	printf ("Writing data...\n");
-
-	fseek(csv_f, 0, SEEK_SET);
-	fgets(sbuffer, 4000, csv_f); /* skip header */
-
-	n_columns = strnchr(sbuffer, delimiter);
-	n_line = 1;
-
-	while (!feof(csv_f))
-	{
-		n_line++;
-		fgets(sbuffer, 4000, csv_f);
-
-		/* write to shape file */
-		double x_pt = atof(delimited_column(sbuffer, delimiter, n_longitude));
-		double y_pt = atof(delimited_column(sbuffer, delimiter, n_latitude));
+    printf("Anaylzing column types...\n");
 
 #ifdef DEBUG
-		printf("debug: sbuffer=%s", sbuffer);
-		printf("debug: x,y = %f, %f\n", x_pt, y_pt);
+    printf("debug: string type = %i\n", FTString);
+    printf("debug: int type = %i\n", FTInteger);
+    printf("debug: double type = %i\n", FTDouble);
 #endif
 
-		SHPObject *shp = SHPCreateSimpleObject(SHPT_POINT, 1, &x_pt, &y_pt, NULL);
-		const int shp_i = SHPWriteObject(shp_h, -1, shp);
-		SHPDestroyObject(shp);
+    column columns[MAX_COLUMNS + 1];
+    for (int x = 0; x <= n_columns; x++)
+    {
+#ifdef DEBUG
+        printf("debug: examining column %i\n", x);
+#endif
+        columns[x].eType = FTInteger;
+        columns[x].nWidth = 2;
+        columns[x].nDecimals = 0;
 
-		/* write to dbf */
+        fseek(csv_f, 0, SEEK_SET);
+        fgets(sbuffer, 4000, csv_f);
 
-		for (int x = 0; x <= n_columns; x++)
-		{
-			char szfield[4096];
-			strcpy(szfield, delimited_column(sbuffer, delimiter, x));
+        while (!feof(csv_f))
+        {
+#ifdef DEBUG
+            printf("column %i, type = %i, w = %i, d = %i\n", x,
+                   columns[x].eType, columns[x].nWidth, columns[x].nDecimals);
+#endif
+            if (NULL == fgets(sbuffer, 4000, csv_f))
+            {
+                if (!feof(csv_f))
+                {
+                    fprintf(stderr, "error during fgets()\n");
+                }
+                continue;
+            }
 
-			int b;
-			switch (columns[x].eType)
-			{
-				case FTInteger:
-					b = DBFWriteIntegerAttribute(dbf_h, shp_i, x, atoi(szfield));
-					break;
-				case FTDouble:
-					b = DBFWriteDoubleAttribute(dbf_h, shp_i, x, atof(szfield));
-					break;
-				case FTString:
-					b = DBFWriteStringAttribute(dbf_h, shp_i, x, szfield);
-					break;
-				default:
-					fprintf(stderr, "unexpected column type %i in column %i\n", columns[x].eType, x);
-			}
+            char szfield[4096];
+            strcpy(szfield, delimited_column(sbuffer, delimiter, x));
+            if (more_general_field_type(str_to_fieldtype(szfield),
+                                        columns[x].eType))
+            {
+                columns[x].eType = str_to_fieldtype(szfield);
+                columns[x].nWidth = 2;
+                columns[x].nDecimals = 0;
+                fseek(csv_f, 0, SEEK_SET);
+                fgets(sbuffer, 4000, csv_f);
+                continue;
+            }
+            if (columns[x].nWidth < str_to_nwidth(szfield, columns[x].eType))
+            {
+                columns[x].nWidth = str_to_nwidth(szfield, columns[x].eType);
+            }
+            if (FTDouble == columns[x].eType &&
+                columns[x].nDecimals < str_to_ndecimals(szfield))
+            {
+                columns[x].nDecimals = str_to_ndecimals(szfield);
+            }
+        }
+    }
 
-			if (!b)
-			{
-				fprintf(stderr, "DBFWrite*Attribute failed\n");
-				exit (EXIT_FAILURE);
-			}
-		}
-	}
+    printf("Initializing output files...\n");
 
-        fclose(csv_f);
-	SHPClose(shp_h);
-        DBFClose(dbf_h);
+    // TODO(schwehr): Close csv_f, shp_h, and dbf_h before EXIT_FAILURE
+    SHPHandle shp_h = SHPCreate(argv[3], SHPT_POINT);
+    DBFHandle dbf_h = DBFCreate(argv[3]);
+    if (NULL == dbf_h)
+    {
+        fprintf(stderr, "DBFCreate failed\n");
+        exit(EXIT_FAILURE);
+    }
 
-	return EXIT_SUCCESS;
+    fseek(csv_f, 0, SEEK_SET);
+    fgets(sbuffer, 4000, csv_f);
+    strip_crlf(sbuffer);
+
+    for (int x = 0; x <= n_columns; x++)
+    {
+#ifdef DEBUG
+        printf(
+            "debug: final: column %i, type = %i, w = %i, d = %i, name=|%s|\n",
+            x, columns[x].eType, columns[x].nWidth, columns[x].nDecimals,
+            delimited_column(sbuffer, delimiter, x));
+#endif
+        if (-1 == DBFAddField(dbf_h, delimited_column(sbuffer, delimiter, x),
+                              columns[x].eType, columns[x].nWidth,
+                              columns[x].nDecimals))
+        {
+            fprintf(stderr, "DBFFieldAdd failed column %i\n", x + 1);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    printf("Writing data...\n");
+
+    fseek(csv_f, 0, SEEK_SET);
+    fgets(sbuffer, 4000, csv_f); /* skip header */
+
+    n_columns = strnchr(sbuffer, delimiter);
+    n_line = 1;
+
+    while (!feof(csv_f))
+    {
+        n_line++;
+        fgets(sbuffer, 4000, csv_f);
+
+        /* write to shape file */
+        double x_pt = atof(delimited_column(sbuffer, delimiter, n_longitude));
+        double y_pt = atof(delimited_column(sbuffer, delimiter, n_latitude));
+
+#ifdef DEBUG
+        printf("debug: sbuffer=%s", sbuffer);
+        printf("debug: x,y = %f, %f\n", x_pt, y_pt);
+#endif
+
+        SHPObject *shp =
+            SHPCreateSimpleObject(SHPT_POINT, 1, &x_pt, &y_pt, NULL);
+        const int shp_i = SHPWriteObject(shp_h, -1, shp);
+        SHPDestroyObject(shp);
+
+        /* write to dbf */
+
+        for (int x = 0; x <= n_columns; x++)
+        {
+            char szfield[4096];
+            strcpy(szfield, delimited_column(sbuffer, delimiter, x));
+
+            int b;
+            switch (columns[x].eType)
+            {
+                case FTInteger:
+                    b = DBFWriteIntegerAttribute(dbf_h, shp_i, x,
+                                                 atoi(szfield));
+                    break;
+                case FTDouble:
+                    b = DBFWriteDoubleAttribute(dbf_h, shp_i, x, atof(szfield));
+                    break;
+                case FTString:
+                    b = DBFWriteStringAttribute(dbf_h, shp_i, x, szfield);
+                    break;
+                default:
+                    fprintf(stderr, "unexpected column type %i in column %i\n",
+                            columns[x].eType, x);
+            }
+
+            if (!b)
+            {
+                fprintf(stderr, "DBFWrite*Attribute failed\n");
+                exit(EXIT_FAILURE);
+            }
+        }
+    }
+
+    fclose(csv_f);
+    SHPClose(shp_h);
+    DBFClose(dbf_h);
+
+    return EXIT_SUCCESS;
 }

--- a/contrib/dbfcat.c
+++ b/contrib/dbfcat.c
@@ -10,45 +10,58 @@
 #include <string.h>
 #include "shapefil.h"
 
-int main( int argc, char ** argv ) {
-    if( argc < 3 )
+int main(int argc, char **argv)
+{
+    if (argc < 3)
     {
-	printf( "dbfcat [-v] [-f] from_DBFfile to_DBFfile\n" );
-	exit( 1 );
+        printf("dbfcat [-v] [-f] from_DBFfile to_DBFfile\n");
+        exit(1);
     }
 
     int force = 0;
     int verbose = 0;
     int shift = 0;
-    if ( strcmp ("-v", argv[1] ) == 0 ) { shift = 1; verbose = 1; }
-    if ( strcmp ("-f", argv[1 + shift] ) == 0 ) { shift ++; force = 1; }
-    if ( strcmp ("-v", argv[1 + shift] ) == 0 ) { shift ++; verbose = 1; }
+    if (strcmp("-v", argv[1]) == 0)
+    {
+        shift = 1;
+        verbose = 1;
+    }
+    if (strcmp("-f", argv[1 + shift]) == 0)
+    {
+        shift++;
+        force = 1;
+    }
+    if (strcmp("-v", argv[1 + shift]) == 0)
+    {
+        shift++;
+        verbose = 1;
+    }
 
     char tfile[160];
-    strcpy (tfile, argv[1 + shift]);
-    strcat (tfile, ".dbf");
+    strcpy(tfile, argv[1 + shift]);
+    strcat(tfile, ".dbf");
 
-    DBFHandle hDBF = DBFOpen( tfile, "rb" );
-    if( hDBF == NULL )
+    DBFHandle hDBF = DBFOpen(tfile, "rb");
+    if (hDBF == NULL)
     {
-	printf( "DBFOpen(%s.dbf,\"r\") failed for From_DBF.\n", tfile );
-	exit( 2 );
+        printf("DBFOpen(%s.dbf,\"r\") failed for From_DBF.\n", tfile);
+        exit(2);
     }
 
-    strcpy (tfile, argv[2 + shift]);
-    strcat (tfile, ".dbf");
+    strcpy(tfile, argv[2 + shift]);
+    strcat(tfile, ".dbf");
 
-    DBFHandle cDBF = DBFOpen( tfile, "rb+" );
-    if( cDBF == NULL )
+    DBFHandle cDBF = DBFOpen(tfile, "rb+");
+    if (cDBF == NULL)
     {
-	printf( "DBFOpen(%s.dbf,\"rb+\") failed for To_DBF.\n", tfile );
-	exit( 2 );
+        printf("DBFOpen(%s.dbf,\"rb+\") failed for To_DBF.\n", tfile);
+        exit(2);
     }
 
-    if( DBFGetFieldCount(hDBF) == 0 )
+    if (DBFGetFieldCount(hDBF) == 0)
     {
-	printf( "There are no fields in this table!\n" );
-	exit( 3 );
+        printf("There are no fields in this table!\n");
+        exit(3);
     }
 
     const int hflds = DBFGetFieldCount(hDBF);
@@ -67,85 +80,103 @@ int main( int argc, char ** argv ) {
     char nTitle[32];
     char cTitle[32];
 
-    for( int i = 0; i < hflds; i++ )
+    for (int i = 0; i < hflds; i++)
     {
-	char szTitle[18];
-	hType = DBFGetFieldInfo( hDBF, i, szTitle, &nWidth, &nDecimals );
+        char szTitle[18];
+        hType = DBFGetFieldInfo(hDBF, i, szTitle, &nWidth, &nDecimals);
 
-	char cname[18];
-	fld_m[i] = -1;
-        for ( int j = 0; j < cflds; j ++ )
-          {
-            const DBFFieldType cType = DBFGetFieldInfo( cDBF, j, cname, &cnWidth, &cnDecimals );
-            if ( strcmp (cname, szTitle) == 0 )
-	     {
-        	if ( hType != cType )
-            	{ printf ("Incompatible fields %s(%s) != %s(%s),\n",
-             	   type_names[hType],nTitle,type_names[cType],cTitle);
-			mismatch = 1;
-              		}
-	        fld_m[i] = j;
-		if ( verbose )
-         	  { printf("%s  %s(%d,%d) <- %s  %s(%d,%d)\n", cname, type_names[cType],
-         	  		cnWidth, cnDecimals,
-         	       szTitle, type_names[hType], nWidth, nDecimals); }
-	        j = cflds;
-	        matches = 1;
-	      }
-	  }
+        char cname[18];
+        fld_m[i] = -1;
+        for (int j = 0; j < cflds; j++)
+        {
+            const DBFFieldType cType =
+                DBFGetFieldInfo(cDBF, j, cname, &cnWidth, &cnDecimals);
+            if (strcmp(cname, szTitle) == 0)
+            {
+                if (hType != cType)
+                {
+                    printf("Incompatible fields %s(%s) != %s(%s),\n",
+                           type_names[hType], nTitle, type_names[cType],
+                           cTitle);
+                    mismatch = 1;
+                }
+                fld_m[i] = j;
+                if (verbose)
+                {
+                    printf("%s  %s(%d,%d) <- %s  %s(%d,%d)\n", cname,
+                           type_names[cType], cnWidth, cnDecimals, szTitle,
+                           type_names[hType], nWidth, nDecimals);
+                }
+                j = cflds;
+                matches = 1;
+            }
+        }
     }
 
-    if ( (matches == 0 ) && !force ) {
-      printf ("ERROR: No field names match for tables, cannot proceed\n   use -f to force processing using blank records\n");
-      exit(-1); }
-    if ( mismatch && !force ) {
-      printf ("ERROR: field type mismatch cannot proceed\n    use -f to force processing using attempted conversions\n");
-      exit(-1); }
+    if ((matches == 0) && !force)
+    {
+        printf("ERROR: No field names match for tables, cannot proceed\n   use "
+               "-f to force processing using blank records\n");
+        exit(-1);
+    }
+    if (mismatch && !force)
+    {
+        printf("ERROR: field type mismatch cannot proceed\n    use -f to force "
+               "processing using attempted conversions\n");
+        exit(-1);
+    }
 
     int iRecord = 0;
-    for( ; iRecord < DBFGetRecordCount(hDBF); iRecord++ )
+    for (; iRecord < DBFGetRecordCount(hDBF); iRecord++)
     {
-      const int ciRecord = DBFGetRecordCount( cDBF );
-      for ( int i = 0; i < hflds;i ++ )
-	{
-	const int ci = fld_m[i];
-	if ( ci != -1 )
-	{
-	const DBFFieldType cType = DBFGetFieldInfo( cDBF, ci, cTitle, &cnWidth, &cnDecimals );
-	hType = DBFGetFieldInfo( hDBF, i, nTitle, &nWidth, &nDecimals );
+        const int ciRecord = DBFGetRecordCount(cDBF);
+        for (int i = 0; i < hflds; i++)
+        {
+            const int ci = fld_m[i];
+            if (ci != -1)
+            {
+                const DBFFieldType cType =
+                    DBFGetFieldInfo(cDBF, ci, cTitle, &cnWidth, &cnDecimals);
+                hType = DBFGetFieldInfo(hDBF, i, nTitle, &nWidth, &nDecimals);
 
-	    switch( cType )
-	    {
-	      case FTString:
-              case FTLogical:
-              case FTDate:
-	        DBFWriteStringAttribute(cDBF, ciRecord, ci,
-     			(char *) DBFReadStringAttribute( hDBF, iRecord, i ) );
-		break;
+                switch (cType)
+                {
+                    case FTString:
+                    case FTLogical:
+                    case FTDate:
+                        DBFWriteStringAttribute(
+                            cDBF, ciRecord, ci,
+                            (char *)DBFReadStringAttribute(hDBF, iRecord, i));
+                        break;
 
-	      case FTInteger:
-	    	DBFWriteIntegerAttribute(cDBF, ciRecord, ci,
-			(int) DBFReadIntegerAttribute( hDBF, iRecord, i ) );
-		break;
+                    case FTInteger:
+                        DBFWriteIntegerAttribute(
+                            cDBF, ciRecord, ci,
+                            (int)DBFReadIntegerAttribute(hDBF, iRecord, i));
+                        break;
 
-	      case FTDouble:
-/*	        cf = DBFReadDoubleAttribute( hDBF, iRecord, i );
+                    case FTDouble:
+                        /*	        cf = DBFReadDoubleAttribute( hDBF, iRecord, i );
 	        printf ("%s <-  %s (%f)\n", cTitle, nTitle, cf);
 */
-	    	DBFWriteDoubleAttribute(cDBF, ciRecord, ci,
-			(double) DBFReadDoubleAttribute( hDBF, iRecord, i ) );
-		break;
+                        DBFWriteDoubleAttribute(
+                            cDBF, ciRecord, ci,
+                            (double)DBFReadDoubleAttribute(hDBF, iRecord, i));
+                        break;
 
-              case FTInvalid:
-                break;
-	    }
-	  }
-	}   /* fields names match */
+                    case FTInvalid:
+                        break;
+                }
+            }
+        } /* fields names match */
     }
 
-    if ( verbose ) { printf (" %d records appended \n\n", iRecord); }
-    DBFClose( hDBF );
-    DBFClose( cDBF );
+    if (verbose)
+    {
+        printf(" %d records appended \n\n", iRecord);
+    }
+    DBFClose(hDBF);
+    DBFClose(cDBF);
 
-    return( 0 );
+    return (0);
 }

--- a/contrib/dbfinfo.c
+++ b/contrib/dbfinfo.c
@@ -12,75 +12,78 @@
 #include <string.h>
 #include "shapefil.h"
 
-int main( int argc, char ** argv ) {
-/* -------------------------------------------------------------------- */
-/*      Display a usage message.                                        */
-/* -------------------------------------------------------------------- */
-    if( argc != 2 )
+int main(int argc, char **argv)
+{
+    /* -------------------------------------------------------------------- */
+    /*      Display a usage message.                                        */
+    /* -------------------------------------------------------------------- */
+    if (argc != 2)
     {
-	printf( "dbfinfo xbase_file\n" );
-	exit( 1 );
+        printf("dbfinfo xbase_file\n");
+        exit(1);
     }
 
-/* -------------------------------------------------------------------- */
-/*      Open the file.                                                  */
-/* -------------------------------------------------------------------- */
-    DBFHandle hDBF = DBFOpen( argv[1], "rb" );
-    if( hDBF == NULL )
+    /* -------------------------------------------------------------------- */
+    /*      Open the file.                                                  */
+    /* -------------------------------------------------------------------- */
+    DBFHandle hDBF = DBFOpen(argv[1], "rb");
+    if (hDBF == NULL)
     {
-	printf( "DBFOpen(%s,\"r\") failed.\n", argv[1] );
-	exit( 2 );
+        printf("DBFOpen(%s,\"r\") failed.\n", argv[1]);
+        exit(2);
     }
 
-    printf ("Info for %s\n",argv[1]);
+    printf("Info for %s\n", argv[1]);
 
-/* -------------------------------------------------------------------- */
-/*	If there is no data in this file let the user know.		*/
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*	If there is no data in this file let the user know.		*/
+    /* -------------------------------------------------------------------- */
     const int iCount = DBFGetFieldCount(hDBF);
-    printf ("%d Columns,  %d Records in file\n", iCount, DBFGetRecordCount(hDBF));
+    printf("%d Columns,  %d Records in file\n", iCount,
+           DBFGetRecordCount(hDBF));
 
-/* -------------------------------------------------------------------- */
-/*	Compute offsets to use when printing each of the field 		*/
-/*	values. We make each field as wide as the field title+1, or 	*/
-/*	the field value + 1. 						*/
-/* -------------------------------------------------------------------- */
-    int *panWidth = (int *) malloc( DBFGetFieldCount( hDBF ) * sizeof(int) );
+    /* -------------------------------------------------------------------- */
+    /*	Compute offsets to use when printing each of the field 		*/
+    /*	values. We make each field as wide as the field title+1, or 	*/
+    /*	the field value + 1. 						*/
+    /* -------------------------------------------------------------------- */
+    int *panWidth = (int *)malloc(DBFGetFieldCount(hDBF) * sizeof(int));
 
-    char	ftype[32];
-    int		nDecimals;
-    int		nWidth;
+    char ftype[32];
+    int nDecimals;
+    int nWidth;
 
-    for( int i = 0; i < DBFGetFieldCount(hDBF); i++ )
+    for (int i = 0; i < DBFGetFieldCount(hDBF); i++)
     {
-	char		szTitle[12];
+        char szTitle[12];
 
-	switch ( DBFGetFieldInfo( hDBF, i, szTitle, &nWidth, &nDecimals )) {
-	      case FTString:
-	        strcpy (ftype, "string");;
-		break;
+        switch (DBFGetFieldInfo(hDBF, i, szTitle, &nWidth, &nDecimals))
+        {
+            case FTString:
+                strcpy(ftype, "string");
+                ;
+                break;
 
-	      case FTInteger:
-	    	strcpy (ftype, "integer");
-		break;
+            case FTInteger:
+                strcpy(ftype, "integer");
+                break;
 
-	      case FTDouble:
-	    	strcpy (ftype, "float");
-		break;
+            case FTDouble:
+                strcpy(ftype, "float");
+                break;
 
-	      case FTInvalid:
-	    	strcpy (ftype, "invalid/unsupported");
-		break;
+            case FTInvalid:
+                strcpy(ftype, "invalid/unsupported");
+                break;
 
-	      default:
-	      	strcpy (ftype, "unknown");
-	      	break;
-	    }
-        printf ("%15.15s\t%15s  (%d,%d)\n",szTitle, ftype, nWidth, nDecimals);
-
+            default:
+                strcpy(ftype, "unknown");
+                break;
+        }
+        printf("%15.15s\t%15s  (%d,%d)\n", szTitle, ftype, nWidth, nDecimals);
     }
 
-    DBFClose( hDBF );
+    DBFClose(hDBF);
 
-    return( 0 );
+    return (0);
 }

--- a/contrib/shpcat.c
+++ b/contrib/shpcat.c
@@ -34,60 +34,61 @@
 #include <string.h>
 #include "shapefil.h"
 
-int main( int argc, char ** argv ) {
-/* -------------------------------------------------------------------- */
-/*      Display a usage message.                                        */
-/* -------------------------------------------------------------------- */
-    if( argc != 3 )
+int main(int argc, char **argv)
+{
+    /* -------------------------------------------------------------------- */
+    /*      Display a usage message.                                        */
+    /* -------------------------------------------------------------------- */
+    if (argc != 3)
     {
-	printf( "shpcat from_shpfile to_shpfile\n" );
-	return 1;
+        printf("shpcat from_shpfile to_shpfile\n");
+        return 1;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Open the passed shapefile.                                      */
-/* -------------------------------------------------------------------- */
-    SHPHandle hSHP = SHPOpen( argv[1], "rb" );
-    if( hSHP == NULL )
+    /* -------------------------------------------------------------------- */
+    /*      Open the passed shapefile.                                      */
+    /* -------------------------------------------------------------------- */
+    SHPHandle hSHP = SHPOpen(argv[1], "rb");
+    if (hSHP == NULL)
     {
-	printf( "Unable to open:%s\n", argv[1] );
-	return 1;
+        printf("Unable to open:%s\n", argv[1]);
+        return 1;
     }
 
     int nEntities;
     int nShapeType;
-    SHPGetInfo( hSHP, &nEntities, &nShapeType, NULL, NULL );
-    fprintf(stderr,"Opened From File %s, with %d shapes\n",argv[1],nEntities);
+    SHPGetInfo(hSHP, &nEntities, &nShapeType, NULL, NULL);
+    fprintf(stderr, "Opened From File %s, with %d shapes\n", argv[1],
+            nEntities);
 
-/* -------------------------------------------------------------------- */
-/*      Open the passed shapefile.                                      */
-/* -------------------------------------------------------------------- */
-    SHPHandle cSHP = SHPOpen( argv[2], "rb+" );
-    if( cSHP == NULL )
+    /* -------------------------------------------------------------------- */
+    /*      Open the passed shapefile.                                      */
+    /* -------------------------------------------------------------------- */
+    SHPHandle cSHP = SHPOpen(argv[2], "rb+");
+    if (cSHP == NULL)
     {
-	printf( "Unable to open:%s\n", argv[2] );
+        printf("Unable to open:%s\n", argv[2]);
         SHPClose(hSHP);
-	return 1;
+        return 1;
     }
 
     int nShpInFile;
-    SHPGetInfo( cSHP, &nShpInFile, NULL, NULL, NULL );
-    fprintf(stderr,"Opened to file %s with %d shapes, ready to add %d\n",
-            argv[2],nShpInFile,nEntities);
+    SHPGetInfo(cSHP, &nShpInFile, NULL, NULL, NULL);
+    fprintf(stderr, "Opened to file %s with %d shapes, ready to add %d\n",
+            argv[2], nShpInFile, nEntities);
 
-/* -------------------------------------------------------------------- */
-/*	Skim over the list of shapes, printing all the vertices.	*/
-/* -------------------------------------------------------------------- */
-    for( int i = 0; i < nEntities; i++ )
+    /* -------------------------------------------------------------------- */
+    /*	Skim over the list of shapes, printing all the vertices.	*/
+    /* -------------------------------------------------------------------- */
+    for (int i = 0; i < nEntities; i++)
     {
-        SHPObject *shape = SHPReadObject( hSHP, i );
-        SHPWriteObject( cSHP, -1, shape );
-        SHPDestroyObject ( shape );
-
+        SHPObject *shape = SHPReadObject(hSHP, i);
+        SHPWriteObject(cSHP, -1, shape);
+        SHPDestroyObject(shape);
     }
 
-    SHPClose( hSHP );
-    SHPClose( cSHP );
+    SHPClose(hSHP);
+    SHPClose(cSHP);
 
     return 0;
 }

--- a/contrib/shpcentrd.c
+++ b/contrib/shpcentrd.c
@@ -40,91 +40,101 @@
 #include "shapefil.h"
 #include "shpgeo.h"
 
-int main( int argc, char ** argv ) {
-    if( argc < 3 )
+int main(int argc, char **argv)
+{
+    if (argc < 3)
     {
-	printf( "shpcentrd shp_file new_shp_file\n" );
+        printf("shpcentrd shp_file new_shp_file\n");
         return 1;
     }
 
     DBFHandle old_DBF = DBFOpen(argv[1], "rb");
-    if (old_DBF == NULL) {
-	printf("Unable to DBFOpen old files:%s\n", argv[1]);
-	return 1;
+    if (old_DBF == NULL)
+    {
+        printf("Unable to DBFOpen old files:%s\n", argv[1]);
+        return 1;
     }
 
     SHPHandle old_SHP = SHPOpen(argv[1], "rb");
-    if (old_SHP == NULL) {
-	printf("Unable to SHPOpen old files:%s\n", argv[1]);
+    if (old_SHP == NULL)
+    {
+        printf("Unable to SHPOpen old files:%s\n", argv[1]);
         DBFClose(old_DBF);
-	return 1;
+        return 1;
     }
 
     int nEntities;
     int nShapeType;
-    SHPGetInfo( old_SHP, &nEntities, &nShapeType, NULL, NULL );
+    SHPGetInfo(old_SHP, &nEntities, &nShapeType, NULL, NULL);
 
-    DBFHandle new_DBF = DBFCloneEmpty (old_DBF, argv[2]);
-    if (new_DBF == NULL) {
-	printf("Unable to create dbf for new files:%s\n", argv[2]);
+    DBFHandle new_DBF = DBFCloneEmpty(old_DBF, argv[2]);
+    if (new_DBF == NULL)
+    {
+        printf("Unable to create dbf for new files:%s\n", argv[2]);
         DBFClose(old_DBF);
         SHPClose(old_SHP);
-	return 1;
+        return 1;
     }
 
-    SHPHandle new_SHP = SHPCreate ( argv[2], SHPT_POINT );
-    if (new_SHP == NULL ) {
-	printf("Unable to create new files:%s\n", argv[2]);
+    SHPHandle new_SHP = SHPCreate(argv[2], SHPT_POINT);
+    if (new_SHP == NULL)
+    {
+        printf("Unable to create new files:%s\n", argv[2]);
         DBFClose(old_DBF);
         SHPClose(old_SHP);
         DBFClose(new_DBF);
-	return 1;
+        return 1;
     }
 
-    char *DBFRow = (char *) malloc ( (old_DBF->nRecordLength) + 15 );
+    char *DBFRow = (char *)malloc((old_DBF->nRecordLength) + 15);
 
     int byRing = 1;
-    for( int i = 0; i < nEntities; i++ )
+    for (int i = 0; i < nEntities; i++)
     {
-        SHPObject *psCShape = SHPReadObject( old_SHP, i );
+        SHPObject *psCShape = SHPReadObject(old_SHP, i);
 
-        if ( byRing == 1 ) {
-          for ( int ring = 0; ring < psCShape->nParts; ring ++ ) {
-	    SHPObject *psO = SHPClone ( psCShape, ring,  ring + 1 );
+        if (byRing == 1)
+        {
+            for (int ring = 0; ring < psCShape->nParts; ring++)
+            {
+                SHPObject *psO = SHPClone(psCShape, ring, ring + 1);
 
-            PT Centrd = SHPCentrd_2d ( psO );
+                PT Centrd = SHPCentrd_2d(psO);
 
-            SHPObject *cent_pt;
-            cent_pt = SHPCreateSimpleObject ( SHPT_POINT, 1,
-        	(double*) &(Centrd.x), (double*) &(Centrd.y), NULL );
+                SHPObject *cent_pt;
+                cent_pt =
+                    SHPCreateSimpleObject(SHPT_POINT, 1, (double *)&(Centrd.x),
+                                          (double *)&(Centrd.y), NULL);
 
-            SHPWriteObject ( new_SHP, -1, cent_pt );
+                SHPWriteObject(new_SHP, -1, cent_pt);
 
-            memcpy ( DBFRow, DBFReadTuple ( old_DBF, i ),
-		 old_DBF->nRecordLength );
-            DBFWriteTuple ( new_DBF, new_DBF->nRecords, DBFRow );
+                memcpy(DBFRow, DBFReadTuple(old_DBF, i),
+                       old_DBF->nRecordLength);
+                DBFWriteTuple(new_DBF, new_DBF->nRecords, DBFRow);
 
-            SHPDestroyObject ( cent_pt );
+                SHPDestroyObject(cent_pt);
 
-	    SHPDestroyObject ( psO );
-          }
-        } else {
-          PT Centrd = SHPCentrd_2d ( psCShape );
+                SHPDestroyObject(psO);
+            }
+        }
+        else
+        {
+            PT Centrd = SHPCentrd_2d(psCShape);
 
-          SHPObject *cent_pt = SHPCreateSimpleObject ( SHPT_POINT, 1,
-        	(double*) &(Centrd.x), (double*) &(Centrd.y), NULL );
+            SHPObject *cent_pt =
+                SHPCreateSimpleObject(SHPT_POINT, 1, (double *)&(Centrd.x),
+                                      (double *)&(Centrd.y), NULL);
 
-          SHPWriteObject ( new_SHP, -1, cent_pt );
+            SHPWriteObject(new_SHP, -1, cent_pt);
 
-          memcpy ( DBFRow, DBFReadTuple ( old_DBF, i ),
-		 old_DBF->nRecordLength );
-          DBFWriteTuple ( new_DBF, new_DBF->nRecords, DBFRow );
+            memcpy(DBFRow, DBFReadTuple(old_DBF, i), old_DBF->nRecordLength);
+            DBFWriteTuple(new_DBF, new_DBF->nRecords, DBFRow);
 
-          SHPDestroyObject ( cent_pt );
+            SHPDestroyObject(cent_pt);
         }
     }
 
-    printf ("\n");
+    printf("\n");
 
     DBFClose(old_DBF);
     SHPClose(old_SHP);

--- a/contrib/shpdata.c
+++ b/contrib/shpdata.c
@@ -30,70 +30,80 @@
 #include "shapefil.h"
 #include "shpgeo.h"
 
-int main( int argc, char ** argv ) {
-    if( argc < 2 )
+int main(int argc, char **argv)
+{
+    if (argc < 2)
     {
-	printf( "shpdata shp_file \n" );
+        printf("shpdata shp_file \n");
         return 1;
     }
 
-    DBFHandle old_DBF = DBFOpen (argv[1], "rb");
-    if(old_DBF == NULL) {
+    DBFHandle old_DBF = DBFOpen(argv[1], "rb");
+    if (old_DBF == NULL)
+    {
         printf("Unable to open old DBF file:%s\n", argv[1]);
         return 1;
     }
 
-    SHPHandle old_SHP = SHPOpen (argv[1], "rb" );
-    if(old_SHP == NULL) {
+    SHPHandle old_SHP = SHPOpen(argv[1], "rb");
+    if (old_SHP == NULL)
+    {
         printf("Unable to open old shape files:%s\n", argv[1]);
         DBFClose(old_DBF);
         return 1;
     }
 
-    int	nEntities;
-    int	nShapeType;
-    SHPGetInfo( old_SHP, &nEntities, &nShapeType, NULL, NULL );
+    int nEntities;
+    int nShapeType;
+    SHPGetInfo(old_SHP, &nEntities, &nShapeType, NULL, NULL);
 
     char *DBFRow = NULL;
     int byRing = 1;
     PT ringCentrd;
 
-    for( int i = 0; i < nEntities; i++ )
+    for (int i = 0; i < nEntities; i++)
     {
-        SHPObject *psCShape = SHPReadObject( old_SHP, i );
+        SHPObject *psCShape = SHPReadObject(old_SHP, i);
 
-        if ( byRing == 1 ) {
-          // const int prevStart = psCShape->nVertices;
-          for ( int ring = (psCShape->nParts - 1); ring >= 0; ring-- ) {
-            const int rStart = psCShape->panPartStart[ring];
-	    int numVtx;
-            if ( ring == (psCShape->nParts -1) )
-              { numVtx = psCShape->nVertices - rStart; }
-             else
-              { numVtx = psCShape->panPartStart[ring+1] - rStart; }
+        if (byRing == 1)
+        {
+            // const int prevStart = psCShape->nVertices;
+            for (int ring = (psCShape->nParts - 1); ring >= 0; ring--)
+            {
+                const int rStart = psCShape->panPartStart[ring];
+                int numVtx;
+                if (ring == (psCShape->nParts - 1))
+                {
+                    numVtx = psCShape->nVertices - rStart;
+                }
+                else
+                {
+                    numVtx = psCShape->panPartStart[ring + 1] - rStart;
+                }
 
-            printf ("(shpdata) Ring(%d) (%d for %d) \n", ring, rStart, numVtx);
-	    SHPObject *psO = SHPClone ( psCShape, ring,  ring + 1 );
+                printf("(shpdata) Ring(%d) (%d for %d) \n", ring, rStart,
+                       numVtx);
+                SHPObject *psO = SHPClone(psCShape, ring, ring + 1);
 
-            const int ringDir = SHPRingDir_2d ( psO, 0 );
-            double ringArea = RingArea_2d (psO->nVertices,(double*) psO->padfX,
-            	 (double*) psO->padfY);
-            RingCentroid_2d ( psO->nVertices, (double*) psO->padfX,
-     		(double*) psO->padfY, &ringCentrd, &ringArea);
+                const int ringDir = SHPRingDir_2d(psO, 0);
+                double ringArea = RingArea_2d(
+                    psO->nVertices, (double *)psO->padfX, (double *)psO->padfY);
+                RingCentroid_2d(psO->nVertices, (double *)psO->padfX,
+                                (double *)psO->padfY, &ringCentrd, &ringArea);
 
-            printf ("(shpdata)  Ring %d, %f Area %d dir \n",
-           	ring, ringArea, ringDir );
+                printf("(shpdata)  Ring %d, %f Area %d dir \n", ring, ringArea,
+                       ringDir);
 
-	    SHPDestroyObject ( psO );
-            printf ("(shpdata) End Ring \n");
-          }  /* (ring) [0,nParts  */
-        }  /* by ring   */
+                SHPDestroyObject(psO);
+                printf("(shpdata) End Ring \n");
+            } /* (ring) [0,nParts  */
+        }     /* by ring   */
 
-        const double oArea = SHPArea_2d ( psCShape );
-        const double oLen = SHPLength_2d ( psCShape );
-        const PT oCentrd = SHPCentrd_2d ( psCShape );
-           printf ("(shpdata) Part (%d) %f Area  %f length, C (%f,%f)\n",
-           	 i, oArea, oLen, oCentrd.x, oCentrd.y );
+        const double oArea = SHPArea_2d(psCShape);
+        const double oLen = SHPLength_2d(psCShape);
+        const PT oCentrd = SHPCentrd_2d(psCShape);
+        printf("(shpdata) Part (%d) %f Area  %f length, C (%f,%f)\n", i, oArea,
+               oLen, oCentrd.x, oCentrd.y);
     }
 
     DBFClose(old_DBF);

--- a/contrib/shpdxf.c
+++ b/contrib/shpdxf.c
@@ -33,146 +33,156 @@
 
 const char FLOAT_PREC[] = "%16.5f\r\n";
 
-static void dxf_hdr(double x1, double y1, double x2,double y2, FILE *df) {
-  // Create HEADER section
-  fprintf(df, "  0\r\n");
-  fprintf(df, "SECTION\r\n");
-  fprintf(df, "  2\r\n" );
-  fprintf(df, "HEADER\r\n" );
-  fprintf(df, "  9\r\n" );
-  fprintf(df, "$EXTMAX\r\n" );
-  fprintf(df, " 10\r\n" );
-  fprintf(df, FLOAT_PREC, x2 );
-  fprintf(df, " 20\r\n" );
-  fprintf(df, FLOAT_PREC, y2 );
-  fprintf(df, "  9\r\n" );
-  fprintf(df, "$EXTMIN\r\n" );
-  fprintf(df, " 10\r\n" );
-  fprintf(df, FLOAT_PREC, x1 );
-  fprintf(df, " 20\r\n" );
-  fprintf(df, FLOAT_PREC, y1 );
-  fprintf(df, "  9\r\n" );
-  fprintf(df, "$LUPREC\r\n" );
-  fprintf(df, " 70\r\n" );
-  fprintf(df, "    14\r\n" );
-  fprintf(df, "  0\r\n" );
-  fprintf(df, "ENDSEC\r\n" );
-
-  // Create TABLES section
-
-  fprintf(df, "  0\r\n" );
-  fprintf(df, "SECTION\r\n" );
-  fprintf(df, "  2\r\n" );
-  fprintf(df, "TABLES\r\n" );
-  // Table 1 - set up line type
-  fprintf(df, "  0\r\n" );
-  fprintf(df, "TABLE\r\n" );
-  fprintf(df, "  2\r\n" );
-  fprintf(df, "LTYPE\r\n" );
-  fprintf(df, " 70\r\n" );
-  fprintf(df, "2\r\n" );
-  // Entry 1 of Table 1
-  fprintf(df, "  0\r\n" );
-  fprintf(df, "LTYPE\r\n" );
-  fprintf(df, "  2\r\n" );
-  fprintf(df, "CONTINUOUS\r\n" );
-  fprintf(df, " 70\r\n" );
-  fprintf(df, "64\r\n" );
-  fprintf(df, "  3\r\n" );
-  fprintf(df, "Solid line\r\n" );
-  fprintf(df, " 72\r\n" );
-  fprintf(df, "65\r\n" );
-  fprintf(df, " 73\r\n" );
-  fprintf(df, "0\r\n" );
-  fprintf(df, " 40\r\n" );
-  fprintf(df, "0.0\r\n" );
-  fprintf(df, "  0\r\n" );
-  fprintf(df, "ENDTAB\r\n" );
-  // End of TABLES section
-  fprintf(df, "  0\r\n" );
-  fprintf(df, "ENDSEC\r\n" );
-
-  // Create BLOCKS section
-  fprintf(df, "  0\r\n" );
-  fprintf(df, "SECTION\r\n" );
-  fprintf(df, "  2\r\n" );
-  fprintf(df, "BLOCKS\r\n" );
-  fprintf(df, "  0\r\n" );
-  fprintf(df, "ENDSEC\r\n" );
-  fprintf(df, "  0\r\n" );
-  fprintf(df, "SECTION\r\n" );
-  fprintf(df, "  2\r\n" );
-  fprintf(df, "ENTITIES\r\n" );
-}
-
-
-static void dxf_ent_preamble (int dxf_type, char *id, FILE *df) {
-  fprintf(df, "  0\r\n" );
-
-  switch (dxf_type) {
-    case  SHPT_POLYGON:
-    case  SHPT_ARC:	  fprintf (df, "POLYLINE\r\n");
-          break;
-    default:  fprintf(df, "POINT\r\n");
-  }
-
-  fprintf(df, "  8\r\n");
-  fprintf(df, "%s\r\n", id );
-  switch ( dxf_type ) {
-    case SHPT_ARC:
-      fprintf(df, "  6\r\n" );
-      fprintf(df, "CONTINUOUS\r\n" );
-      fprintf(df, " 66\r\n" );
-      fprintf(df, "1\r\n" );
-      break;
-    case SHPT_POLYGON:
-      fprintf(df, "  6\r\n" );
-      fprintf(df, "CONTINUOUS\r\n" );
-      fprintf(df, " 66\r\n" );
-      fprintf(df, "1\r\n" );
-      fprintf(df, " 70\r\n");
-      fprintf(df, "1\r\n");
-    default:     break;
-  }
-}
-
-static void
-dxf_ent (char *id, double x, double y, double z, int dxf_type, FILE *df) {
-  if ((dxf_type == SHPT_ARC) || ( dxf_type == SHPT_POLYGON))  {
+static void dxf_hdr(double x1, double y1, double x2, double y2, FILE *df)
+{
+    // Create HEADER section
     fprintf(df, "  0\r\n");
-    fprintf(df, "VERTEX\r\n");
+    fprintf(df, "SECTION\r\n");
+    fprintf(df, "  2\r\n");
+    fprintf(df, "HEADER\r\n");
+    fprintf(df, "  9\r\n");
+    fprintf(df, "$EXTMAX\r\n");
+    fprintf(df, " 10\r\n");
+    fprintf(df, FLOAT_PREC, x2);
+    fprintf(df, " 20\r\n");
+    fprintf(df, FLOAT_PREC, y2);
+    fprintf(df, "  9\r\n");
+    fprintf(df, "$EXTMIN\r\n");
+    fprintf(df, " 10\r\n");
+    fprintf(df, FLOAT_PREC, x1);
+    fprintf(df, " 20\r\n");
+    fprintf(df, FLOAT_PREC, y1);
+    fprintf(df, "  9\r\n");
+    fprintf(df, "$LUPREC\r\n");
+    fprintf(df, " 70\r\n");
+    fprintf(df, "    14\r\n");
+    fprintf(df, "  0\r\n");
+    fprintf(df, "ENDSEC\r\n");
+
+    // Create TABLES section
+
+    fprintf(df, "  0\r\n");
+    fprintf(df, "SECTION\r\n");
+    fprintf(df, "  2\r\n");
+    fprintf(df, "TABLES\r\n");
+    // Table 1 - set up line type
+    fprintf(df, "  0\r\n");
+    fprintf(df, "TABLE\r\n");
+    fprintf(df, "  2\r\n");
+    fprintf(df, "LTYPE\r\n");
+    fprintf(df, " 70\r\n");
+    fprintf(df, "2\r\n");
+    // Entry 1 of Table 1
+    fprintf(df, "  0\r\n");
+    fprintf(df, "LTYPE\r\n");
+    fprintf(df, "  2\r\n");
+    fprintf(df, "CONTINUOUS\r\n");
+    fprintf(df, " 70\r\n");
+    fprintf(df, "64\r\n");
+    fprintf(df, "  3\r\n");
+    fprintf(df, "Solid line\r\n");
+    fprintf(df, " 72\r\n");
+    fprintf(df, "65\r\n");
+    fprintf(df, " 73\r\n");
+    fprintf(df, "0\r\n");
+    fprintf(df, " 40\r\n");
+    fprintf(df, "0.0\r\n");
+    fprintf(df, "  0\r\n");
+    fprintf(df, "ENDTAB\r\n");
+    // End of TABLES section
+    fprintf(df, "  0\r\n");
+    fprintf(df, "ENDSEC\r\n");
+
+    // Create BLOCKS section
+    fprintf(df, "  0\r\n");
+    fprintf(df, "SECTION\r\n");
+    fprintf(df, "  2\r\n");
+    fprintf(df, "BLOCKS\r\n");
+    fprintf(df, "  0\r\n");
+    fprintf(df, "ENDSEC\r\n");
+    fprintf(df, "  0\r\n");
+    fprintf(df, "SECTION\r\n");
+    fprintf(df, "  2\r\n");
+    fprintf(df, "ENTITIES\r\n");
+}
+
+static void dxf_ent_preamble(int dxf_type, char *id, FILE *df)
+{
+    fprintf(df, "  0\r\n");
+
+    switch (dxf_type)
+    {
+        case SHPT_POLYGON:
+        case SHPT_ARC:
+            fprintf(df, "POLYLINE\r\n");
+            break;
+        default:
+            fprintf(df, "POINT\r\n");
+    }
+
     fprintf(df, "  8\r\n");
     fprintf(df, "%s\r\n", id);
-  }
-  fprintf(df, " 10\r\n" );
-  fprintf(df, FLOAT_PREC, x );
-  fprintf(df, " 20\r\n" );
-  fprintf(df, FLOAT_PREC, y );
-  fprintf(df, " 30\r\n" );
-  if ( z != 0 )
-    fprintf(df, FLOAT_PREC, z );
-  else
-    fprintf(df, "0.0\r\n" );
+    switch (dxf_type)
+    {
+        case SHPT_ARC:
+            fprintf(df, "  6\r\n");
+            fprintf(df, "CONTINUOUS\r\n");
+            fprintf(df, " 66\r\n");
+            fprintf(df, "1\r\n");
+            break;
+        case SHPT_POLYGON:
+            fprintf(df, "  6\r\n");
+            fprintf(df, "CONTINUOUS\r\n");
+            fprintf(df, " 66\r\n");
+            fprintf(df, "1\r\n");
+            fprintf(df, " 70\r\n");
+            fprintf(df, "1\r\n");
+        default:
+            break;
+    }
 }
 
-
-static void dxf_ent_postamble (int dxf_type, FILE *df) {
-  if ((dxf_type == SHPT_ARC) || ( dxf_type == SHPT_POLYGON))
-    fprintf(df, "  0\r\nSEQEND\r\n  8\r\n0\r\n");
+static void dxf_ent(char *id, double x, double y, double z, int dxf_type,
+                    FILE *df)
+{
+    if ((dxf_type == SHPT_ARC) || (dxf_type == SHPT_POLYGON))
+    {
+        fprintf(df, "  0\r\n");
+        fprintf(df, "VERTEX\r\n");
+        fprintf(df, "  8\r\n");
+        fprintf(df, "%s\r\n", id);
+    }
+    fprintf(df, " 10\r\n");
+    fprintf(df, FLOAT_PREC, x);
+    fprintf(df, " 20\r\n");
+    fprintf(df, FLOAT_PREC, y);
+    fprintf(df, " 30\r\n");
+    if (z != 0)
+        fprintf(df, FLOAT_PREC, z);
+    else
+        fprintf(df, "0.0\r\n");
 }
 
+static void dxf_ent_postamble(int dxf_type, FILE *df)
+{
+    if ((dxf_type == SHPT_ARC) || (dxf_type == SHPT_POLYGON))
+        fprintf(df, "  0\r\nSEQEND\r\n  8\r\n0\r\n");
+}
 
 #define MAX_FILESIZE 80
 
-int main(int argc, char **argv) {
-    if (argc < 2) {
+int main(int argc, char **argv)
+{
+    if (argc < 2)
+    {
         printf("usage: shpdxf shapefile {idfield}\n");
         return -1;
     }
 
     char *shpFileName = argv[1];
     const size_t len = strlen(shpFileName);
-    if (len < 5 || len > MAX_FILESIZE - 1) {
+    if (len < 5 || len > MAX_FILESIZE - 1)
+    {
         // e.g. "a.shp"
         printf("shapefile name must be between 5 and %d characters\n",
                MAX_FILESIZE - 1);
@@ -181,43 +191,45 @@ int main(int argc, char **argv) {
 
     char dbfFileName[MAX_FILESIZE] = "";
     strncpy(dbfFileName, shpFileName, len - 3);
-    strcat(dbfFileName,"dbf");
+    strcat(dbfFileName, "dbf");
 
     char dxfFileName[MAX_FILESIZE] = "";
     strncpy(dxfFileName, shpFileName, len - 3);
     strcat(dxfFileName, "dxf");
 
     DBFHandle dbf = DBFOpen(dbfFileName, "rb");
-    if (dbf == NULL) {
-	printf("Unable to open dbf: %s\n", dbfFileName);
-	return EXIT_FAILURE;
+    if (dbf == NULL)
+    {
+        printf("Unable to open dbf: %s\n", dbfFileName);
+        return EXIT_FAILURE;
     }
 
     SHPHandle shp = SHPOpen(shpFileName, "rb");
-    if (shp == NULL) {
-	printf("Unable to open shp: %s\n", shpFileName);
+    if (shp == NULL)
+    {
+        printf("Unable to open shp: %s\n", shpFileName);
         DBFClose(dbf);
-	return EXIT_FAILURE;
+        return EXIT_FAILURE;
     }
 
     FILE *dxf = fopen(dxfFileName, "w");
-    if (dxf == NULL) {
-	printf("Unable to open dxf: %s\n", dxfFileName);
+    if (dxf == NULL)
+    {
+        printf("Unable to open dxf: %s\n", dxfFileName);
         DBFClose(dbf);
         SHPClose(shp);
-	return EXIT_FAILURE;
-
+        return EXIT_FAILURE;
     }
 
-    printf("Starting conversion %s(%s) -> %s\r\n",
-           shpFileName,dbfFileName,dxfFileName);
+    printf("Starting conversion %s(%s) -> %s\r\n", shpFileName, dbfFileName,
+           dxfFileName);
 
-    int	shp_numrec;
-    int	shp_type;
+    int shp_numrec;
+    int shp_type;
     double adfBoundsMin[4];
     double adfBoundsMax[4];
-    SHPGetInfo(shp, &shp_numrec, &shp_type, adfBoundsMin, adfBoundsMax );
-    printf ("file has %d objects\r\n", shp_numrec);
+    SHPGetInfo(shp, &shp_numrec, &shp_type, adfBoundsMin, adfBoundsMax);
+    printf("file has %d objects\r\n", shp_numrec);
 
     dxf_hdr(adfBoundsMin[0], adfBoundsMin[1], adfBoundsMax[0], adfBoundsMax[1],
             dxf);
@@ -226,62 +238,71 @@ int main(int argc, char **argv) {
     // default to the record number.
 
     unsigned int MaxElem = -1;
-    if ( argc > 3 )  MaxElem = atoi(argv[3]);
+    if (argc > 3)
+        MaxElem = atoi(argv[3]);
 
     const int nflds = DBFGetFieldCount(dbf);
     int idfld = -1;
     DBFFieldType idfld_type = FTInvalid;
     char fldName[15];
 
-    if (argc > 2) {
+    if (argc > 2)
+    {
         char idfldName[15];
         strcpy(idfldName, argv[2]);
-        for ( idfld=0; idfld < nflds; idfld++ ) {
-            idfld_type = DBFGetFieldInfo( dbf, idfld, fldName, NULL, NULL);
-            if (!strcmp (idfldName, fldName ))
+        for (idfld = 0; idfld < nflds; idfld++)
+        {
+            idfld_type = DBFGetFieldInfo(dbf, idfld, fldName, NULL, NULL);
+            if (!strcmp(idfldName, fldName))
                 break;
         }
-        if ( idfld >= nflds ) {
-            printf ("Id field %s not found, using default\r\n",idfldName);
+        if (idfld >= nflds)
+        {
+            printf("Id field %s not found, using default\r\n", idfldName);
             idfld = -1;
-        } else
-            printf ("proceeding with field %s for LayerNames\r\n",fldName);
+        }
+        else
+            printf("proceeding with field %s for LayerNames\r\n", fldName);
     }
-
 
     int zfld = 0;
-    for (; zfld < nflds; zfld++) {
+    for (; zfld < nflds; zfld++)
+    {
         const char zfldName[6] = "ELEV";
         DBFGetFieldInfo(dbf, zfld, fldName, NULL, NULL);
-        if (!strcmp (zfldName, fldName))
+        if (!strcmp(zfldName, fldName))
             break;
     }
-    if ( zfld >= nflds )
+    if (zfld >= nflds)
         zfld = -1;
 
 #ifdef DEBUG
-    printf ("proceeding with id = %d, elevation = %d\r\n",idfld, zfld);
+    printf("proceeding with id = %d, elevation = %d\r\n", idfld, zfld);
 #endif
 
     char id[255];
 
     // Proceed to process data.
-    for (int recNum = 0; (recNum < shp_numrec) && (recNum < MaxElem); recNum++)  {
-        if ( idfld >= 0 )
-            switch (idfld_type) {
-              case FTString:
-                sprintf(id, "lvl_%s", DBFReadStringAttribute (dbf, recNum, idfld));
-                break;
-              default:
-                sprintf(id, "%-20.0lf", DBFReadDoubleAttribute (dbf, recNum, idfld));
+    for (int recNum = 0; (recNum < shp_numrec) && (recNum < MaxElem); recNum++)
+    {
+        if (idfld >= 0)
+            switch (idfld_type)
+            {
+                case FTString:
+                    sprintf(id, "lvl_%s",
+                            DBFReadStringAttribute(dbf, recNum, idfld));
+                    break;
+                default:
+                    sprintf(id, "%-20.0lf",
+                            DBFReadDoubleAttribute(dbf, recNum, idfld));
             }
         else
-            sprintf (id,"lvl_%-20d",(recNum +1 ));
-
+            sprintf(id, "lvl_%-20d", (recNum + 1));
 
         double elev = 0.0;
-        if (zfld < 0) {
-            elev = DBFReadDoubleAttribute (dbf, recNum, zfld);
+        if (zfld < 0)
+        {
+            elev = DBFReadDoubleAttribute(dbf, recNum, zfld);
         }
 
 #ifdef DEBUG
@@ -294,34 +315,36 @@ int main(int argc, char **argv) {
         const int nParts = shape->nParts;
         int *panParts = shape->panPartStart;
         int part = 0;
-        for (int vrtx = 0; vrtx < nVertices; vrtx++) {
+        for (int vrtx = 0; vrtx < nVertices; vrtx++)
+        {
 #ifdef DEBUG
-            printf("\rworking on part %d, vertex %d", part,vrtx);
+            printf("\rworking on part %d, vertex %d", part, vrtx);
 #endif
-            if (panParts[part] == vrtx) {
+            if (panParts[part] == vrtx)
+            {
 #ifdef DEBUG
-                printf ("object preamble\r\n");
+                printf("object preamble\r\n");
 #endif
                 dxf_ent_preamble(shp_type, id, dxf);
             }
 
-            dxf_ent(id, shape->padfX[vrtx], shape->padfY[vrtx],
-                    elev, shp_type, dxf);
+            dxf_ent(id, shape->padfX[vrtx], shape->padfY[vrtx], elev, shp_type,
+                    dxf);
 
-            if (panParts[part] == (vrtx + 1) || vrtx == (nVertices - 1)) {
+            if (panParts[part] == (vrtx + 1) || vrtx == (nVertices - 1))
+            {
                 dxf_ent_postamble(shp_type, dxf);
                 part++;
             }
         }
-        SHPDestroyObject( shape );
+        SHPDestroyObject(shape);
     }
 
     // close out DXF file
-    fprintf(dxf, "0\r\n" );
+    fprintf(dxf, "0\r\n");
     fprintf(dxf, "ENDSEC\r\n");
-    fprintf(dxf, "0\r\n" );
-    fprintf(dxf, "EOF\r\n" );
-
+    fprintf(dxf, "0\r\n");
+    fprintf(dxf, "EOF\r\n");
 
     DBFClose(dbf);
     SHPClose(shp);
@@ -329,9 +352,3 @@ int main(int argc, char **argv) {
 
     return 0;
 }
-
-
-
-
-
-

--- a/contrib/shpfix.c
+++ b/contrib/shpfix.c
@@ -36,17 +36,20 @@
 #include <string.h>
 #include "shapefil.h"
 
-int main(int argc, char ** argv) {
-    if(argc <= 3) {
+int main(int argc, char **argv)
+{
+    if (argc <= 3)
+    {
         printf("shpfix shpfile new_file <Record# to Blank>\n");
         return EXIT_FAILURE;
     }
 
     const int fix_rec = atoi(argv[3]) - 1;
 
-   // Open the passed shapefile.
+    // Open the passed shapefile.
     SHPHandle hSHP = SHPOpen(argv[1], "rb+");
-    if(hSHP == NULL) {
+    if (hSHP == NULL)
+    {
         printf("Unable to open source: %s\n", argv[1]);
         return EXIT_FAILURE;
     }
@@ -57,7 +60,8 @@ int main(int argc, char ** argv) {
 
     // Open the passed shapefile.
     SHPHandle cSHP = SHPCreate(argv[2], nShapeType);
-    if(cSHP == NULL) {
+    if (cSHP == NULL)
+    {
         printf("Unable to create destination: %s\n", argv[2]);
         SHPClose(hSHP);
         return EXIT_FAILURE;
@@ -65,12 +69,14 @@ int main(int argc, char ** argv) {
 
     int cShapeType;
     double adBounds[4];
-    SHPGetInfo(cSHP, NULL, &cShapeType, &(adBounds[0]), &(adBounds[2]) );
+    SHPGetInfo(cSHP, NULL, &cShapeType, &(adBounds[0]), &(adBounds[2]));
 
     // Skim over the list of shapes, printing all the vertices.
-    for (int i = 0; i < nEntities; i++) {
+    for (int i = 0; i < nEntities; i++)
+    {
         SHPObject *shape = SHPReadObject(hSHP, i);
-        if (i == fix_rec) {
+        if (i == fix_rec)
+        {
             shape->nParts = 0;
             shape->nVertices = 0;
         }

--- a/contrib/shpgeo.c
+++ b/contrib/shpgeo.c
@@ -47,7 +47,7 @@
 #define NAN (INFINITY - INFINITY)
 #endif
 
- /* I'm using some shorthand throughout this file
+/* I'm using some shorthand throughout this file
  *      R+ is a Clockwise Ring and is the positive portion of an object
  *      R- is a CounterClockwise Ring and is a hole in a R+
  *      A complex object is one having at least one R-
@@ -72,28 +72,30 @@
  * utility function, toss part of filename after last dot
  *
  * **************************************************************************/
-char * asFileName ( const char *fil, char *ext ) {
-/* -------------------------------------------------------------------- */
-/*	Compute the base (layer) name.  If there is any extension	*/
-/*	on the passed in filename we will strip it off.			*/
-/* -------------------------------------------------------------------- */
+char *asFileName(const char *fil, char *ext)
+{
+    /* -------------------------------------------------------------------- */
+    /*	Compute the base (layer) name.  If there is any extension	*/
+    /*	on the passed in filename we will strip it off.			*/
+    /* -------------------------------------------------------------------- */
     char pszBasename[120];
-    strcpy( pszBasename, fil );
+    strcpy(pszBasename, fil);
     int i = strlen(pszBasename) - 1;
-    for( ;
-	 i > 0 && pszBasename[i] != '.' && pszBasename[i] != '/'
-	       && pszBasename[i] != '\\';
-	 i-- ) {}
+    for (; i > 0 && pszBasename[i] != '.' && pszBasename[i] != '/' &&
+           pszBasename[i] != '\\';
+         i--)
+    {
+    }
 
-    if( pszBasename[i] == '.' )
+    if (pszBasename[i] == '.')
         pszBasename[i] = '\0';
 
-/* -------------------------------------------------------------------- */
-/*	Note that files pulled from					*/
-/*	a PC to Unix with upper case filenames won't work!		*/
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*	Note that files pulled from					*/
+    /*	a PC to Unix with upper case filenames won't work!		*/
+    /* -------------------------------------------------------------------- */
     static char pszFullname[120];
-    sprintf( pszFullname, "%s.%s", pszBasename, ext );
+    sprintf(pszFullname, "%s.%s", pszBasename, ext);
 
     return pszFullname;
 }
@@ -104,32 +106,73 @@ char * asFileName ( const char *fil, char *ext ) {
  * Convert Both ways from and to OGIS Geometry Types
  *
  * **************************************************************************/
-int SHPOGisType ( int GeomType, int toOGis) {
+int SHPOGisType(int GeomType, int toOGis)
+{
 
-    if ( toOGis == 0 )  /* connect OGis -> SHP types  					*/
-	switch (GeomType) {
-            case (OGIST_POINT):		return ( SHPT_POINT );      break;
-            case (OGIST_LINESTRING):	return ( SHPT_ARC );        break;
-            case (OGIST_POLYGON):		return ( SHPT_POLYGON );    break;
-            case (OGIST_MULTIPOINT):	return ( SHPT_MULTIPOINT ); break;
-            case (OGIST_MULTILINE):	return ( SHPT_ARC );	    break;
-            case (OGIST_MULTIPOLYGON):	return ( SHPT_POLYGON );    break;
+    if (toOGis == 0) /* connect OGis -> SHP types  					*/
+        switch (GeomType)
+        {
+            case (OGIST_POINT):
+                return (SHPT_POINT);
+                break;
+            case (OGIST_LINESTRING):
+                return (SHPT_ARC);
+                break;
+            case (OGIST_POLYGON):
+                return (SHPT_POLYGON);
+                break;
+            case (OGIST_MULTIPOINT):
+                return (SHPT_MULTIPOINT);
+                break;
+            case (OGIST_MULTILINE):
+                return (SHPT_ARC);
+                break;
+            case (OGIST_MULTIPOLYGON):
+                return (SHPT_POLYGON);
+                break;
         }
-    else  /* ok so its SHP->OGis types 									*/
-        switch (GeomType) {
-	    case (SHPT_POINT):		return ( OGIST_POINT );	    break;
-	    case (SHPT_POINTM):		return ( OGIST_POINT );	    break;
-	    case (SHPT_POINTZ):		return ( OGIST_POINT );	    break;
-	    case (SHPT_ARC):		return ( OGIST_LINESTRING );break;
-	    case (SHPT_ARCZ):		return ( OGIST_LINESTRING );break;
-	    case (SHPT_ARCM):		return ( OGIST_LINESTRING );break;
-	    case (SHPT_POLYGON):	return ( OGIST_MULTIPOLYGON );break;
-	    case (SHPT_POLYGONZ):	return ( OGIST_MULTIPOLYGON );break;
-	    case (SHPT_POLYGONM):	return ( OGIST_MULTIPOLYGON );break;
-	    case (SHPT_MULTIPOINT):	return ( OGIST_MULTIPOINT );break;
-	    case (SHPT_MULTIPOINTZ):	return ( OGIST_MULTIPOINT );break;
-	    case (SHPT_MULTIPOINTM):	return ( OGIST_MULTIPOINT );break;
-	    case (SHPT_MULTIPATCH):	return ( OGIST_GEOMCOLL );  break;
+    else /* ok so its SHP->OGis types 									*/
+        switch (GeomType)
+        {
+            case (SHPT_POINT):
+                return (OGIST_POINT);
+                break;
+            case (SHPT_POINTM):
+                return (OGIST_POINT);
+                break;
+            case (SHPT_POINTZ):
+                return (OGIST_POINT);
+                break;
+            case (SHPT_ARC):
+                return (OGIST_LINESTRING);
+                break;
+            case (SHPT_ARCZ):
+                return (OGIST_LINESTRING);
+                break;
+            case (SHPT_ARCM):
+                return (OGIST_LINESTRING);
+                break;
+            case (SHPT_POLYGON):
+                return (OGIST_MULTIPOLYGON);
+                break;
+            case (SHPT_POLYGONZ):
+                return (OGIST_MULTIPOLYGON);
+                break;
+            case (SHPT_POLYGONM):
+                return (OGIST_MULTIPOLYGON);
+                break;
+            case (SHPT_MULTIPOINT):
+                return (OGIST_MULTIPOINT);
+                break;
+            case (SHPT_MULTIPOINTZ):
+                return (OGIST_MULTIPOINT);
+                break;
+            case (SHPT_MULTIPOINTM):
+                return (OGIST_MULTIPOINT);
+                break;
+            case (SHPT_MULTIPATCH):
+                return (OGIST_GEOMCOLL);
+                break;
         }
 
     return 0;
@@ -141,36 +184,38 @@ int SHPOGisType ( int GeomType, int toOGis) {
  * Encapsulate entire SHPObject for use with Postgresql
  *
  * **************************************************************************/
-static int SHPWriteSHPStream ( WKBStreamObj *stream_obj, SHPObject *psCShape ) {
-  int need_swap = 1;
-  need_swap = ((char*) (&need_swap))[0];
+static int SHPWriteSHPStream(WKBStreamObj *stream_obj, SHPObject *psCShape)
+{
+    int need_swap = 1;
+    need_swap = ((char *)(&need_swap))[0];
 
-  /*realloc (stream_obj, obj_storage );*/
+    /*realloc (stream_obj, obj_storage );*/
 
-  if ( need_swap ) {
+    if (need_swap)
+    {
+    }
+    else
+    {
+        memcpy(stream_obj, psCShape, 4 * sizeof(int));
+        memcpy(stream_obj, psCShape, 4 * sizeof(double));
+        // TODO(schwehr): What?
+        // const int use_Z = 0;
+        // const int use_M = 0;
+        // if ( use_Z )
+        //   memcpy (stream_obj, psCShape, 2 * sizeof (double) );
+        // if ( use_M )
+        //   memcpy (stream_obj, psCShape, 2 * sizeof (double) );
 
-  } else {
-    memcpy (stream_obj, psCShape, 4 * sizeof (int) );
-    memcpy (stream_obj, psCShape, 4 * sizeof (double) );
-    // TODO(schwehr): What?
-    // const int use_Z = 0;
-    // const int use_M = 0;
-    // if ( use_Z )
-    //   memcpy (stream_obj, psCShape, 2 * sizeof (double) );
-    // if ( use_M )
-    //   memcpy (stream_obj, psCShape, 2 * sizeof (double) );
+        memcpy(stream_obj, psCShape, psCShape->nParts * 2 * sizeof(int));
+        memcpy(stream_obj, psCShape, psCShape->nVertices * 2 * sizeof(double));
+        // if ( use_Z )
+        //   memcpy (stream_obj, psCShape, psCShape->nVertices * 2 * sizeof (double) );
+        // if ( use_M )
+        //   memcpy (stream_obj, psCShape, psCShape->nVertices * 2 * sizeof (double) );
+    }
 
-    memcpy (stream_obj, psCShape, psCShape->nParts * 2 * sizeof (int) );
-    memcpy (stream_obj, psCShape, psCShape->nVertices * 2 * sizeof (double) );
-    // if ( use_Z )
-    //   memcpy (stream_obj, psCShape, psCShape->nVertices * 2 * sizeof (double) );
-    // if ( use_M )
-    //   memcpy (stream_obj, psCShape, psCShape->nVertices * 2 * sizeof (double) );
-   }
-
-  return (0);
+    return (0);
 }
-
 
 /* **************************************************************************
  * WKBStreamWrite
@@ -178,18 +223,17 @@ static int SHPWriteSHPStream ( WKBStreamObj *stream_obj, SHPObject *psCShape ) {
  * Encapsulate entire SHPObject for use with Postgresql
  *
  * **************************************************************************/
-static int WKBStreamWrite ( WKBStreamObj* wso, void* this, int tcount, int tsize ) {
-   if ( wso->NeedSwap )
-     SwapG ( &(wso->wStream[wso->StreamPos]), this, tcount, tsize );
-   else
-     memcpy ( &(wso->wStream[wso->StreamPos]), this, tsize * tcount );
+static int WKBStreamWrite(WKBStreamObj *wso, void *this, int tcount, int tsize)
+{
+    if (wso->NeedSwap)
+        SwapG(&(wso->wStream[wso->StreamPos]), this, tcount, tsize);
+    else
+        memcpy(&(wso->wStream[wso->StreamPos]), this, tsize * tcount);
 
-   wso->StreamPos += tsize;
+    wso->StreamPos += tsize;
 
-   return 0;
+    return 0;
 }
-
-
 
 /* **************************************************************************
  * WKBStreamRead
@@ -197,18 +241,17 @@ static int WKBStreamWrite ( WKBStreamObj* wso, void* this, int tcount, int tsize
  * Encapsulate entire SHPObject for use with Postgresql
  *
  * **************************************************************************/
-static int WKBStreamRead ( WKBStreamObj* wso, void* this, int tcount, int tsize ) {
-   if ( wso->NeedSwap )
-     SwapG ( this, &(wso->wStream[wso->StreamPos]), tcount, tsize );
-   else
-     memcpy ( this, &(wso->wStream[wso->StreamPos]), tsize * tcount );
+static int WKBStreamRead(WKBStreamObj *wso, void *this, int tcount, int tsize)
+{
+    if (wso->NeedSwap)
+        SwapG(this, &(wso->wStream[wso->StreamPos]), tcount, tsize);
+    else
+        memcpy(this, &(wso->wStream[wso->StreamPos]), tsize * tcount);
 
-   wso->StreamPos += tsize;
+    wso->StreamPos += tsize;
 
-   return 0;
+    return 0;
 }
-
-
 
 /* **************************************************************************
  * SHPReadOGisWKB
@@ -216,35 +259,43 @@ static int WKBStreamRead ( WKBStreamObj* wso, void* this, int tcount, int tsize 
  * Encapsulate entire SHPObject for use with Postgresql
  *
  * **************************************************************************/
-SHPObject* SHPReadOGisWKB ( WKBStreamObj *stream_obj) {
-  char WKB_order;
-  WKBStreamRead ( stream_obj, &WKB_order, 1, sizeof(char));
-  int my_order = 1;
-  my_order = ((char*) (&my_order))[0];
-  stream_obj->NeedSwap = !(WKB_order & my_order);
+SHPObject *SHPReadOGisWKB(WKBStreamObj *stream_obj)
+{
+    char WKB_order;
+    WKBStreamRead(stream_obj, &WKB_order, 1, sizeof(char));
+    int my_order = 1;
+    my_order = ((char *)(&my_order))[0];
+    stream_obj->NeedSwap = !(WKB_order & my_order);
 
-  /* convert OGis Types to SHP types  */
-  int GeoType = 0;
-  const int nSHPType = SHPOGisType ( GeoType, 0 );
+    /* convert OGis Types to SHP types  */
+    int GeoType = 0;
+    const int nSHPType = SHPOGisType(GeoType, 0);
 
-  WKBStreamRead ( stream_obj, &GeoType, 1, sizeof(int));
+    WKBStreamRead(stream_obj, &GeoType, 1, sizeof(int));
 
-  const int thisDim = SHPDimension ( nSHPType );
+    const int thisDim = SHPDimension(nSHPType);
 
-  // SHPObject *psCShape;
-  if ( thisDim && SHPD_AREA ) {
-    /* psCShape = */ SHPReadOGisPolygon ( stream_obj );
-  } else {
-    if ( thisDim && SHPD_LINE ) {
-      /* psCShape = */ SHPReadOGisLine ( stream_obj );
-    } else {
-      if ( thisDim && SHPD_POINT ) {
-        /* psCShape = */ SHPReadOGisPoint ( stream_obj );
-      }
+    // SHPObject *psCShape;
+    if (thisDim && SHPD_AREA)
+    {
+        /* psCShape = */ SHPReadOGisPolygon(stream_obj);
     }
-  }
+    else
+    {
+        if (thisDim && SHPD_LINE)
+        {
+            /* psCShape = */ SHPReadOGisLine(stream_obj);
+        }
+        else
+        {
+            if (thisDim && SHPD_POINT)
+            {
+                /* psCShape = */ SHPReadOGisPoint(stream_obj);
+            }
+        }
+    }
 
-   return (0);
+    return (0);
 }
 
 /* **************************************************************************
@@ -253,72 +304,86 @@ SHPObject* SHPReadOGisWKB ( WKBStreamObj *stream_obj) {
  * Encapsulate entire SHPObject for use with Postgresql
  *
  * **************************************************************************/
-int SHPWriteOGisWKB ( WKBStreamObj* stream_obj, SHPObject *psCShape ) {
-  /* OGis WKB can handle either byte order,  but if I get to choose I'd
+int SHPWriteOGisWKB(WKBStreamObj *stream_obj, SHPObject *psCShape)
+{
+    /* OGis WKB can handle either byte order,  but if I get to choose I'd
   /* rather have it predicatable system-to-system							*/
 
-  if ( stream_obj ) {
-    if ( stream_obj->wStream )
-      free ( stream_obj->wStream );
-   } else
-    { stream_obj = calloc ( 3, sizeof (int ) ); }
+    if (stream_obj)
+    {
+        if (stream_obj->wStream)
+            free(stream_obj->wStream);
+    }
+    else
+    {
+        stream_obj = calloc(3, sizeof(int));
+    }
 
-  /* object size needs to be 9 bytes for the wrapper, and for each polygon	*/
-  /* another 9 bytes all plus twice the total number of vertices 		*/
-  /* times the sizeof (double) and just pad with 10 more chars for fun 		*/
-  stream_obj->wStream = calloc (1, (9 * (psCShape->nParts + 1)) +
-  	( sizeof(double) * 2 * psCShape->nVertices ) + 10 );
+    /* object size needs to be 9 bytes for the wrapper, and for each polygon	*/
+    /* another 9 bytes all plus twice the total number of vertices 		*/
+    /* times the sizeof (double) and just pad with 10 more chars for fun 		*/
+    stream_obj->wStream =
+        calloc(1, (9 * (psCShape->nParts + 1)) +
+                      (sizeof(double) * 2 * psCShape->nVertices) + 10);
 
- #ifdef DEBUG2
-   printf (" I just allocated %d bytes to wkbObj \n",
-  	(int)(sizeof (int) + sizeof (int) + sizeof(int) +
-        ( sizeof(int) * psCShape->nParts + 1 ) +
-  	( sizeof(double) * 2 * psCShape->nVertices ) + 10) );
- #endif
+#ifdef DEBUG2
+    printf(" I just allocated %d bytes to wkbObj \n",
+           (int)(sizeof(int) + sizeof(int) + sizeof(int) +
+                 (sizeof(int) * psCShape->nParts + 1) +
+                 (sizeof(double) * 2 * psCShape->nVertices) + 10));
+#endif
 
-  /* indicate that this WKB is in LSB Order	*/
-  int my_order = 1;
-  my_order = ((char*) (&my_order))[0];
-  /* Need to swap if this system is not  LSB (Intel Order)					*/
-  char LSB = 1;
-  stream_obj->NeedSwap = ( my_order != LSB );
+    /* indicate that this WKB is in LSB Order	*/
+    int my_order = 1;
+    my_order = ((char *)(&my_order))[0];
+    /* Need to swap if this system is not  LSB (Intel Order)					*/
+    char LSB = 1;
+    stream_obj->NeedSwap = (my_order != LSB);
 
-  stream_obj->StreamPos = 0;
+    stream_obj->StreamPos = 0;
 
-  #ifdef DEBUG2
-    printf ("this system is (%d) LSB recorded as needSwap %d\n",my_order, stream_obj->NeedSwap);
-  #endif
+#ifdef DEBUG2
+    printf("this system is (%d) LSB recorded as needSwap %d\n", my_order,
+           stream_obj->NeedSwap);
+#endif
 
-  WKBStreamWrite ( stream_obj, & LSB, 1, sizeof(char) );
+    WKBStreamWrite(stream_obj, &LSB, 1, sizeof(char));
 
-  #ifdef DEBUG2
-    printf ("this system in LSB \n");
-  #endif
+#ifdef DEBUG2
+    printf("this system in LSB \n");
+#endif
 
+    /* convert SHP Types to OGis types  */
+    int GeoType = SHPOGisType(psCShape->nSHPType, 1);
+    WKBStreamWrite(stream_obj, &GeoType, 1, sizeof(int));
 
-  /* convert SHP Types to OGis types  */
-  int GeoType = SHPOGisType ( psCShape->nSHPType, 1 );
-  WKBStreamWrite ( stream_obj, &GeoType, 1, sizeof(int) );
+    const int thisDim = SHPDimension(psCShape->nSHPType);
 
-  const int thisDim = SHPDimension ( psCShape->nSHPType );
-
-  if ( thisDim && SHPD_AREA )
-    { SHPWriteOGisPolygon ( stream_obj, psCShape ); }
-   else {
-    if ( thisDim && SHPD_LINE )
-      { SHPWriteOGisLine ( stream_obj, psCShape ); }
-    else {
-      if ( thisDim && SHPD_POINT )
-        { SHPWriteOGisPoint ( stream_obj, psCShape ); }
-      }
+    if (thisDim && SHPD_AREA)
+    {
+        SHPWriteOGisPolygon(stream_obj, psCShape);
+    }
+    else
+    {
+        if (thisDim && SHPD_LINE)
+        {
+            SHPWriteOGisLine(stream_obj, psCShape);
+        }
+        else
+        {
+            if (thisDim && SHPD_POINT)
+            {
+                SHPWriteOGisPoint(stream_obj, psCShape);
+            }
+        }
     }
 
 #ifdef DEBUG2
-  printf("(SHPWriteOGisWKB) outta here when stream pos is %d \n", stream_obj->StreamPos);
+    printf("(SHPWriteOGisWKB) outta here when stream pos is %d \n",
+           stream_obj->StreamPos);
 #endif
-  return (0);
+    return (0);
 }
-
 
 /* **************************************************************************
  * SHPWriteOGisPolygon
@@ -329,58 +394,67 @@ int SHPWriteOGisWKB ( WKBStreamObj* stream_obj, SHPObject *psCShape ) {
  * Encapsulate entire SHPObject for use with Postgresql
  *
  * **************************************************************************/
-int SHPWriteOGisPolygon ( WKBStreamObj *stream_obj, SHPObject *psCShape ) {
-   /* cannot have more than nParts complex objects in this object */
-   SHPObject **ppsC = calloc ( psCShape->nParts, sizeof(int) );
+int SHPWriteOGisPolygon(WKBStreamObj *stream_obj, SHPObject *psCShape)
+{
+    /* cannot have more than nParts complex objects in this object */
+    SHPObject **ppsC = calloc(psCShape->nParts, sizeof(int));
 
-   int nextring = 0;
-   int cParts=0;
-   while ( nextring >= 0 ) {
-       ppsC[cParts] = SHPUnCompound ( psCShape, &nextring );
-       cParts++;
+    int nextring = 0;
+    int cParts = 0;
+    while (nextring >= 0)
+    {
+        ppsC[cParts] = SHPUnCompound(psCShape, &nextring);
+        cParts++;
     }
 
 #ifdef DEBUG2
-     printf ("(SHPWriteOGisPolygon) Uncompounded into %d parts \n", cParts);
+    printf("(SHPWriteOGisPolygon) Uncompounded into %d parts \n", cParts);
 #endif
 
-   WKBStreamWrite ( stream_obj, &cParts, 1, sizeof(int) );
+    WKBStreamWrite(stream_obj, &cParts, 1, sizeof(int));
 
-   int GeoType = OGIST_POLYGON;
+    int GeoType = OGIST_POLYGON;
 
-   char Flag = 1;
-   for ( int cpart = 0; cpart < cParts; cpart++) {
-     WKBStreamWrite ( stream_obj, & Flag, 1, sizeof(char) );
-     WKBStreamWrite ( stream_obj, & GeoType, 1, sizeof(int) );
+    char Flag = 1;
+    for (int cpart = 0; cpart < cParts; cpart++)
+    {
+        WKBStreamWrite(stream_obj, &Flag, 1, sizeof(char));
+        WKBStreamWrite(stream_obj, &GeoType, 1, sizeof(int));
 
-     SHPObject *psC = (SHPObject*) ppsC[cpart];
-     WKBStreamWrite ( stream_obj, &(psC->nParts), 1, sizeof(int) );
+        SHPObject *psC = (SHPObject *)ppsC[cpart];
+        WKBStreamWrite(stream_obj, &(psC->nParts), 1, sizeof(int));
 
-     for ( int ring = 0; (ring < (psC->nParts)) && (psC->nParts > 0); ring ++) {
-       int rVertices;
-       if ( ring < (psC->nParts-2) )
-         { rVertices = psC->panPartStart[ring+1] - psC->panPartStart[ring]; }
-       else
-         { rVertices = psC->nVertices - psC->panPartStart[ring]; }
+        for (int ring = 0; (ring < (psC->nParts)) && (psC->nParts > 0); ring++)
+        {
+            int rVertices;
+            if (ring < (psC->nParts - 2))
+            {
+                rVertices =
+                    psC->panPartStart[ring + 1] - psC->panPartStart[ring];
+            }
+            else
+            {
+                rVertices = psC->nVertices - psC->panPartStart[ring];
+            }
 #ifdef DEBUG2
-     printf ("(SHPWriteOGisPolygon) scanning part %d, ring %d %d vtxs \n",
-     		cpart, ring, rVertices);
+            printf("(SHPWriteOGisPolygon) scanning part %d, ring %d %d vtxs \n",
+                   cpart, ring, rVertices);
 #endif
-       const int rPart = psC->panPartStart[ring];
-       WKBStreamWrite ( stream_obj, &rVertices, 1, sizeof(int) );
-       for ( int j = rPart; j < (rPart + rVertices); j++ ) {
-         WKBStreamWrite ( stream_obj, &(psC->padfX[j]), 1, sizeof(double) );
-         WKBStreamWrite ( stream_obj, &(psC->padfY[j]), 1, sizeof(double) );
-        } /* for each vertex */
-      }  /* for each ring */
-    }  /* for each complex part */
+            const int rPart = psC->panPartStart[ring];
+            WKBStreamWrite(stream_obj, &rVertices, 1, sizeof(int));
+            for (int j = rPart; j < (rPart + rVertices); j++)
+            {
+                WKBStreamWrite(stream_obj, &(psC->padfX[j]), 1, sizeof(double));
+                WKBStreamWrite(stream_obj, &(psC->padfY[j]), 1, sizeof(double));
+            } /* for each vertex */
+        }     /* for each ring */
+    }         /* for each complex part */
 
 #ifdef DEBUG2
-     printf ("(SHPWriteOGisPolygon) outta here \n");
+    printf("(SHPWriteOGisPolygon) outta here \n");
 #endif
-  return (1);
+    return (1);
 }
-
 
 /* **************************************************************************
  * SHPWriteOGisLine
@@ -391,10 +465,10 @@ int SHPWriteOGisPolygon ( WKBStreamObj *stream_obj, SHPObject *psCShape ) {
  * Encapsulate entire SHPObject for use with Postgresql
  *
  * **************************************************************************/
-int SHPWriteOGisLine ( WKBStreamObj *stream_obj, SHPObject *psCShape ) {
-  return ( SHPWriteOGisPolygon( stream_obj, psCShape ));
+int SHPWriteOGisLine(WKBStreamObj *stream_obj, SHPObject *psCShape)
+{
+    return (SHPWriteOGisPolygon(stream_obj, psCShape));
 }
-
 
 /* **************************************************************************
  * SHPWriteOGisPoint
@@ -405,18 +479,18 @@ int SHPWriteOGisLine ( WKBStreamObj *stream_obj, SHPObject *psCShape ) {
  * Encapsulate entire SHPObject for use with Postgresql
  *
  * **************************************************************************/
-int SHPWriteOGisPoint ( WKBStreamObj *stream_obj, SHPObject *psCShape ) {
-   WKBStreamWrite ( stream_obj, &(psCShape->nVertices), 1, sizeof(int) );
+int SHPWriteOGisPoint(WKBStreamObj *stream_obj, SHPObject *psCShape)
+{
+    WKBStreamWrite(stream_obj, &(psCShape->nVertices), 1, sizeof(int));
 
-   for ( int j = 0; j < psCShape->nVertices; j++ ) {
-     WKBStreamWrite ( stream_obj, &(psCShape->padfX[j]), 1, sizeof(double) );
-     WKBStreamWrite ( stream_obj, &(psCShape->padfY[j]), 1, sizeof(double) );
+    for (int j = 0; j < psCShape->nVertices; j++)
+    {
+        WKBStreamWrite(stream_obj, &(psCShape->padfX[j]), 1, sizeof(double));
+        WKBStreamWrite(stream_obj, &(psCShape->padfY[j]), 1, sizeof(double));
     } /* for each vertex */
 
-  return (1);
+    return (1);
 }
-
-
 
 /* **************************************************************************
  * SHPReadOGisPolygon
@@ -427,59 +501,68 @@ int SHPWriteOGisPoint ( WKBStreamObj *stream_obj, SHPObject *psCShape ) {
  * Encapsulate entire SHPObject for use with Postgresql
  *
  * **************************************************************************/
-SHPObject* SHPReadOGisPolygon ( WKBStreamObj *stream_obj ) {
-   SHPObject *psC = SHPCreateObject ( SHPT_POLYGON, -1, 0, NULL, NULL, 0,
-        	NULL, NULL, NULL, NULL );
-   /* initialize a blank SHPObject */
+SHPObject *SHPReadOGisPolygon(WKBStreamObj *stream_obj)
+{
+    SHPObject *psC = SHPCreateObject(SHPT_POLYGON, -1, 0, NULL, NULL, 0, NULL,
+                                     NULL, NULL, NULL);
+    /* initialize a blank SHPObject */
 
-   int cParts;
-   WKBStreamRead ( stream_obj, &cParts, 1, sizeof(char) );
+    int cParts;
+    WKBStreamRead(stream_obj, &cParts, 1, sizeof(char));
 
-   int totParts = cParts;
-   int totVertices = 0;
+    int totParts = cParts;
+    int totVertices = 0;
 
-   psC->panPartStart = realloc(psC->panPartStart, cParts * sizeof(int));
-   psC->panPartType = realloc(psC->panPartType, cParts * sizeof(int));
+    psC->panPartStart = realloc(psC->panPartStart, cParts * sizeof(int));
+    psC->panPartType = realloc(psC->panPartType, cParts * sizeof(int));
 
-   int rVertices;
-   int nParts;
-   for ( int cpart = 0; cpart < cParts; cpart++) {
-     WKBStreamRead ( stream_obj, &nParts, 1, sizeof(int) );
-     const int pRings = nParts;
-     /* pRings is the number of rings prior to the Ring loop below */
+    int rVertices;
+    int nParts;
+    for (int cpart = 0; cpart < cParts; cpart++)
+    {
+        WKBStreamRead(stream_obj, &nParts, 1, sizeof(int));
+        const int pRings = nParts;
+        /* pRings is the number of rings prior to the Ring loop below */
 
-     if ( nParts > 1 ) {
-       totParts += nParts - 1;
-       psC->panPartStart = realloc(psC->panPartStart, totParts * sizeof(int));
-       psC->panPartType = realloc(psC->panPartType, totParts * sizeof(int));
-      }
+        if (nParts > 1)
+        {
+            totParts += nParts - 1;
+            psC->panPartStart =
+                realloc(psC->panPartStart, totParts * sizeof(int));
+            psC->panPartType =
+                realloc(psC->panPartType, totParts * sizeof(int));
+        }
 
-     int rPart = 0;
-     for ( int ring = 0; ring < (nParts - 1); ring ++) {
-       WKBStreamRead ( stream_obj, &rVertices, 1, sizeof(int) );
-       totVertices += rVertices;
+        int rPart = 0;
+        for (int ring = 0; ring < (nParts - 1); ring++)
+        {
+            WKBStreamRead(stream_obj, &rVertices, 1, sizeof(int));
+            totVertices += rVertices;
 
-       psC->panPartStart[ring+pRings] = rPart;
-       if ( ring == 0 )
-         { psC->panPartType[ring + pRings] = SHPP_OUTERRING; }
-        else
-         { psC->panPartType[ring + pRings] = SHPP_INNERRING; }
+            psC->panPartStart[ring + pRings] = rPart;
+            if (ring == 0)
+            {
+                psC->panPartType[ring + pRings] = SHPP_OUTERRING;
+            }
+            else
+            {
+                psC->panPartType[ring + pRings] = SHPP_INNERRING;
+            }
 
-       psC->padfX = realloc(psC->padfX, totVertices * sizeof (double));
-       psC->padfY = realloc(psC->padfY, totVertices * sizeof (double));
+            psC->padfX = realloc(psC->padfX, totVertices * sizeof(double));
+            psC->padfY = realloc(psC->padfY, totVertices * sizeof(double));
 
-       for ( int j = rPart; j < (rPart + rVertices); j++ ) {
-         WKBStreamRead ( stream_obj, &(psC->padfX[j]), 1, sizeof(double) );
-         WKBStreamRead ( stream_obj, &(psC->padfY[j]), 1, sizeof(double) );
-        } /* for each vertex */
-       rPart += rVertices;
-      }  /* for each ring */
-    }  /* for each complex part */
+            for (int j = rPart; j < (rPart + rVertices); j++)
+            {
+                WKBStreamRead(stream_obj, &(psC->padfX[j]), 1, sizeof(double));
+                WKBStreamRead(stream_obj, &(psC->padfY[j]), 1, sizeof(double));
+            } /* for each vertex */
+            rPart += rVertices;
+        } /* for each ring */
+    }     /* for each complex part */
 
-    return ( psC );
-
+    return (psC);
 }
-
 
 /* **************************************************************************
  * SHPReadOGisLine
@@ -490,58 +573,68 @@ SHPObject* SHPReadOGisPolygon ( WKBStreamObj *stream_obj ) {
  * Encapsulate entire SHPObject for use with Postgresql
  *
  * **************************************************************************/
-SHPObject* SHPReadOGisLine ( WKBStreamObj *stream_obj ) {
-   SHPObject *psC = SHPCreateObject ( SHPT_ARC, -1, 0, NULL, NULL, 0,
-        	NULL, NULL, NULL, NULL );
-   /* initialize a blank SHPObject */
+SHPObject *SHPReadOGisLine(WKBStreamObj *stream_obj)
+{
+    SHPObject *psC =
+        SHPCreateObject(SHPT_ARC, -1, 0, NULL, NULL, 0, NULL, NULL, NULL, NULL);
+    /* initialize a blank SHPObject */
 
-   int cParts;
-   WKBStreamRead ( stream_obj, &cParts, 1, sizeof(int) );
+    int cParts;
+    WKBStreamRead(stream_obj, &cParts, 1, sizeof(int));
 
-   int totParts = cParts;
-   int totVertices = 0;
+    int totParts = cParts;
+    int totVertices = 0;
 
-   psC->panPartStart = realloc(psC->panPartStart, cParts * sizeof(int));
-   psC->panPartType = realloc(psC->panPartType, cParts * sizeof(int));
+    psC->panPartStart = realloc(psC->panPartStart, cParts * sizeof(int));
+    psC->panPartType = realloc(psC->panPartType, cParts * sizeof(int));
 
-   int rVertices;
-   int nParts;
-   for ( int cpart = 0; cpart < cParts; cpart++) {
-     WKBStreamRead ( stream_obj, &nParts, 1, sizeof(int) );
-     int pRings = totParts;
-     /* pRings is the number of rings prior to the Ring loop below			*/
+    int rVertices;
+    int nParts;
+    for (int cpart = 0; cpart < cParts; cpart++)
+    {
+        WKBStreamRead(stream_obj, &nParts, 1, sizeof(int));
+        int pRings = totParts;
+        /* pRings is the number of rings prior to the Ring loop below			*/
 
-     if ( nParts > 1 ) {
-       totParts += nParts - 1;
-       psC->panPartStart = realloc(psC->panPartStart, totParts * sizeof(int));
-       psC->panPartType = realloc(psC->panPartType, totParts * sizeof(int));
-      }
+        if (nParts > 1)
+        {
+            totParts += nParts - 1;
+            psC->panPartStart =
+                realloc(psC->panPartStart, totParts * sizeof(int));
+            psC->panPartType =
+                realloc(psC->panPartType, totParts * sizeof(int));
+        }
 
-     int rPart = 0;
-     for ( int ring = 0; ring < (nParts - 1); ring ++) {
-       WKBStreamRead ( stream_obj, &rVertices, 1, sizeof(int) );
-       totVertices += rVertices;
+        int rPart = 0;
+        for (int ring = 0; ring < (nParts - 1); ring++)
+        {
+            WKBStreamRead(stream_obj, &rVertices, 1, sizeof(int));
+            totVertices += rVertices;
 
-       psC->panPartStart[ring+pRings] = rPart;
-       if ( ring == 0 )
-         { psC->panPartType[ring + pRings] = SHPP_OUTERRING; }
-        else
-         { psC->panPartType[ring + pRings] = SHPP_INNERRING; }
+            psC->panPartStart[ring + pRings] = rPart;
+            if (ring == 0)
+            {
+                psC->panPartType[ring + pRings] = SHPP_OUTERRING;
+            }
+            else
+            {
+                psC->panPartType[ring + pRings] = SHPP_INNERRING;
+            }
 
-       psC->padfX = realloc(psC->padfX, totVertices * sizeof (double));
-       psC->padfY = realloc(psC->padfY, totVertices * sizeof (double));
+            psC->padfX = realloc(psC->padfX, totVertices * sizeof(double));
+            psC->padfY = realloc(psC->padfY, totVertices * sizeof(double));
 
-       for ( int j = rPart; j < (rPart + rVertices); j++ ) {
-         WKBStreamRead ( stream_obj, &(psC->padfX[j]), 1, sizeof(double) );
-         WKBStreamRead ( stream_obj, &(psC->padfY[j]), 1, sizeof(double) );
-        } /* for each vertex */
-       rPart += rVertices;
-      }  /* for each ring */
-    }  /* for each complex part */
+            for (int j = rPart; j < (rPart + rVertices); j++)
+            {
+                WKBStreamRead(stream_obj, &(psC->padfX[j]), 1, sizeof(double));
+                WKBStreamRead(stream_obj, &(psC->padfY[j]), 1, sizeof(double));
+            } /* for each vertex */
+            rPart += rVertices;
+        } /* for each ring */
+    }     /* for each complex part */
 
-    return ( psC );
+    return (psC);
 }
-
 
 /* **************************************************************************
  * SHPReadOGisPoint
@@ -549,25 +642,26 @@ SHPObject* SHPReadOGisLine ( WKBStreamObj *stream_obj ) {
  * Encapsulate entire SHPObject for use with Postgresql
  *
  * **************************************************************************/
-SHPObject* SHPReadOGisPoint ( WKBStreamObj *stream_obj ) {
-   SHPObject *psC = SHPCreateObject ( SHPT_MULTIPOINT, -1, 0, NULL, NULL, 0,
-        	NULL, NULL, NULL, NULL );
-   /* initialize a blank SHPObject */
+SHPObject *SHPReadOGisPoint(WKBStreamObj *stream_obj)
+{
+    SHPObject *psC = SHPCreateObject(SHPT_MULTIPOINT, -1, 0, NULL, NULL, 0,
+                                     NULL, NULL, NULL, NULL);
+    /* initialize a blank SHPObject */
 
-   int nVertices;
-   WKBStreamRead ( stream_obj, &nVertices, 1, sizeof(int) );
+    int nVertices;
+    WKBStreamRead(stream_obj, &nVertices, 1, sizeof(int));
 
-   psC->padfX = realloc(psC->padfX, nVertices * sizeof (double));
-   psC->padfY = realloc(psC->padfY, nVertices * sizeof (double));
+    psC->padfX = realloc(psC->padfX, nVertices * sizeof(double));
+    psC->padfY = realloc(psC->padfY, nVertices * sizeof(double));
 
-   for ( int j = 0; j < nVertices; j++ ) {
-     WKBStreamRead ( stream_obj, &(psC->padfX[j]), 1, sizeof(double) );
-     WKBStreamRead ( stream_obj, &(psC->padfY[j]), 1, sizeof(double) );
+    for (int j = 0; j < nVertices; j++)
+    {
+        WKBStreamRead(stream_obj, &(psC->padfX[j]), 1, sizeof(double));
+        WKBStreamRead(stream_obj, &(psC->padfY[j]), 1, sizeof(double));
     } /* for each vertex */
 
-    return ( psC );
+    return (psC);
 }
-
 
 /* **************************************************************************
  * SHPDimension
@@ -576,28 +670,55 @@ SHPObject* SHPReadOGisPoint ( WKBStreamObj *stream_obj ) {
  * a handy utility function
  *
  * **************************************************************************/
-int SHPDimension ( int SHPType ) {
+int SHPDimension(int SHPType)
+{
     int dimension = 0;
 
-    switch ( SHPType ) {
-      case  SHPT_POINT       :	dimension = SHPD_POINT; break;
-      case  SHPT_ARC         :	dimension = SHPD_LINE; break;
-      case  SHPT_POLYGON     :	dimension = SHPD_AREA; break;
-      case  SHPT_MULTIPOINT  :	dimension = SHPD_POINT; break;
-      case  SHPT_POINTZ      :	dimension = SHPD_POINT | SHPD_Z; break;
-      case  SHPT_ARCZ        :	dimension = SHPD_LINE | SHPD_Z; break;
-      case  SHPT_POLYGONZ    :	dimension = SHPD_AREA | SHPD_Z; break;
-      case  SHPT_MULTIPOINTZ :	dimension = SHPD_POINT | SHPD_Z; break;
-      case  SHPT_POINTM      :	dimension = SHPD_POINT | SHPD_MEASURE; break;
-      case  SHPT_ARCM        :	dimension = SHPD_LINE | SHPD_MEASURE; break;
-      case  SHPT_POLYGONM    :	dimension = SHPD_AREA | SHPD_MEASURE; break;
-      case  SHPT_MULTIPOINTM :	dimension = SHPD_POINT | SHPD_MEASURE; break;
-      case  SHPT_MULTIPATCH  :	dimension = SHPD_AREA; break;
+    switch (SHPType)
+    {
+        case SHPT_POINT:
+            dimension = SHPD_POINT;
+            break;
+        case SHPT_ARC:
+            dimension = SHPD_LINE;
+            break;
+        case SHPT_POLYGON:
+            dimension = SHPD_AREA;
+            break;
+        case SHPT_MULTIPOINT:
+            dimension = SHPD_POINT;
+            break;
+        case SHPT_POINTZ:
+            dimension = SHPD_POINT | SHPD_Z;
+            break;
+        case SHPT_ARCZ:
+            dimension = SHPD_LINE | SHPD_Z;
+            break;
+        case SHPT_POLYGONZ:
+            dimension = SHPD_AREA | SHPD_Z;
+            break;
+        case SHPT_MULTIPOINTZ:
+            dimension = SHPD_POINT | SHPD_Z;
+            break;
+        case SHPT_POINTM:
+            dimension = SHPD_POINT | SHPD_MEASURE;
+            break;
+        case SHPT_ARCM:
+            dimension = SHPD_LINE | SHPD_MEASURE;
+            break;
+        case SHPT_POLYGONM:
+            dimension = SHPD_AREA | SHPD_MEASURE;
+            break;
+        case SHPT_MULTIPOINTM:
+            dimension = SHPD_POINT | SHPD_MEASURE;
+            break;
+        case SHPT_MULTIPATCH:
+            dimension = SHPD_AREA;
+            break;
     }
 
-    return ( dimension );
+    return (dimension);
 }
-
 
 /* **************************************************************************
  * SHPPointinPoly_2d
@@ -609,26 +730,29 @@ int SHPDimension ( int SHPType ) {
  * reject non area SHP Types
  *
  * **************************************************************************/
-PT SHPPointinPoly_2d ( SHPObject *psCShape ) {
-   PT rPT;
-   if ( !(SHPDimension (psCShape->nSHPType) & SHPD_AREA) )
-   {
-       rPT.x = NAN;
-       rPT.y = NAN;
-       return rPT;
-   }
-
-   PT *sPT = SHPPointsinPoly_2d ( psCShape );
-   if ( sPT ) {
-     rPT.x = sPT[0].x;
-     rPT.y = sPT[0].y;
-    } else {
-     rPT.x = NAN;
-     rPT.y = NAN;
+PT SHPPointinPoly_2d(SHPObject *psCShape)
+{
+    PT rPT;
+    if (!(SHPDimension(psCShape->nSHPType) & SHPD_AREA))
+    {
+        rPT.x = NAN;
+        rPT.y = NAN;
+        return rPT;
     }
-   return ( rPT );
-}
 
+    PT *sPT = SHPPointsinPoly_2d(psCShape);
+    if (sPT)
+    {
+        rPT.x = sPT[0].x;
+        rPT.y = sPT[0].y;
+    }
+    else
+    {
+        rPT.x = NAN;
+        rPT.y = NAN;
+    }
+    return (rPT);
+}
 
 /* **************************************************************************
  * SHPPointsinPoly_2d
@@ -640,85 +764,89 @@ PT SHPPointinPoly_2d ( SHPObject *psCShape ) {
  * reject non area SHP Types
  *
  * **************************************************************************/
-PT *SHPPointsinPoly_2d(SHPObject *psCShape) {
-   if ( !(SHPDimension(psCShape->nSHPType) & SHPD_AREA) )
-      return NULL;
+PT *SHPPointsinPoly_2d(SHPObject *psCShape)
+{
+    if (!(SHPDimension(psCShape->nSHPType) & SHPD_AREA))
+        return NULL;
 
-   PT *PIP = NULL;
-   int cRing = 0;
-   int nPIP = 0;
-   int rMpart, ring_nVertices;
-   // TODO(schwehr): Is this a bug?  Should rLen be zero'ed on each loop?
-   double	rLen = 0;
-   double	rLenMax = 0;
+    PT *PIP = NULL;
+    int cRing = 0;
+    int nPIP = 0;
+    int rMpart, ring_nVertices;
+    // TODO(schwehr): Is this a bug?  Should rLen be zero'ed on each loop?
+    double rLen = 0;
+    double rLenMax = 0;
 
-   SHPObject	*psO;
-   while (psO = SHPUnCompound(psCShape, &cRing)) {
-     double *CLx = calloc(4, sizeof(double));
-     double *CLy = calloc(4, sizeof(double));
-     int *CLst = calloc(2, sizeof(int));
-     int *CLstt = calloc(2, sizeof(int));
-     // TODO(schwehr): Check for allocation failures
+    SHPObject *psO;
+    while (psO = SHPUnCompound(psCShape, &cRing))
+    {
+        double *CLx = calloc(4, sizeof(double));
+        double *CLy = calloc(4, sizeof(double));
+        int *CLst = calloc(2, sizeof(int));
+        int *CLstt = calloc(2, sizeof(int));
+        // TODO(schwehr): Check for allocation failures
 
-     // a horizontal & vertical compound line though the middle of the extents
-     CLx[0] = psO->dfXMin;
-     CLy[0] = (psO->dfYMin + psO->dfYMax ) * 0.5;
-     CLx[1] = psO->dfXMax;
-     CLy[1] = (psO->dfYMin + psO->dfYMax ) * 0.5;
+        // a horizontal & vertical compound line though the middle of the extents
+        CLx[0] = psO->dfXMin;
+        CLy[0] = (psO->dfYMin + psO->dfYMax) * 0.5;
+        CLx[1] = psO->dfXMax;
+        CLy[1] = (psO->dfYMin + psO->dfYMax) * 0.5;
 
-     CLx[2] = (psO->dfXMin + psO->dfXMax ) * 0.5;
-     CLy[2] = psO->dfYMin;
-     CLx[3] = (psO->dfXMin + psO->dfXMax ) * 0.5;
-     CLy[3] = psO->dfYMax;
+        CLx[2] = (psO->dfXMin + psO->dfXMax) * 0.5;
+        CLy[2] = psO->dfYMin;
+        CLx[3] = (psO->dfXMin + psO->dfXMax) * 0.5;
+        CLy[3] = psO->dfYMax;
 
-     CLst[0] = 0;   CLst[1] = 2;
-     CLstt[0] = SHPP_RING; CLstt[1] = SHPP_RING;
+        CLst[0] = 0;
+        CLst[1] = 2;
+        CLstt[0] = SHPP_RING;
+        CLstt[1] = SHPP_RING;
 
-     SHPObject *CLine = SHPCreateObject ( SHPT_POINT, -1, 2, CLst, CLstt, 4,
-        	CLx, CLy, NULL, NULL );
+        SHPObject *CLine = SHPCreateObject(SHPT_POINT, -1, 2, CLst, CLstt, 4,
+                                           CLx, CLy, NULL, NULL);
 
-     /* with the H & V centrline compound object, intersect it with the OBJ	*/
-     SHPObject *psInt = SHPIntersect_2d ( CLine, psO );
-     /* return SHP type is lowest common dimensionality of the input types 	*/
+        /* with the H & V centrline compound object, intersect it with the OBJ	*/
+        SHPObject *psInt = SHPIntersect_2d(CLine, psO);
+        /* return SHP type is lowest common dimensionality of the input types 	*/
 
+        // find the longest linestring returned by the intersection
+        int ring_vtx = psInt->nVertices;
+        for (int ring = (psInt->nParts - 1); ring >= 0; ring--)
+        {
+            ring_nVertices = ring_vtx - psInt->panPartStart[ring];
 
-     // find the longest linestring returned by the intersection
-     int ring_vtx = psInt->nVertices;
-     for (int ring = (psInt->nParts - 1); ring >= 0; ring--) {
-       ring_nVertices = ring_vtx - psInt->panPartStart[ring];
+            rLen += RingLength_2d(
+                ring_nVertices,
+                (double *)&(psInt->padfX[psInt->panPartStart[ring]]),
+                (double *)&(psInt->padfY[psInt->panPartStart[ring]]));
 
-       rLen += RingLength_2d (
-           ring_nVertices,
-           (double*) &(psInt->padfX [psInt->panPartStart[ring]]),
-           (double*) &(psInt->padfY [psInt->panPartStart[ring]]));
+            if (rLen > rLenMax)
+            {
+                rLenMax = rLen;
+                rMpart = psInt->panPartStart[ring];
+            }
+            ring_vtx = psInt->panPartStart[ring];
+        }
 
-       if (rLen > rLenMax) {
-           rLenMax = rLen;
-           rMpart = psInt->panPartStart[ring];
-       }
-       ring_vtx = psInt->panPartStart[ring];
-      }
+        // add the centerpoint of the longest ARC of the intersection to the PIP list
+        nPIP++;
+        PIP = realloc(PIP, sizeof(double) * 2 * nPIP);
+        PIP[nPIP].x = (psInt->padfX[rMpart] + psInt->padfX[rMpart]) * 0.5;
+        PIP[nPIP].y = (psInt->padfY[rMpart] + psInt->padfY[rMpart]) * 0.5;
 
-     // add the centerpoint of the longest ARC of the intersection to the PIP list
-     nPIP++;
-     PIP = realloc(PIP, sizeof(double) * 2 * nPIP);
-     PIP[nPIP].x = (psInt ->padfX [rMpart] + psInt ->padfX [rMpart]) * 0.5;
-     PIP[nPIP].y = (psInt ->padfY [rMpart] + psInt ->padfY [rMpart]) * 0.5;
+        SHPDestroyObject(psO);
+        SHPDestroyObject(CLine);
 
-     SHPDestroyObject (psO);
-     SHPDestroyObject (CLine);
+        // does SHPCreateobject use preallocated memory or does it copy the
+        // contents.  To be safe conditionally release CLx, CLy, CLst, CLstt
+        free(CLx);
+        free(CLy);
+        free(CLst);
+        free(CLstt);
+    }
 
-     // does SHPCreateobject use preallocated memory or does it copy the
-     // contents.  To be safe conditionally release CLx, CLy, CLst, CLstt
-     free(CLx);
-     free(CLy);
-     free(CLst);
-     free(CLstt);
-   }
-
-  return ( PIP );
+    return (PIP);
 }
-
 
 /* **************************************************************************
  * SHPCentrd_2d
@@ -729,60 +857,62 @@ PT *SHPPointsinPoly_2d(SHPObject *psCShape) {
  * reject non area SHP Types
  *
  * **************************************************************************/
-PT SHPCentrd_2d ( SHPObject *psCShape ) {
-   PT C;
-   if ( !(SHPDimension (psCShape->nSHPType) & SHPD_AREA) )
-   {
-       C.x = NAN;
-       C.y = NAN;
-       return C;
-   }
-
-#ifdef DEBUG
-	printf ("for Object with %d vtx, %d parts [ %d, %d] \n",
-		psCShape->nVertices, psCShape->nParts,
-		psCShape->panPartStart[0],psCShape->panPartStart[1]);
-#endif
-
-   double Area = 0;
-   C.x = 0.0;
-   C.y = 0.0;
-
-   /* for each ring in compound / complex object calc the ring cntrd		*/
-
-   double ringArea;
-   PT ringCentrd;
-   int ringPrev = psCShape->nVertices;
-   for ( int ring = (psCShape->nParts - 1); ring >= 0; ring-- ) {
-     const int rStart = psCShape->panPartStart[ring];
-     const int ring_nVertices = ringPrev - rStart;
-
-     RingCentroid_2d ( ring_nVertices, (double*) &(psCShape->padfX [rStart]),
-     	(double*) &(psCShape->padfY [rStart]), &ringCentrd, &ringArea);
-
-#ifdef DEBUG
-	printf ("(SHPCentrd_2d)  Ring %d, vtxs %d, area: %f, ring centrd %f, %f \n",
-		ring, ring_nVertices, ringArea, ringCentrd.x, ringCentrd.y);
-#endif
-
-     /* use Superposition of these rings to build a composite Centroid		*/
-     /* sum the ring centrds * ringAreas,  at the end divide by total area	*/
-     C.x +=  ringCentrd.x * ringArea;
-     C.y +=  ringCentrd.y * ringArea;
-     Area += ringArea;
-     ringPrev = rStart;
+PT SHPCentrd_2d(SHPObject *psCShape)
+{
+    PT C;
+    if (!(SHPDimension(psCShape->nSHPType) & SHPD_AREA))
+    {
+        C.x = NAN;
+        C.y = NAN;
+        return C;
     }
 
-     /* hold on the division by AREA until were at the end					*/
-     C.x = C.x / Area;
-     C.y = C.y / Area;
 #ifdef DEBUG
-	printf ("SHPCentrd_2d) Overall Area: %f, Centrd %f, %f \n",
-		Area, C.x, C.y);
+    printf("for Object with %d vtx, %d parts [ %d, %d] \n", psCShape->nVertices,
+           psCShape->nParts, psCShape->panPartStart[0],
+           psCShape->panPartStart[1]);
 #endif
-   return ( C );
-}
 
+    double Area = 0;
+    C.x = 0.0;
+    C.y = 0.0;
+
+    /* for each ring in compound / complex object calc the ring cntrd		*/
+
+    double ringArea;
+    PT ringCentrd;
+    int ringPrev = psCShape->nVertices;
+    for (int ring = (psCShape->nParts - 1); ring >= 0; ring--)
+    {
+        const int rStart = psCShape->panPartStart[ring];
+        const int ring_nVertices = ringPrev - rStart;
+
+        RingCentroid_2d(ring_nVertices, (double *)&(psCShape->padfX[rStart]),
+                        (double *)&(psCShape->padfY[rStart]), &ringCentrd,
+                        &ringArea);
+
+#ifdef DEBUG
+        printf(
+            "(SHPCentrd_2d)  Ring %d, vtxs %d, area: %f, ring centrd %f, %f \n",
+            ring, ring_nVertices, ringArea, ringCentrd.x, ringCentrd.y);
+#endif
+
+        /* use Superposition of these rings to build a composite Centroid		*/
+        /* sum the ring centrds * ringAreas,  at the end divide by total area	*/
+        C.x += ringCentrd.x * ringArea;
+        C.y += ringCentrd.y * ringArea;
+        Area += ringArea;
+        ringPrev = rStart;
+    }
+
+    /* hold on the division by AREA until were at the end					*/
+    C.x = C.x / Area;
+    C.y = C.y / Area;
+#ifdef DEBUG
+    printf("SHPCentrd_2d) Overall Area: %f, Centrd %f, %f \n", Area, C.x, C.y);
+#endif
+    return (C);
+}
 
 /* **************************************************************************
  * RingCentroid_2d
@@ -790,58 +920,60 @@ PT SHPCentrd_2d ( SHPObject *psCShape ) {
  * Return the mathematical / geometric centroid of a single closed ring
  *
  * **************************************************************************/
-int RingCentroid_2d ( int nVertices, double *a, double *b, PT *C, double *Area ) {
-/* the centroid of a closed Ring is defined as
+int RingCentroid_2d(int nVertices, double *a, double *b, PT *C, double *Area)
+{
+    /* the centroid of a closed Ring is defined as
  *
  *      Cx = sum (cx * dArea ) / Total Area
  *  and
  *      Cy = sum (cy * dArea ) / Total Area
  */
-  double x_base = a[0];
-  double y_base = b[0];
+    double x_base = a[0];
+    double y_base = b[0];
 
-  double Cy_accum = 0.0;
-  double Cx_accum = 0.0;
+    double Cy_accum = 0.0;
+    double Cx_accum = 0.0;
 
-  double ppx = a[1] - x_base;
-  double ppy = b[1] - y_base;
-  *Area = 0;
+    double ppx = a[1] - x_base;
+    double ppy = b[1] - y_base;
+    *Area = 0;
 
-  /* Skip the closing vector */
-  for ( int iv = 2; iv <= nVertices - 2; iv++ ) {
-    const double x = a[iv] - x_base;
-    const double y = b[iv] - y_base;
+    /* Skip the closing vector */
+    for (int iv = 2; iv <= nVertices - 2; iv++)
+    {
+        const double x = a[iv] - x_base;
+        const double y = b[iv] - y_base;
 
-    /* calc the area and centroid of triangle built out of an arbitrary 	*/
-    /* base_point on the ring and each successive pair on the ring			*/
+        /* calc the area and centroid of triangle built out of an arbitrary 	*/
+        /* base_point on the ring and each successive pair on the ring			*/
 
-    /* Area of a triangle is the cross product of its defining vectors		*/
-    /* Centroid of a triangle is the average of its vertices				*/
+        /* Area of a triangle is the cross product of its defining vectors		*/
+        /* Centroid of a triangle is the average of its vertices				*/
 
-    const double dx_Area =  ((x * ppy) - (y * ppx)) * 0.5;
-    *Area += dx_Area;
+        const double dx_Area = ((x * ppy) - (y * ppx)) * 0.5;
+        *Area += dx_Area;
 
-    Cx_accum += ( ppx + x ) * dx_Area;
-    Cy_accum += ( ppy + y ) * dx_Area;
+        Cx_accum += (ppx + x) * dx_Area;
+        Cy_accum += (ppy + y) * dx_Area;
 #ifdef DEBUG2
-    printf("(ringcentrd_2d)  Pp( %f, %f), P(%f, %f)\n", ppx, ppy, x, y);
-    printf("(ringcentrd_2d)    dA: %f, sA: %f, Cx: %f, Cy: %f \n",
-		dx_Area, *Area, Cx_accum, Cy_accum);
+        printf("(ringcentrd_2d)  Pp( %f, %f), P(%f, %f)\n", ppx, ppy, x, y);
+        printf("(ringcentrd_2d)    dA: %f, sA: %f, Cx: %f, Cy: %f \n", dx_Area,
+               *Area, Cx_accum, Cy_accum);
 #endif
-    ppx = x;
-    ppy = y;
-  }
+        ppx = x;
+        ppy = y;
+    }
 
 #ifdef DEBUG2
-  printf("(ringcentrd_2d)  Cx: %f, Cy: %f \n",
-  	( Cx_accum / ( *Area * 3) ), ( Cy_accum / (*Area * 3) ));
+    printf("(ringcentrd_2d)  Cx: %f, Cy: %f \n", (Cx_accum / (*Area * 3)),
+           (Cy_accum / (*Area * 3)));
 #endif
 
-  /* adjust back to world coords 											*/
-  C->x = ( Cx_accum / ( *Area * 3)) + x_base;
-  C->y = ( Cy_accum / ( *Area * 3)) + y_base;
+    /* adjust back to world coords 											*/
+    C->x = (Cx_accum / (*Area * 3)) + x_base;
+    C->y = (Cy_accum / (*Area * 3)) + y_base;
 
-  return ( 1 );
+    return (1);
 }
 
 /* **************************************************************************
@@ -853,71 +985,85 @@ int RingCentroid_2d ( int nVertices, double *a, double *b, PT *C, double *Area )
  * return -1 for R-
  * return 0  for error
  * **************************************************************************/
-int SHPRingDir_2d ( SHPObject *psCShape, int Ring ) {
-   if ( Ring >= psCShape->nParts ) return ( 0 );
+int SHPRingDir_2d(SHPObject *psCShape, int Ring)
+{
+    if (Ring >= psCShape->nParts)
+        return (0);
 
-   double tX = 0.0;
-   double *a = psCShape->padfX;
-   double *b = psCShape->padfY;
+    double tX = 0.0;
+    double *a = psCShape->padfX;
+    double *b = psCShape->padfY;
 
-   int last_vtx;
-   if ( Ring >= psCShape->nParts -1 )
-     { last_vtx = psCShape->nVertices; }
+    int last_vtx;
+    if (Ring >= psCShape->nParts - 1)
+    {
+        last_vtx = psCShape->nVertices;
+    }
     else
-     { last_vtx = psCShape->panPartStart[Ring + 1]; }
+    {
+        last_vtx = psCShape->panPartStart[Ring + 1];
+    }
 
-   /* All vertices at the corners of the extrema (rightmost lowest, leftmost lowest, 	*/
-   /* topmost rightest, ...) must be less than pi wide.  If they weren't, they couldn't be	*/
-   /* extrema.																			*/
-   /* of course the following will fail if the Extents are even a little wrong 			*/
+    /* All vertices at the corners of the extrema (rightmost lowest, leftmost lowest, 	*/
+    /* topmost rightest, ...) must be less than pi wide.  If they weren't, they couldn't be	*/
+    /* extrema.																			*/
+    /* of course the following will fail if the Extents are even a little wrong 			*/
 
-   int ti;
-   for ( int i = psCShape->panPartStart[Ring]; i < last_vtx; i++ ) {
-     if ( b[i] == psCShape->dfYMax && a[i] > tX )
-      { ti = i; }
-   }
-
-#ifdef DEBUG2
-   printf ("(shpgeo:SHPRingDir) highest Rightmost Pt is vtx %d (%f, %f)\n", ti, a[ti], b[ti]);
-#endif
-
-   /* cross product */
-   /* the sign of the cross product of two vectors indicates the right or left half-plane	*/
-   /* which we can use to indicate Ring Dir													*/
-   double dx0;
-   double dx1;
-   double dy0;
-   double dy1;
-   if ( ti > psCShape->panPartStart[Ring] && ti < last_vtx )
-    { dx0 = a[ti-1] - a[ti];
-      dx1 = a[ti+1] - a[ti];
-      dy0 = b[ti-1] - b[ti];
-      dy1 = b[ti+1] - b[ti];
-   }
-   else
-   /* if the tested vertex is at the origin then continue from 0 */
-   {  dx1 = a[1] - a[0];
-      dx0 = a[last_vtx] - a[0];
-      dy1 = b[1] - b[0];
-      dy0 = b[last_vtx] - b[0];
-   }
-
-//   v1 = ( (dy0 * 0) - (0 * dy1) );
-//   v2 = ( (0 * dx1) - (dx0 * 0) );
-/* these above are always zero so why do the math */
-   const double v3 = ( (dx0 * dy1) - (dx1 * dy0) );
+    int ti;
+    for (int i = psCShape->panPartStart[Ring]; i < last_vtx; i++)
+    {
+        if (b[i] == psCShape->dfYMax && a[i] > tX)
+        {
+            ti = i;
+        }
+    }
 
 #ifdef DEBUG2
-   printf ("(shpgeo:SHPRingDir)  cross product for vtx %d was %f \n", ti, v3);
+    printf("(shpgeo:SHPRingDir) highest Rightmost Pt is vtx %d (%f, %f)\n", ti,
+           a[ti], b[ti]);
 #endif
 
-   if ( v3 > 0 )
-    { return (1); }
-   else
-    { return (-1); }
+    /* cross product */
+    /* the sign of the cross product of two vectors indicates the right or left half-plane	*/
+    /* which we can use to indicate Ring Dir													*/
+    double dx0;
+    double dx1;
+    double dy0;
+    double dy1;
+    if (ti > psCShape->panPartStart[Ring] && ti < last_vtx)
+    {
+        dx0 = a[ti - 1] - a[ti];
+        dx1 = a[ti + 1] - a[ti];
+        dy0 = b[ti - 1] - b[ti];
+        dy1 = b[ti + 1] - b[ti];
+    }
+    else
+    /* if the tested vertex is at the origin then continue from 0 */
+    {
+        dx1 = a[1] - a[0];
+        dx0 = a[last_vtx] - a[0];
+        dy1 = b[1] - b[0];
+        dy0 = b[last_vtx] - b[0];
+    }
+
+    //   v1 = ( (dy0 * 0) - (0 * dy1) );
+    //   v2 = ( (0 * dx1) - (dx0 * 0) );
+    /* these above are always zero so why do the math */
+    const double v3 = ((dx0 * dy1) - (dx1 * dy0));
+
+#ifdef DEBUG2
+    printf("(shpgeo:SHPRingDir)  cross product for vtx %d was %f \n", ti, v3);
+#endif
+
+    if (v3 > 0)
+    {
+        return (1);
+    }
+    else
+    {
+        return (-1);
+    }
 }
-
-
 
 /* **************************************************************************
  * SHPArea_2d
@@ -925,38 +1071,40 @@ int SHPRingDir_2d ( SHPObject *psCShape, int Ring ) {
  * Calculate the XY Area of Polygon ( can be compound / complex )
  *
  * **************************************************************************/
-double SHPArea_2d ( SHPObject *psCShape ) {
-   if ( !(SHPDimension (psCShape->nSHPType) & SHPD_AREA) )
-       return ( -1 );
+double SHPArea_2d(SHPObject *psCShape)
+{
+    if (!(SHPDimension(psCShape->nSHPType) & SHPD_AREA))
+        return (-1);
 
-   double cArea = 0;
+    double cArea = 0;
 
-   /* Walk each ring adding its signed Area,  R- will return a negative 	*/
-   /* area, so we don't have to test for them								*/
+    /* Walk each ring adding its signed Area,  R- will return a negative 	*/
+    /* area, so we don't have to test for them								*/
 
-   /* I just start at the last ring and work down to the first				*/
-   int ring_vtx = psCShape->nVertices ;
-   for ( int ring = (psCShape->nParts - 1); ring >= 0; ring-- ) {
-     const int ring_nVertices = ring_vtx - psCShape->panPartStart[ring];
+    /* I just start at the last ring and work down to the first				*/
+    int ring_vtx = psCShape->nVertices;
+    for (int ring = (psCShape->nParts - 1); ring >= 0; ring--)
+    {
+        const int ring_nVertices = ring_vtx - psCShape->panPartStart[ring];
 
 #ifdef DEBUG2
-     printf("(shpgeo:SHPArea_2d) part %d, vtx %d \n", ring,  ring_nVertices);
+        printf("(shpgeo:SHPArea_2d) part %d, vtx %d \n", ring, ring_nVertices);
 #endif
-     cArea += RingArea_2d ( ring_nVertices,
-     	(double*) &(psCShape->padfX [psCShape->panPartStart[ring]]),
-     	(double*) &(psCShape->padfY [psCShape->panPartStart[ring]]) );
+        cArea += RingArea_2d(
+            ring_nVertices,
+            (double *)&(psCShape->padfX[psCShape->panPartStart[ring]]),
+            (double *)&(psCShape->padfY[psCShape->panPartStart[ring]]));
 
-     ring_vtx = psCShape->panPartStart[ring];
+        ring_vtx = psCShape->panPartStart[ring];
     }
 
 #ifdef DEBUG2
-    printf ("(shpgeo:SHPArea_2d) Area = %f \n", cArea);
+    printf("(shpgeo:SHPArea_2d) Area = %f \n", cArea);
 #endif
 
     /* Area is signed, negative Areas are R-									*/
-    return ( cArea );
+    return (cArea);
 }
-
 
 /* **************************************************************************
  * SHPLength_2d
@@ -965,28 +1113,31 @@ double SHPArea_2d ( SHPObject *psCShape ) {
  *    or Polyline ( can be compound ).  Length on Polygon is its Perimeter
  *
  * **************************************************************************/
-double SHPLength_2d ( SHPObject *psCShape ) {
-    if ( !(SHPDimension (psCShape->nSHPType) && (SHPD_AREA || SHPD_LINE)) )
-       return -1.0;
+double SHPLength_2d(SHPObject *psCShape)
+{
+    if (!(SHPDimension(psCShape->nSHPType) && (SHPD_AREA || SHPD_LINE)))
+        return -1.0;
 
     double Length = 0;
     int j = 1;
-    for ( int i = 1; i < psCShape->nVertices; i++ ) {
-      if ( psCShape->panPartStart[j] == i )
-       { j ++; }
-    /* skip the moves with "pen up" from ring to ring */
-      else
-       {
-        const double dx = psCShape->padfX[i] - psCShape->padfX[i-1];
-        const double dy = psCShape->padfY[i] - psCShape->padfY[i-1];
-        Length += sqrt ( ( dx * dx ) + ( dy * dy ) );
-       }
-     /* simplify this equation */
-     }
+    for (int i = 1; i < psCShape->nVertices; i++)
+    {
+        if (psCShape->panPartStart[j] == i)
+        {
+            j++;
+        }
+        /* skip the moves with "pen up" from ring to ring */
+        else
+        {
+            const double dx = psCShape->padfX[i] - psCShape->padfX[i - 1];
+            const double dy = psCShape->padfY[i] - psCShape->padfY[i - 1];
+            Length += sqrt((dx * dx) + (dy * dy));
+        }
+        /* simplify this equation */
+    }
 
-   return Length;
+    return Length;
 }
-
 
 /* **************************************************************************
  * RingLength_2d
@@ -995,19 +1146,20 @@ double SHPLength_2d ( SHPObject *psCShape ) {
  *    or Polyline ( can be compound ).  Length of Polygon is its Perimeter
  *
  * **************************************************************************/
-double RingLength_2d ( int nVertices, double *a, double *b ) {
+double RingLength_2d(int nVertices, double *a, double *b)
+{
     double Length = 0;
     // int j = 1;
-    for ( int i = 1; i < nVertices; i++ ) {
-      const double dx = a[i] - b[i-1];
-      const double dy = b[i] - b[i-1];
-      Length += sqrt ( ( dx * dx ) + ( dy * dy ) );
-     /* simplify this equation */
-     }
+    for (int i = 1; i < nVertices; i++)
+    {
+        const double dx = a[i] - b[i - 1];
+        const double dy = b[i] - b[i - 1];
+        Length += sqrt((dx * dx) + (dy * dy));
+        /* simplify this equation */
+    }
 
-   return ( Length );
+    return (Length);
 }
-
 
 /* **************************************************************************
  * RingArea_2d
@@ -1015,42 +1167,42 @@ double RingLength_2d ( int nVertices, double *a, double *b ) {
  * Calculate the Planar Area of a single closed ring
  *
  * **************************************************************************/
-double RingArea_2d ( int nVertices, double *a, double *b ) {
-  const double x_base = a[0];
-  const double y_base = b[0];
+double RingArea_2d(int nVertices, double *a, double *b)
+{
+    const double x_base = a[0];
+    const double y_base = b[0];
 
-  double ppx = a[1] - x_base;
-  double ppy = b[1] - y_base;
-  static double	Area = 0.0;
-
-#ifdef DEBUG2
-  printf("(shpgeo:RingArea) %d vertices \n", nVertices);
-#endif
-  for ( int iv = 2; iv <= ( nVertices - 1 ); iv++ ) {
-    const double x = a[iv] - x_base;
-    const double y = b[iv] - y_base;
-
-    /* Area of a triangle is the cross product of its defining vectors		*/
-
-    const double dx_Area = ((x * ppy) - (y * ppx)) * 0.5;
-
-    Area += dx_Area;
-#ifdef DEBUG2
-    printf ("(shpgeo:RingArea)  dxArea %f  sArea %f for pt(%f, %f)\n",
-    		dx_Area, Area, x, y);
-#endif
-
-    ppx = x;
-    ppy = y;
-  }
+    double ppx = a[1] - x_base;
+    double ppy = b[1] - y_base;
+    static double Area = 0.0;
 
 #ifdef DEBUG2
-  printf ("(shpgeo:RingArea)  total RingArea %f \n", Area);
+    printf("(shpgeo:RingArea) %d vertices \n", nVertices);
 #endif
-  return Area;
+    for (int iv = 2; iv <= (nVertices - 1); iv++)
+    {
+        const double x = a[iv] - x_base;
+        const double y = b[iv] - y_base;
+
+        /* Area of a triangle is the cross product of its defining vectors		*/
+
+        const double dx_Area = ((x * ppy) - (y * ppx)) * 0.5;
+
+        Area += dx_Area;
+#ifdef DEBUG2
+        printf("(shpgeo:RingArea)  dxArea %f  sArea %f for pt(%f, %f)\n",
+               dx_Area, Area, x, y);
+#endif
+
+        ppx = x;
+        ppy = y;
+    }
+
+#ifdef DEBUG2
+    printf("(shpgeo:RingArea)  total RingArea %f \n", Area);
+#endif
+    return Area;
 }
-
-
 
 /* **************************************************************************
  * SHPUnCompound
@@ -1063,29 +1215,31 @@ double RingArea_2d ( int nVertices, double *a, double *b ) {
  * ignore complexity in Z dimension for now
  *
  * **************************************************************************/
-SHPObject *SHPUnCompound(SHPObject *psCShape, int *ringNumber) {
-   if (*ringNumber >= psCShape->nParts || *ringNumber == -1) {
- 	*ringNumber = -1;
-	return NULL;
-      }
+SHPObject *SHPUnCompound(SHPObject *psCShape, int *ringNumber)
+{
+    if (*ringNumber >= psCShape->nParts || *ringNumber == -1)
+    {
+        *ringNumber = -1;
+        return NULL;
+    }
 
+    if (*ringNumber == (psCShape->nParts - 1))
+    {
+        *ringNumber = -1;
+        return (SHPClone(psCShape, (psCShape->nParts - 1), -1));
+    }
 
-   if ( *ringNumber == (psCShape->nParts - 1) )  {
-        *ringNumber =  -1;
-        return ( SHPClone(psCShape, (psCShape->nParts - 1), -1) );
-      }
+    const int lRing = *ringNumber;
+    int ringDir = -1;
+    int ring = (lRing + 1);
+    for (; (ring < psCShape->nParts) && (ringDir < 0); ring++)
+        ringDir = SHPRingDir_2d(psCShape, ring);
 
-   const int lRing = *ringNumber;
-   int ringDir = -1;
-   int ring = (lRing + 1);
-   for ( ; (ring < psCShape->nParts) && ( ringDir < 0 ); ring ++)
-     ringDir = SHPRingDir_2d ( psCShape, ring);
-
-   if ( ring ==  psCShape->nParts )
-     *ringNumber = -1;
-   else
-     *ringNumber = ring;
-/*    I am strictly assuming that all R- parts of a complex object
+    if (ring == psCShape->nParts)
+        *ringNumber = -1;
+    else
+        *ringNumber = ring;
+        /*    I am strictly assuming that all R- parts of a complex object
  *	   directly follow their R+, so when we hit a new R+ its a
  *	   new part of a compound object
  *         a SHPClean may be needed to enforce this as it is not part
@@ -1093,12 +1247,10 @@ SHPObject *SHPUnCompound(SHPObject *psCShape, int *ringNumber) {
  */
 
 #ifdef DEBUG2
-    printf ("(SHPUnCompound) asked for ring %d, lastring is %d \n", lRing, ring);
+    printf("(SHPUnCompound) asked for ring %d, lastring is %d \n", lRing, ring);
 #endif
-    return ( SHPClone(psCShape, lRing, ring ) );
-
+    return (SHPClone(psCShape, lRing, ring));
 }
-
 
 /* **************************************************************************
  * SHPIntersect_2d
@@ -1109,17 +1261,17 @@ SHPObject *SHPUnCompound(SHPObject *psCShape, int *ringNumber) {
  * return object with lowest common dimensionality of objects
  *
  * **************************************************************************/
-SHPObject* SHPIntersect_2d ( SHPObject* a, SHPObject* b ) {
-  if ( (SHPDimension(a->nSHPType) && SHPD_POINT) || ( SHPDimension(b->nSHPType) && SHPD_POINT ) )
-    return ( NULL );
-  /* there is no intersect function like this for points  */
+SHPObject *SHPIntersect_2d(SHPObject *a, SHPObject *b)
+{
+    if ((SHPDimension(a->nSHPType) && SHPD_POINT) ||
+        (SHPDimension(b->nSHPType) && SHPD_POINT))
+        return (NULL);
+    /* there is no intersect function like this for points  */
 
-  SHPObject *C = SHPClone ( a, 0 , -1 );
+    SHPObject *C = SHPClone(a, 0, -1);
 
-  return C;
+    return C;
 }
-
-
 
 /* **************************************************************************
  * SHPClean
@@ -1138,7 +1290,8 @@ SHPObject* SHPIntersect_2d ( SHPObject* a, SHPObject* b ) {
  * not sure why but return object in place
  * use for object casting and object verification
  * **************************************************************************/
-int SHPClean ( SHPObject *psCShape ) {
+int SHPClean(SHPObject *psCShape)
+{
     return (0);
 }
 
@@ -1148,77 +1301,87 @@ int SHPClean ( SHPObject *psCShape ) {
  * Clone a SHPObject, replicating all data
  *
  * **************************************************************************/
-SHPObject* SHPClone ( SHPObject *psCShape, int lowPart, int highPart ) {
-    if ( highPart >= psCShape->nParts || highPart == -1 )
-	highPart = psCShape->nParts ;
+SHPObject *SHPClone(SHPObject *psCShape, int lowPart, int highPart)
+{
+    if (highPart >= psCShape->nParts || highPart == -1)
+        highPart = psCShape->nParts;
 
 #ifdef DEBUG
-    printf (" cloning SHP (%d parts) from ring %d to ring %d \n",
-	 psCShape->nParts, lowPart, highPart);
+    printf(" cloning SHP (%d parts) from ring %d to ring %d \n",
+           psCShape->nParts, lowPart, highPart);
 #endif
 
     const int newParts = highPart - lowPart;
-    if ( newParts == 0 ) { return ( NULL ); }
+    if (newParts == 0)
+    {
+        return (NULL);
+    }
 
-    SHPObject	*psObject = (SHPObject *) calloc(1,sizeof(SHPObject));
+    SHPObject *psObject = (SHPObject *)calloc(1, sizeof(SHPObject));
     psObject->nSHPType = psCShape->nSHPType;
     psObject->nShapeId = psCShape->nShapeId;
 
     psObject->nParts = newParts;
-    if ( psCShape->padfX ) {
-        psObject->panPartStart = (int*) calloc (newParts, sizeof (int));
-        memcpy ( psObject->panPartStart, psCShape->panPartStart,
-      		newParts * sizeof (int) );
+    if (psCShape->padfX)
+    {
+        psObject->panPartStart = (int *)calloc(newParts, sizeof(int));
+        memcpy(psObject->panPartStart, psCShape->panPartStart,
+               newParts * sizeof(int));
 
-        psObject->panPartType = (int*)calloc(newParts, sizeof(int));
-        memcpy(psObject->panPartType,
-               (int *) &(psCShape->panPartType[lowPart]),
+        psObject->panPartType = (int *)calloc(newParts, sizeof(int));
+        memcpy(psObject->panPartType, (int *)&(psCShape->panPartType[lowPart]),
                newParts * sizeof(int));
     }
 
     int newVertices;
-    if ( highPart != psCShape->nParts ) {
-      newVertices = psCShape->panPartStart[highPart] -
-	 psCShape->panPartStart[lowPart];
-     }
+    if (highPart != psCShape->nParts)
+    {
+        newVertices =
+            psCShape->panPartStart[highPart] - psCShape->panPartStart[lowPart];
+    }
     else
-     { newVertices = psCShape->nVertices - psCShape->panPartStart[lowPart]; }
+    {
+        newVertices = psCShape->nVertices - psCShape->panPartStart[lowPart];
+    }
 
 #ifdef DEBUG
     int i;
-    if ( highPart = psCShape->nParts )
-      i = psCShape->nVertices;
-     else
-      i = psCShape->panPartStart[highPart];
-    printf (" from part %d (%d) to %d (%d) is %d vertices \n",
-	 lowPart, psCShape->panPartStart[lowPart], highPart,
-	 i, newVertices);
+    if (highPart = psCShape->nParts)
+        i = psCShape->nVertices;
+    else
+        i = psCShape->panPartStart[highPart];
+    printf(" from part %d (%d) to %d (%d) is %d vertices \n", lowPart,
+           psCShape->panPartStart[lowPart], highPart, i, newVertices);
 #endif
     psObject->nVertices = newVertices;
-    if ( psCShape->padfX ) {
-      psObject->padfX = (double*) calloc (newVertices, sizeof (double));
-      memcpy ( psObject->padfX,
-	 (double *) &(psCShape->padfX[psCShape->panPartStart[lowPart]]),
-      		newVertices * sizeof (double) );
-     }
-    if ( psCShape->padfY ) {
-      psObject->padfY = (double*) calloc (newVertices, sizeof (double));
-      memcpy ( psObject->padfY,
-	 (double *) &(psCShape->padfY[psCShape->panPartStart[lowPart]]),
-      		newVertices * sizeof (double) );
-     }
-    if ( psCShape->padfZ ) {
-      psObject->padfZ = (double*) calloc (newVertices, sizeof (double));
-      memcpy ( psObject->padfZ,
-	 (double *) &(psCShape->padfZ[psCShape->panPartStart[lowPart]]),
-      		newVertices * sizeof (double) );
-     }
-    if ( psCShape->padfM ) {
-      psObject->padfM = (double*) calloc (newVertices, sizeof (double));
-      memcpy ( psObject->padfM,
-	(double *) &(psCShape->padfM[psCShape->panPartStart[lowPart]]),
-      		newVertices * sizeof (double) );
-     }
+    if (psCShape->padfX)
+    {
+        psObject->padfX = (double *)calloc(newVertices, sizeof(double));
+        memcpy(psObject->padfX,
+               (double *)&(psCShape->padfX[psCShape->panPartStart[lowPart]]),
+               newVertices * sizeof(double));
+    }
+    if (psCShape->padfY)
+    {
+        psObject->padfY = (double *)calloc(newVertices, sizeof(double));
+        memcpy(psObject->padfY,
+               (double *)&(psCShape->padfY[psCShape->panPartStart[lowPart]]),
+               newVertices * sizeof(double));
+    }
+    if (psCShape->padfZ)
+    {
+        psObject->padfZ = (double *)calloc(newVertices, sizeof(double));
+        memcpy(psObject->padfZ,
+               (double *)&(psCShape->padfZ[psCShape->panPartStart[lowPart]]),
+               newVertices * sizeof(double));
+    }
+    if (psCShape->padfM)
+    {
+        psObject->padfM = (double *)calloc(newVertices, sizeof(double));
+        memcpy(psObject->padfM,
+               (double *)&(psCShape->padfM[psCShape->panPartStart[lowPart]]),
+               newVertices * sizeof(double));
+    }
 
     psObject->dfXMin = psCShape->dfXMin;
     psObject->dfYMin = psCShape->dfYMin;
@@ -1230,8 +1393,8 @@ SHPObject* SHPClone ( SHPObject *psCShape, int lowPart, int highPart ) {
     psObject->dfZMax = psCShape->dfZMax;
     psObject->dfMMax = psCShape->dfMMax;
 
-    SHPComputeExtents ( psObject );
-    return ( psObject );
+    SHPComputeExtents(psObject);
+    return (psObject);
 }
 
 /************************************************************************/
@@ -1239,16 +1402,17 @@ SHPObject* SHPClone ( SHPObject *psCShape, int lowPart, int highPart ) {
 /*                                                                      */
 /*      Swap a 2, 4 or 8 byte word.                                     */
 /************************************************************************/
-void SwapG( void *so, void *in, int this_cnt, int this_size ) {
-  // return to a new pointer otherwise it would invalidate existing data
-  // as prevent further use of it
-    for( int j=0; j < this_cnt; j++ )
-     {
-      for( int i=0; i < this_size/2; i++ )
-      {
-	((unsigned char *) so)[i] = ((unsigned char *) in)[this_size-i-1];
-	((unsigned char *) so)[this_size-i-1] = ((unsigned char *) in)[i];
-      }
+void SwapG(void *so, void *in, int this_cnt, int this_size)
+{
+    // return to a new pointer otherwise it would invalidate existing data
+    // as prevent further use of it
+    for (int j = 0; j < this_cnt; j++)
+    {
+        for (int i = 0; i < this_size / 2; i++)
+        {
+            ((unsigned char *)so)[i] = ((unsigned char *)in)[this_size - i - 1];
+            ((unsigned char *)so)[this_size - i - 1] = ((unsigned char *)in)[i];
+        }
     }
 }
 
@@ -1259,12 +1423,13 @@ void SwapG( void *so, void *in, int this_cnt, int this_size ) {
  * need to change this over to shapelib, Frank Warmerdam's functions
  *
  * **************************************************************************/
-void swapW (void *so, unsigned char *in, long bytes) {
-  const unsigned char map[4] = {3,2,1,0};
-  unsigned char *out = so;
-  for (int i=0; i <= (bytes/4); i++)
-   for (int j=0; j < 4; j++)
-      out[(i*4)+map[j]] = in[(i*4)+j];
+void swapW(void *so, unsigned char *in, long bytes)
+{
+    const unsigned char map[4] = {3, 2, 1, 0};
+    unsigned char *out = so;
+    for (int i = 0; i <= (bytes / 4); i++)
+        for (int j = 0; j < 4; j++)
+            out[(i * 4) + map[j]] = in[(i * 4) + j];
 }
 
 /* **************************************************************************
@@ -1274,10 +1439,11 @@ void swapW (void *so, unsigned char *in, long bytes) {
  * need to change this over to shapelib, Frank Warmerdam's functions
  *
  * **************************************************************************/
-void swapD (void *so, unsigned char *in, long bytes) {
-  const unsigned char map[8] = {7,6,5,4,3,2,1,0};
-  unsigned char *out = so;
-  for (int i=0; i <= (bytes/8); i++)
-   for (int j=0; j < 8; j++)
-      out[(i*8)+map[j]] = in[(i*8)+j];
+void swapD(void *so, unsigned char *in, long bytes)
+{
+    const unsigned char map[8] = {7, 6, 5, 4, 3, 2, 1, 0};
+    unsigned char *out = so;
+    for (int i = 0; i <= (bytes / 8); i++)
+        for (int j = 0; j < 8; j++)
+            out[(i * 8) + map[j]] = in[(i * 8) + j];
 }

--- a/contrib/shpgeo.h
+++ b/contrib/shpgeo.h
@@ -26,7 +26,7 @@
  * support for geometric and other additions to shapelib
  */
 
- /* I'm using some shorthand throughout this file
+/* I'm using some shorthand throughout this file
  *      R+ is a Clockwise Ring and is the positive portion of an object
  *      R- is a CounterClockwise Ring and is a hole in a R+
  *      A complex object is one having at least one R-
@@ -48,86 +48,89 @@
 #ifndef SHPGEO_H
 #define SHPGEO_H
 
-
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-#define		SHPD_POINT	 		1
-#define		SHPD_LINE	 		2
-#define		SHPD_AREA			4
-#define 	SHPD_Z		 		8
-#define		SHPD_MEASURE		16
-
+#define SHPD_POINT 1
+#define SHPD_LINE 2
+#define SHPD_AREA 4
+#define SHPD_Z 8
+#define SHPD_MEASURE 16
 
 /* move these into a ogis header file ogis.h */
-#define		OGIST_UNKNOWN			0
-#define		OGIST_POINT				1
-#define		OGIST_LINESTRING		2
-#define		OGIST_POLYGON			3
-#define		OGIST_MULTIPOINT		4
-#define		OGIST_MULTILINE			5
-#define		OGIST_MULTIPOLYGON		6
-#define		OGIST_GEOMCOLL			7
+#define OGIST_UNKNOWN 0
+#define OGIST_POINT 1
+#define OGIST_LINESTRING 2
+#define OGIST_POLYGON 3
+#define OGIST_MULTIPOINT 4
+#define OGIST_MULTILINE 5
+#define OGIST_MULTIPOLYGON 6
+#define OGIST_GEOMCOLL 7
 
-typedef struct { int	StreamPos;
-		 int	NeedSwap;
-		 char	*wStream;
-		} WKBStreamObj;
+    typedef struct
+    {
+        int StreamPos;
+        int NeedSwap;
+        char *wStream;
+    } WKBStreamObj;
 
-typedef struct { double x; double y; } PT;
+    typedef struct
+    {
+        double x;
+        double y;
+    } PT;
 
+    typedef struct
+    {
+        int cParts;
+        SHPObject *SHPObj;
+    } SHPObjectList;
 
-typedef struct { int		cParts;
-		 SHPObject	*SHPObj;
-	  	} SHPObjectList;
+#define LSB_ORDER (int)1
 
+    extern char *asFileName(const char *fil, char *ext);
 
-#define   	LSB_ORDER  (int) 1
+    extern int SHPDimension(int SHPType);
 
+    extern double SHPArea_2d(SHPObject *psCShape);
+    extern int SHPRingDir_2d(SHPObject *psCShape, int Ring);
+    extern double SHPLength_2d(SHPObject *psCShape);
+    extern PT SHPCentrd_2d(SHPObject *psCShape);
+    extern PT SHPPointinPoly_2d(SHPObject *psCShape);
+    extern PT *SHPPointsinPoly_2d(SHPObject *psCShape);
 
-extern char * asFileName ( const char *fil, char *ext );
+    extern int RingCentroid_2d(int nVertices, double *a, double *b, PT *C,
+                               double *Area);
+    extern double RingLength_2d(int nVertices, double *a, double *b);
+    extern int RingDir_2d(int nVertices, double *a, double *b);
+    extern double RingArea_2d(int nVertices, double *a, double *b);
 
-extern int 	SHPDimension ( int SHPType );
+    extern SHPObject *SHPClone(SHPObject *psCShape, int lowPart, int highPart);
+    extern SHPObject *SHPUnCompound(SHPObject *psCShape, int *ringNumber);
+    extern SHPObject *SHPIntersect_2d(SHPObject *a, SHPObject *b);
 
-extern double 	SHPArea_2d ( SHPObject *psCShape );
-extern int 	SHPRingDir_2d ( SHPObject *psCShape, int Ring );
-extern double 	SHPLength_2d ( SHPObject *psCShape );
-extern PT 	SHPCentrd_2d ( SHPObject *psCShape );
-extern PT	SHPPointinPoly_2d ( SHPObject *psCShape );
-extern PT*	SHPPointsinPoly_2d ( SHPObject *psCShape );
+    extern int SHPWriteOGisWKB(WKBStreamObj *stream_obj, SHPObject *psCShape);
+    extern SHPObject *SHPReadOGisWKB(WKBStreamObj *stream_obj);
 
-extern int 	RingCentroid_2d ( int nVertices, double *a, double *b, PT *C,
-	double *Area );
-extern double 	RingLength_2d ( int nVertices, double *a, double *b );
-extern int	RingDir_2d ( int nVertices, double *a, double *b );
-extern double 	RingArea_2d ( int nVertices, double *a, double *b );
+    int SHPWriteOGisPolygon(WKBStreamObj *stream_obj, SHPObject *psCShape);
+    int SHPWriteOGisLine(WKBStreamObj *stream_obj, SHPObject *psCShape);
+    int SHPWriteOGisPoint(WKBStreamObj *stream_obj, SHPObject *psCShape);
 
-extern SHPObject* 	SHPClone ( SHPObject *psCShape, int lowPart, int highPart );
-extern SHPObject* 	SHPUnCompound  ( SHPObject *psCShape, int * ringNumber );
-extern SHPObject* 	SHPIntersect_2d ( SHPObject* a, SHPObject* b );
+    SHPObject *SHPReadOGisPolygon(WKBStreamObj *stream_obj);
+    SHPObject *SHPReadOGisLine(WKBStreamObj *stream_obj);
+    SHPObject *SHPReadOGisPoint(WKBStreamObj *stream_obj);
 
-extern int 	SHPWriteOGisWKB ( WKBStreamObj *stream_obj, SHPObject *psCShape );
-extern SHPObject*	SHPReadOGisWKB ( WKBStreamObj *stream_obj );
+    extern int SHPClean(SHPObject *psCShape);
+    extern int SHPOGisType(int GeomType, int toOGis);
 
-int SHPWriteOGisPolygon ( WKBStreamObj *stream_obj, SHPObject *psCShape );
-int SHPWriteOGisLine ( WKBStreamObj *stream_obj, SHPObject *psCShape );
-int SHPWriteOGisPoint ( WKBStreamObj *stream_obj, SHPObject *psCShape );
-
-SHPObject* SHPReadOGisPolygon ( WKBStreamObj *stream_obj );
-SHPObject* SHPReadOGisLine ( WKBStreamObj *stream_obj );
-SHPObject* SHPReadOGisPoint ( WKBStreamObj *stream_obj );
-
-extern int 	SHPClean ( SHPObject *psCShape );
-extern int 	SHPOGisType ( int GeomType, int toOGis);
-
-void 	swapD (void *so, unsigned char *in, long bytes);
-void 	swapW (void *so, unsigned char *in, long bytes);
-void 	SwapG( void *so, void *in, int this_cnt, int this_size );
-
+    void swapD(void *so, unsigned char *in, long bytes);
+    void swapW(void *so, unsigned char *in, long bytes);
+    void SwapG(void *so, void *in, int this_cnt, int this_size);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif   /* ndef SHPGEO_H	*/
+#endif /* ndef SHPGEO_H	*/

--- a/contrib/shpinfo.c
+++ b/contrib/shpinfo.c
@@ -29,14 +29,17 @@
 #include <string.h>
 #include "shapefil.h"
 
-int main(int argc, char ** argv) {
-    if(argc != 2) {
+int main(int argc, char **argv)
+{
+    if (argc != 2)
+    {
         printf("shpinfo shp_file\n");
         return EXIT_FAILURE;
     }
 
     SHPHandle hSHP = SHPOpen(argv[1], "rb");
-    if (hSHP == NULL) {
+    if (hSHP == NULL)
+    {
         printf("Unable to open:%s\n", argv[1]);
         return EXIT_FAILURE;
     }
@@ -49,8 +52,9 @@ int main(int argc, char ** argv) {
     SHPClose(hSHP);
 
     // TODO(schwehr): Make a function for all of shapelib.
-    const char *sType = NULL; // [15]= "";
-    switch (nShapeType) {
+    const char *sType = NULL;  // [15]= "";
+    switch (nShapeType)
+    {
         case SHPT_POINT:
             sType = "Point";
             break;
@@ -64,12 +68,12 @@ int main(int argc, char ** argv) {
             sType = "MultiPoint";
             break;
         default:
-          // TODO(schwehr): Handle all of the SHPT types.
-          sType = "UNKNOWN";
+            // TODO(schwehr): Handle all of the SHPT types.
+            sType = "UNKNOWN";
     }
 
-    printf ("Info for %s\n",argv[1]);
-    printf ("%s(%d), %d Records in file\n",sType,nShapeType,nEntities);
+    printf("Info for %s\n", argv[1]);
+    printf("%s(%d), %d Records in file\n", sType, nShapeType, nEntities);
 
     // Print out the file bounds.
     // TODO(schwehr): Do a better job at formatting the results.

--- a/contrib/shpsort.c
+++ b/contrib/shpsort.c
@@ -34,28 +34,36 @@
 #include <string.h>
 #include "shapefil.h"
 
-enum FieldOrderEnum {DESCENDING, ASCENDING};
-enum FieldTypeEnum {
-  FIDType = -2,
-  SHPType = -1,
-  StringType = FTString,
-  LogicalType = FTLogical,
-  IntegerType = FTInteger,
-  DoubleType = FTDouble
+enum FieldOrderEnum
+{
+    DESCENDING,
+    ASCENDING
+};
+enum FieldTypeEnum
+{
+    FIDType = -2,
+    SHPType = -1,
+    StringType = FTString,
+    LogicalType = FTLogical,
+    IntegerType = FTInteger,
+    DoubleType = FTDouble
 };
 
-struct DataUnion {
-  int null;
-  union {
-    int i;
-    double d;
-    char *s;
-  } u;
+struct DataUnion
+{
+    int null;
+    union
+    {
+        int i;
+        double d;
+        char *s;
+    } u;
 };
 
-struct DataStruct {
-  int record;
-  struct DataUnion *value;
+struct DataStruct
+{
+    int record;
+    struct DataUnion *value;
 };
 
 /*
@@ -74,473 +82,572 @@ int nShapes;
 // TODO(schwehr): Use strdup.
 static char *dupstr(const char *src)
 {
-  char *dst = malloc(strlen(src) + 1);
-  if (!dst) {
-    fprintf(stderr, "%s:%d: malloc failed!\n", __FILE__, __LINE__);
-    exit(EXIT_FAILURE);
-  }
-  char *cptr = dst;
-  while ((*cptr++ = *src++))
-    ;
-  return dst;
+    char *dst = malloc(strlen(src) + 1);
+    if (!dst)
+    {
+        fprintf(stderr, "%s:%d: malloc failed!\n", __FILE__, __LINE__);
+        exit(EXIT_FAILURE);
+    }
+    char *cptr = dst;
+    while ((*cptr++ = *src++))
+        ;
+    return dst;
 }
 
-static char ** split(const char *arg, const char *delim) {
-  char *copy = dupstr(arg);
-  char **result = NULL;
-  int i = 0;
-
-  for (char *cptr = strtok(copy, delim); cptr; cptr = strtok(NULL, delim)) {
-    char **tmp = realloc (result, sizeof *result * (i + 1));
-    if (!tmp && result) {
-      while (i > 0) {
-	free(result[--i]);
-      }
-      free(result);
-      free(copy);
-      return NULL;
-    }
-    result = tmp;
-    result[i++] = dupstr(cptr);
-  }
-
-  free(copy);
-
-  if (i) {
-    char **tmp = realloc(result, sizeof *result * (i + 1));
-    if (!tmp) {
-      while (i > 0) {
-	free(result[--i]);
-      }
-      free(result);
-      return NULL;
-    }
-    result = tmp;
-    result[i++] = NULL;
-  }
-
-  return result;
-}
-
-
-static void copy_related (const char *inName, const char *outName,
-			  const char *old_ext, const char *new_ext)
+static char **split(const char *arg, const char *delim)
 {
-  size_t name_len = strlen(inName);
-  const size_t old_len  = strlen(old_ext);
-  const size_t new_len  = strlen(new_ext);
+    char *copy = dupstr(arg);
+    char **result = NULL;
+    int i = 0;
 
-  char *in = malloc(name_len - old_len + new_len + 1);
-  strncpy(in, inName, (name_len - old_len));
-  strcpy(&in[(name_len - old_len)], new_ext);
-  FILE *inFile = fopen(in, "rb");
-  if (!inFile) {
-    free(in);
-    return;
-  }
-  name_len = strlen(outName);
-  char *out = malloc(name_len - old_len + new_len + 1);
-  if (!out) {
-    fprintf(stderr, "%s:%d: couldn't copy related file!\n",
-	    __FILE__, __LINE__);
+    for (char *cptr = strtok(copy, delim); cptr; cptr = strtok(NULL, delim))
+    {
+        char **tmp = realloc(result, sizeof *result * (i + 1));
+        if (!tmp && result)
+        {
+            while (i > 0)
+            {
+                free(result[--i]);
+            }
+            free(result);
+            free(copy);
+            return NULL;
+        }
+        result = tmp;
+        result[i++] = dupstr(cptr);
+    }
+
+    free(copy);
+
+    if (i)
+    {
+        char **tmp = realloc(result, sizeof *result * (i + 1));
+        if (!tmp)
+        {
+            while (i > 0)
+            {
+                free(result[--i]);
+            }
+            free(result);
+            return NULL;
+        }
+        result = tmp;
+        result[i++] = NULL;
+    }
+
+    return result;
+}
+
+static void copy_related(const char *inName, const char *outName,
+                         const char *old_ext, const char *new_ext)
+{
+    size_t name_len = strlen(inName);
+    const size_t old_len = strlen(old_ext);
+    const size_t new_len = strlen(new_ext);
+
+    char *in = malloc(name_len - old_len + new_len + 1);
+    strncpy(in, inName, (name_len - old_len));
+    strcpy(&in[(name_len - old_len)], new_ext);
+    FILE *inFile = fopen(in, "rb");
+    if (!inFile)
+    {
+        free(in);
+        return;
+    }
+    name_len = strlen(outName);
+    char *out = malloc(name_len - old_len + new_len + 1);
+    if (!out)
+    {
+        fprintf(stderr, "%s:%d: couldn't copy related file!\n", __FILE__,
+                __LINE__);
+        fclose(inFile);
+        free(in);
+        free(out);
+        return;
+    }
+    strncpy(out, outName, (name_len - old_len));
+    strcpy(&out[(name_len - old_len)], new_ext);
+
+    FILE *outFile = fopen(out, "wb");
+
+    int c;
+    while ((c = fgetc(inFile)) != EOF)
+    {
+        fputc(c, outFile);
+    }
     fclose(inFile);
+    fclose(outFile);
     free(in);
     free(out);
-    return;
-  }
-  strncpy(out, outName, (name_len - old_len));
-  strcpy(&out[(name_len - old_len)], new_ext);
-
-  FILE *outFile = fopen(out, "wb");
-
-  int c;
-  while ((c = fgetc(inFile)) != EOF) {
-    fputc(c, outFile);
-  }
-  fclose(inFile);
-  fclose(outFile);
-  free(in);
-  free(out);
 }
 
 #ifdef DEBUG
-static void PrintDataStruct (struct DataStruct *data) {
-  for (int i = 0; i < nShapes; i++) {
-    printf("data[%d] {\n", i);
-    printf("\t.record = %d\n", data[i].record);
-    for (int j = 0; j < nFields; j++) {
-      printf("\t.value[%d].null = %d\n", j, data[i].value[j].null);
-      if (!data[i].value[j].null) {
-	switch(fldType[j]) {
-	case FIDType:
-	case IntegerType:
-	case LogicalType:
-	  printf("\t.value[%d].u.i = %d\n", j, data[i].value[j].u.i);
-	  break;
-	case DoubleType:
-	case SHPType:
-	  printf("\t.value[%d].u.d = %f\n", j, data[i].value[j].u.d);
-	  break;
-	case StringType:
-	  printf("\t.value[%d].u.s = %s\n", j, data[i].value[j].u.s);
-	  break;
-	}
-      }
+static void PrintDataStruct(struct DataStruct *data)
+{
+    for (int i = 0; i < nShapes; i++)
+    {
+        printf("data[%d] {\n", i);
+        printf("\t.record = %d\n", data[i].record);
+        for (int j = 0; j < nFields; j++)
+        {
+            printf("\t.value[%d].null = %d\n", j, data[i].value[j].null);
+            if (!data[i].value[j].null)
+            {
+                switch (fldType[j])
+                {
+                    case FIDType:
+                    case IntegerType:
+                    case LogicalType:
+                        printf("\t.value[%d].u.i = %d\n", j,
+                               data[i].value[j].u.i);
+                        break;
+                    case DoubleType:
+                    case SHPType:
+                        printf("\t.value[%d].u.d = %f\n", j,
+                               data[i].value[j].u.d);
+                        break;
+                    case StringType:
+                        printf("\t.value[%d].u.s = %s\n", j,
+                               data[i].value[j].u.s);
+                        break;
+                }
+            }
+        }
+        puts("}");
     }
-    puts("}");
-  }
 }
 #endif
 
-static double length2d_polyline (int n, const double *x, const double *y) {
-  double length = 0.0;
-  for (int i = 1; i < n; i++) {
-    length += sqrt((x[i] - x[i-1])*(x[i] - x[i-1])
-		   +
-		   (y[i] - y[i-1])*(y[i] - y[i-1]));
-  }
-  return length;
+static double length2d_polyline(int n, const double *x, const double *y)
+{
+    double length = 0.0;
+    for (int i = 1; i < n; i++)
+    {
+        length += sqrt((x[i] - x[i - 1]) * (x[i] - x[i - 1]) +
+                       (y[i] - y[i - 1]) * (y[i] - y[i - 1]));
+    }
+    return length;
 }
 
-static double shp_length (SHPObject *feat) {
-  double length = 0.0;
-  if (feat->nParts == 0) {
-    length = length2d_polyline(feat->nVertices, feat->padfX, feat->padfY);
-  }
-  else {
-    for (int part = 0; part < feat->nParts; part++) {
-      int n;
-      if (part < feat->nParts - 1) {
-	n = feat->panPartStart[part+1] - feat->panPartStart[part];
-      }
-      else {
-	n = feat->nVertices - feat->panPartStart[part];
-      }
-      length += length2d_polyline (n,
-				   &(feat->padfX[feat->panPartStart[part]]),
-				   &(feat->padfY[feat->panPartStart[part]]));
+static double shp_length(SHPObject *feat)
+{
+    double length = 0.0;
+    if (feat->nParts == 0)
+    {
+        length = length2d_polyline(feat->nVertices, feat->padfX, feat->padfY);
     }
-  }
-  return length;
+    else
+    {
+        for (int part = 0; part < feat->nParts; part++)
+        {
+            int n;
+            if (part < feat->nParts - 1)
+            {
+                n = feat->panPartStart[part + 1] - feat->panPartStart[part];
+            }
+            else
+            {
+                n = feat->nVertices - feat->panPartStart[part];
+            }
+            length +=
+                length2d_polyline(n, &(feat->padfX[feat->panPartStart[part]]),
+                                  &(feat->padfY[feat->panPartStart[part]]));
+        }
+    }
+    return length;
 }
 
-static double area2d_polygon (int n, const double *x, const double *y) {
-  double area = 0;
-  for (int i = 1; i < n; i++) {
-    area += (x[i-1] + x[i]) * (y[i] - y[i-1]);
-  }
-  return area / 2.0;
+static double area2d_polygon(int n, const double *x, const double *y)
+{
+    double area = 0;
+    for (int i = 1; i < n; i++)
+    {
+        area += (x[i - 1] + x[i]) * (y[i] - y[i - 1]);
+    }
+    return area / 2.0;
 }
 
-static double shp_area (SHPObject *feat) {
-  double area = 0.0;
-  if (feat->nParts == 0) {
-    area = area2d_polygon (feat->nVertices, feat->padfX, feat->padfY);
-  }
-  else {
-    for (int part = 0; part < feat->nParts; part++) {
-      int n;
-      if (part < feat->nParts - 1) {
-	n = feat->panPartStart[part+1] - feat->panPartStart[part];
-      }
-      else {
-	n = feat->nVertices - feat->panPartStart[part];
-      }
-      area += area2d_polygon (n, &(feat->padfX[feat->panPartStart[part]]),
-			      &(feat->padfY[feat->panPartStart[part]]));
+static double shp_area(SHPObject *feat)
+{
+    double area = 0.0;
+    if (feat->nParts == 0)
+    {
+        area = area2d_polygon(feat->nVertices, feat->padfX, feat->padfY);
     }
-  }
-  /* our area function computes in opposite direction */
-  return -area;
+    else
+    {
+        for (int part = 0; part < feat->nParts; part++)
+        {
+            int n;
+            if (part < feat->nParts - 1)
+            {
+                n = feat->panPartStart[part + 1] - feat->panPartStart[part];
+            }
+            else
+            {
+                n = feat->nVertices - feat->panPartStart[part];
+            }
+            area += area2d_polygon(n, &(feat->padfX[feat->panPartStart[part]]),
+                                   &(feat->padfY[feat->panPartStart[part]]));
+        }
+    }
+    /* our area function computes in opposite direction */
+    return -area;
 }
 
-static int compare(const void *A, const void *B) {
-  const struct DataStruct *a = A;
-  const struct DataStruct *b = B;
+static int compare(const void *A, const void *B)
+{
+    const struct DataStruct *a = A;
+    const struct DataStruct *b = B;
 
-  for (int i = 0; i < nFields; i++) {
-    if (a->value[i].null && b->value[i].null) {
-      continue;
+    for (int i = 0; i < nFields; i++)
+    {
+        if (a->value[i].null && b->value[i].null)
+        {
+            continue;
+        }
+        if (a->value[i].null && !b->value[i].null)
+        {
+            return (fldOrder[i]) ? 1 : -1;
+        }
+        if (!a->value[i].null && b->value[i].null)
+        {
+            return (fldOrder[i]) ? -1 : 1;
+        }
+        switch (fldType[i])
+        {
+            case FIDType:
+            case IntegerType:
+            case LogicalType:
+                if (a->value[i].u.i < b->value[i].u.i)
+                {
+                    return (fldOrder[i]) ? -1 : 1;
+                }
+                if (a->value[i].u.i > b->value[i].u.i)
+                {
+                    return (fldOrder[i]) ? 1 : -1;
+                }
+                break;
+            case DoubleType:
+            case SHPType:
+                if (a->value[i].u.d < b->value[i].u.d)
+                {
+                    return (fldOrder[i]) ? -1 : 1;
+                }
+                if (a->value[i].u.d > b->value[i].u.d)
+                {
+                    return (fldOrder[i]) ? 1 : -1;
+                }
+                break;
+            case StringType:
+            {
+                const int result = strcmp(a->value[i].u.s, b->value[i].u.s);
+                if (result)
+                {
+                    return (fldOrder[i]) ? result : -result;
+                }
+                break;
+            }
+            default:
+                fprintf(stderr,
+                        "compare: Program Error! Unhandled field type! "
+                        "fldType[%d] = %d\n",
+                        i, fldType[i]);
+                break;
+        }
     }
-    if (a->value[i].null && !b->value[i].null) {
-      return (fldOrder[i]) ? 1 : -1;
-    }
-    if (!a->value[i].null && b->value[i].null) {
-      return (fldOrder[i]) ? -1 : 1;
-    }
-    switch (fldType[i]) {
-    case FIDType:
-    case IntegerType:
-    case LogicalType:
-      if (a->value[i].u.i < b->value[i].u.i) {
-	return (fldOrder[i]) ? -1 : 1;
-      }
-      if (a->value[i].u.i > b->value[i].u.i) {
-	return (fldOrder[i]) ? 1 : -1;
-      }
-      break;
-    case DoubleType:
-    case SHPType:
-      if (a->value[i].u.d < b->value[i].u.d) {
-	return (fldOrder[i]) ? -1 : 1;
-      }
-      if (a->value[i].u.d > b->value[i].u.d) {
-	return (fldOrder[i]) ? 1 : -1;
-      }
-      break;
-    case StringType:
-     {
-      const int result = strcmp(a->value[i].u.s, b->value[i].u.s);
-      if (result) {
-	return (fldOrder[i]) ? result : -result;
-      }
-      break;
-     }
-    default:
-      fprintf(stderr, "compare: Program Error! Unhandled field type! fldType[%d] = %d\n", i, fldType[i]);
-      break;
-    }
-  }
-  return 0;
+    return 0;
 }
 
-static struct DataStruct * build_index (SHPHandle shp, DBFHandle dbf) {
-  struct DataStruct *data = malloc (sizeof *data * nShapes);
-  if (!data) {
-    fputs("malloc failed!\n", stderr);
-    exit(EXIT_FAILURE);
-  }
+static struct DataStruct *build_index(SHPHandle shp, DBFHandle dbf)
+{
+    struct DataStruct *data = malloc(sizeof *data * nShapes);
+    if (!data)
+    {
+        fputs("malloc failed!\n", stderr);
+        exit(EXIT_FAILURE);
+    }
 
-  /* populate array */
-  for (int i = 0; i < nShapes; i++) {
-    data[i].value = malloc(sizeof data[0].value[0] * nFields);
-    if (0 == data[i].value) {
-      fputs("malloc failed!\n", stderr);
-      exit(EXIT_FAILURE);
+    /* populate array */
+    for (int i = 0; i < nShapes; i++)
+    {
+        data[i].value = malloc(sizeof data[0].value[0] * nFields);
+        if (0 == data[i].value)
+        {
+            fputs("malloc failed!\n", stderr);
+            exit(EXIT_FAILURE);
+        }
+        data[i].record = i;
+        for (int j = 0; j < nFields; j++)
+        {
+            data[i].value[j].null = 0;
+            switch (fldType[j])
+            {
+                case FIDType:
+                    data[i].value[j].u.i = i;
+                    break;
+                case SHPType:
+                {
+                    SHPObject *feat = SHPReadObject(shp, i);
+                    switch (feat->nSHPType)
+                    {
+                        case SHPT_NULL:
+                            fprintf(stderr, "Shape %d is a null feature!\n", i);
+                            data[i].value[j].null = 1;
+                            break;
+                        case SHPT_POINT:
+                        case SHPT_POINTZ:
+                        case SHPT_POINTM:
+                        case SHPT_MULTIPOINT:
+                        case SHPT_MULTIPOINTZ:
+                        case SHPT_MULTIPOINTM:
+                        case SHPT_MULTIPATCH:
+                            /* Y-sort bounds */
+                            data[i].value[j].u.d = feat->dfYMax;
+                            break;
+                        case SHPT_ARC:
+                        case SHPT_ARCZ:
+                        case SHPT_ARCM:
+                            data[i].value[j].u.d = shp_length(feat);
+                            break;
+                        case SHPT_POLYGON:
+                        case SHPT_POLYGONZ:
+                        case SHPT_POLYGONM:
+                            data[i].value[j].u.d = shp_area(feat);
+                            break;
+                        default:
+                            fputs("Can't sort on Shapefile feature type!\n",
+                                  stderr);
+                            exit(EXIT_FAILURE);
+                    }
+                    SHPDestroyObject(feat);
+                    break;
+                }
+                case FTString:
+                    data[i].value[j].null =
+                        DBFIsAttributeNULL(dbf, i, fldIdx[j]);
+                    if (!data[i].value[j].null)
+                    {
+                        data[i].value[j].u.s =
+                            dupstr(DBFReadStringAttribute(dbf, i, fldIdx[j]));
+                    }
+                    break;
+                case FTInteger:
+                case FTLogical:
+                    data[i].value[j].null =
+                        DBFIsAttributeNULL(dbf, i, fldIdx[j]);
+                    if (!data[i].value[j].null)
+                    {
+                        data[i].value[j].u.i =
+                            DBFReadIntegerAttribute(dbf, i, fldIdx[j]);
+                    }
+                    break;
+                case FTDouble:
+                    data[i].value[j].null =
+                        DBFIsAttributeNULL(dbf, i, fldIdx[j]);
+                    if (!data[i].value[j].null)
+                    {
+                        data[i].value[j].u.d =
+                            DBFReadDoubleAttribute(dbf, i, fldIdx[j]);
+                    }
+                    break;
+            }
+        }
     }
-    data[i].record = i;
-    for (int j = 0; j < nFields; j++) {
-      data[i].value[j].null = 0;
-      switch (fldType[j]) {
-      case FIDType:
-	data[i].value[j].u.i = i;
-	break;
-      case SHPType:
-       {
-        SHPObject *feat = SHPReadObject(shp, i);
-	switch (feat->nSHPType) {
-	case SHPT_NULL:
-	  fprintf(stderr, "Shape %d is a null feature!\n", i);
-	  data[i].value[j].null = 1;
-	  break;
-	case SHPT_POINT:
-	case SHPT_POINTZ:
-	case SHPT_POINTM:
-	case SHPT_MULTIPOINT:
-	case SHPT_MULTIPOINTZ:
-	case SHPT_MULTIPOINTM:
-	case SHPT_MULTIPATCH:
-	  /* Y-sort bounds */
-	  data[i].value[j].u.d = feat->dfYMax;
-	  break;
-	case SHPT_ARC:
-	case SHPT_ARCZ:
-	case SHPT_ARCM:
-	  data[i].value[j].u.d = shp_length(feat);
-	  break;
-	case SHPT_POLYGON:
-	case SHPT_POLYGONZ:
-	case SHPT_POLYGONM:
-	  data[i].value[j].u.d = shp_area(feat);
-	  break;
-	default:
-	  fputs("Can't sort on Shapefile feature type!\n", stderr);
-	  exit(EXIT_FAILURE);
-	}
-	SHPDestroyObject(feat);
-	break;
-       }
-      case FTString:
-	data[i].value[j].null = DBFIsAttributeNULL(dbf, i, fldIdx[j]);
-	if (!data[i].value[j].null) {
-	  data[i].value[j].u.s = dupstr(DBFReadStringAttribute(dbf, i, fldIdx[j]));
-	}
-	break;
-      case FTInteger:
-      case FTLogical:
-	data[i].value[j].null = DBFIsAttributeNULL(dbf, i, fldIdx[j]);
-	if (!data[i].value[j].null) {
-	  data[i].value[j].u.i  = DBFReadIntegerAttribute(dbf, i, fldIdx[j]);
-	}
-	break;
-      case FTDouble:
-	data[i].value[j].null = DBFIsAttributeNULL(dbf, i, fldIdx[j]);
-	if (!data[i].value[j].null) {
-	  data[i].value[j].u.d = DBFReadDoubleAttribute(dbf, i, fldIdx[j]);
-	}
-	break;
-      }
-    }
-  }
 
 #ifdef DEBUG
-  PrintDataStruct(data);
-  fputs("build_index: sorting array\n", stdout);
+    PrintDataStruct(data);
+    fputs("build_index: sorting array\n", stdout);
 #endif
 
-  qsort (data, nShapes, sizeof data[0], compare);
+    qsort(data, nShapes, sizeof data[0], compare);
 
 #ifdef DEBUG
-  PrintDataStruct(data);
-  fputs("build_index: returning array\n", stdout);
+    PrintDataStruct(data);
+    fputs("build_index: returning array\n", stdout);
 #endif
 
-  return data;
+    return data;
 }
 
-int main (int argc, char *argv[]) {
-  if (argc < 4) {
-    printf("USAGE: shpsort <infile> <outfile> <field[;...]> [<(ASCENDING|DESCENDING)[;...]>]\n");
-    exit(EXIT_FAILURE);
-  }
-
-  SHPHandle inSHP = SHPOpen (argv[1], "rb");
-  if (!inSHP) {
-    fputs("Couldn't open shapefile for reading!\n", stderr);
-    exit(EXIT_FAILURE);
-  }
-  SHPGetInfo(inSHP, &nShapes, &shpType, NULL, NULL);
-
-  /* If we can open the inSHP, open its DBF */
-  DBFHandle inDBF = DBFOpen (argv[1], "rb");
-  if (!inDBF) {
-    fputs("Couldn't open dbf file for reading!\n", stderr);
-    exit(EXIT_FAILURE);
-  }
-
-  /* Parse fields and validate existence */
-  char **fieldNames = split(argv[3], ";");
-  if (!fieldNames) {
-    fputs("ERROR: parsing field names!\n", stderr);
-    exit(EXIT_FAILURE);
-  }
-  for (nFields = 0; fieldNames[nFields] ; nFields++) {
-    continue;
-  }
-
-  fldIdx = malloc(sizeof *fldIdx * nFields);
-  if (!fldIdx) {
-    fputs("malloc failed!\n", stderr);
-    exit(EXIT_FAILURE);
-  }
-  for (int i = 0; i < nFields; i++) {
-    int len = (int)strlen(fieldNames[i]);
-    while(len > 0) {
-      --len;
-      fieldNames[i][len] = (char)toupper((unsigned char)fieldNames[i][len]);
+int main(int argc, char *argv[])
+{
+    if (argc < 4)
+    {
+        printf("USAGE: shpsort <infile> <outfile> <field[;...]> "
+               "[<(ASCENDING|DESCENDING)[;...]>]\n");
+        exit(EXIT_FAILURE);
     }
-    fldIdx[i] = DBFGetFieldIndex(inDBF, fieldNames[i]);
-    if (fldIdx[i] < 0) {
-      /* try "SHAPE" */
-      if (strcmp(fieldNames[i], "SHAPE") == 0) {
-	fldIdx[i] = -1;
-      }
-      else if (strcmp(fieldNames[i], "FID") == 0) {
-	fldIdx[i] = -2;
-      }
-      else {
-	fprintf(stderr, "ERROR: field '%s' not found!\n", fieldNames[i]);
-	exit(EXIT_FAILURE);
-      }
+
+    SHPHandle inSHP = SHPOpen(argv[1], "rb");
+    if (!inSHP)
+    {
+        fputs("Couldn't open shapefile for reading!\n", stderr);
+        exit(EXIT_FAILURE);
     }
-  }
+    SHPGetInfo(inSHP, &nShapes, &shpType, NULL, NULL);
 
-  /* set up field type array */
-  fldType = malloc(sizeof *fldType * nFields);
-  if (!fldType) {
-    fputs("malloc failed!\n", stderr);
-    exit(EXIT_FAILURE);
-  }
-  int width;
-  int decimals;
-  for (int i = 0; i < nFields; i++) {
-    if (fldIdx[i] < 0) {
-      fldType[i] = fldIdx[i];
+    /* If we can open the inSHP, open its DBF */
+    DBFHandle inDBF = DBFOpen(argv[1], "rb");
+    if (!inDBF)
+    {
+        fputs("Couldn't open dbf file for reading!\n", stderr);
+        exit(EXIT_FAILURE);
     }
-    else {
-      fldType[i] = DBFGetFieldInfo(inDBF, fldIdx[i], NULL, &width, &decimals);
-      if (fldType[i] == FTInvalid) {
-	fputs("Unrecognized field type in dBASE file!\n", stderr);
-	exit(EXIT_FAILURE);
-      }
+
+    /* Parse fields and validate existence */
+    char **fieldNames = split(argv[3], ";");
+    if (!fieldNames)
+    {
+        fputs("ERROR: parsing field names!\n", stderr);
+        exit(EXIT_FAILURE);
     }
-  }
-
-  /* set up field order array */
-  fldOrder = malloc(sizeof *fldOrder * nFields);
-  if (!fldOrder) {
-    fputs("malloc failed!\n", stderr);
-    exit(EXIT_FAILURE);
-  }
-  for (int i = 0; i < nFields; i++) {
-    /* default to ascending order */
-    fldOrder[i] = ASCENDING;
-  }
-  if (argc > 4) {
-    char **strOrder = split(argv[4], ";");
-    if (!strOrder) {
-      fputs("ERROR: parsing fields ordering!\n", stderr);
-      exit(EXIT_FAILURE);
+    for (nFields = 0; fieldNames[nFields]; nFields++)
+    {
+        continue;
     }
-    for (int i = 0; i < nFields && strOrder[i]; i++) {
-      if (strcmp(strOrder[i], "DESCENDING") == 0) {
-	fldOrder[i] = DESCENDING;
-      }
+
+    fldIdx = malloc(sizeof *fldIdx * nFields);
+    if (!fldIdx)
+    {
+        fputs("malloc failed!\n", stderr);
+        exit(EXIT_FAILURE);
     }
-  }
-
-  /* build the index */
-  struct DataStruct *index = build_index (inSHP, inDBF);
-
-  /* Create output shapefile */
-  SHPHandle outSHP = SHPCreate(argv[2], shpType);
-  if (!outSHP) {
-    fprintf(stderr, "%s:%d: couldn't create output shapefile!\n",
-	    __FILE__, __LINE__);
-    exit(EXIT_FAILURE);
-  }
-
-  /* Create output dbf */
-  DBFHandle outDBF = DBFCloneEmpty(inDBF, argv[2]);
-  if (!outDBF) {
-    fprintf(stderr, "%s:%d: couldn't create output dBASE file!\n",
-	    __FILE__, __LINE__);
-    exit(EXIT_FAILURE);
-  }
-
-  /* Copy projection file, if any */
-  copy_related(argv[1], argv[2], ".shp", ".prj");
-
-  /* Copy metadata file, if any */
-  copy_related(argv[1], argv[2], ".shp", ".shp.xml");
-
-  /* Write out sorted results */
-  for (int i = 0; i < nShapes; i++) {
-    SHPObject *feat = SHPReadObject(inSHP, index[i].record);
-    if (SHPWriteObject(outSHP, -1, feat) < 0) {
-      fprintf(stderr, "%s:%d: error writing shapefile!\n", __FILE__, __LINE__);
-      exit(EXIT_FAILURE);
+    for (int i = 0; i < nFields; i++)
+    {
+        int len = (int)strlen(fieldNames[i]);
+        while (len > 0)
+        {
+            --len;
+            fieldNames[i][len] =
+                (char)toupper((unsigned char)fieldNames[i][len]);
+        }
+        fldIdx[i] = DBFGetFieldIndex(inDBF, fieldNames[i]);
+        if (fldIdx[i] < 0)
+        {
+            /* try "SHAPE" */
+            if (strcmp(fieldNames[i], "SHAPE") == 0)
+            {
+                fldIdx[i] = -1;
+            }
+            else if (strcmp(fieldNames[i], "FID") == 0)
+            {
+                fldIdx[i] = -2;
+            }
+            else
+            {
+                fprintf(stderr, "ERROR: field '%s' not found!\n",
+                        fieldNames[i]);
+                exit(EXIT_FAILURE);
+            }
+        }
     }
-    void *tuple = (void *) DBFReadTuple(inDBF, index[i].record);
-    if (DBFWriteTuple(outDBF, i, tuple) < 0) {
-      fprintf(stderr, "%s:%d: error writing dBASE file!\n", __FILE__, __LINE__);
-      exit(EXIT_FAILURE);
-    }
-  }
-  SHPClose(inSHP);
-  SHPClose(outSHP);
-  DBFClose(inDBF);
-  DBFClose(outDBF);
 
-  return EXIT_SUCCESS;
+    /* set up field type array */
+    fldType = malloc(sizeof *fldType * nFields);
+    if (!fldType)
+    {
+        fputs("malloc failed!\n", stderr);
+        exit(EXIT_FAILURE);
+    }
+    int width;
+    int decimals;
+    for (int i = 0; i < nFields; i++)
+    {
+        if (fldIdx[i] < 0)
+        {
+            fldType[i] = fldIdx[i];
+        }
+        else
+        {
+            fldType[i] =
+                DBFGetFieldInfo(inDBF, fldIdx[i], NULL, &width, &decimals);
+            if (fldType[i] == FTInvalid)
+            {
+                fputs("Unrecognized field type in dBASE file!\n", stderr);
+                exit(EXIT_FAILURE);
+            }
+        }
+    }
+
+    /* set up field order array */
+    fldOrder = malloc(sizeof *fldOrder * nFields);
+    if (!fldOrder)
+    {
+        fputs("malloc failed!\n", stderr);
+        exit(EXIT_FAILURE);
+    }
+    for (int i = 0; i < nFields; i++)
+    {
+        /* default to ascending order */
+        fldOrder[i] = ASCENDING;
+    }
+    if (argc > 4)
+    {
+        char **strOrder = split(argv[4], ";");
+        if (!strOrder)
+        {
+            fputs("ERROR: parsing fields ordering!\n", stderr);
+            exit(EXIT_FAILURE);
+        }
+        for (int i = 0; i < nFields && strOrder[i]; i++)
+        {
+            if (strcmp(strOrder[i], "DESCENDING") == 0)
+            {
+                fldOrder[i] = DESCENDING;
+            }
+        }
+    }
+
+    /* build the index */
+    struct DataStruct *index = build_index(inSHP, inDBF);
+
+    /* Create output shapefile */
+    SHPHandle outSHP = SHPCreate(argv[2], shpType);
+    if (!outSHP)
+    {
+        fprintf(stderr, "%s:%d: couldn't create output shapefile!\n", __FILE__,
+                __LINE__);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Create output dbf */
+    DBFHandle outDBF = DBFCloneEmpty(inDBF, argv[2]);
+    if (!outDBF)
+    {
+        fprintf(stderr, "%s:%d: couldn't create output dBASE file!\n", __FILE__,
+                __LINE__);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Copy projection file, if any */
+    copy_related(argv[1], argv[2], ".shp", ".prj");
+
+    /* Copy metadata file, if any */
+    copy_related(argv[1], argv[2], ".shp", ".shp.xml");
+
+    /* Write out sorted results */
+    for (int i = 0; i < nShapes; i++)
+    {
+        SHPObject *feat = SHPReadObject(inSHP, index[i].record);
+        if (SHPWriteObject(outSHP, -1, feat) < 0)
+        {
+            fprintf(stderr, "%s:%d: error writing shapefile!\n", __FILE__,
+                    __LINE__);
+            exit(EXIT_FAILURE);
+        }
+        void *tuple = (void *)DBFReadTuple(inDBF, index[i].record);
+        if (DBFWriteTuple(outDBF, i, tuple) < 0)
+        {
+            fprintf(stderr, "%s:%d: error writing dBASE file!\n", __FILE__,
+                    __LINE__);
+            exit(EXIT_FAILURE);
+        }
+    }
+    SHPClose(inSHP);
+    SHPClose(outSHP);
+    DBFClose(inDBF);
+    DBFClose(outDBF);
+
+    return EXIT_SUCCESS;
 }

--- a/contrib/shpwkb.c
+++ b/contrib/shpwkb.c
@@ -30,33 +30,38 @@
 #include "shapefil.h"
 #include "shpgeo.h"
 
-int main(int argc, char ** argv ) {
-    if(argc < 3) {
-        printf( "shpwkb shp_file wkb_file\n" );
+int main(int argc, char **argv)
+{
+    if (argc < 3)
+    {
+        printf("shpwkb shp_file wkb_file\n");
         return EXIT_FAILURE;
     }
 
-    DBFHandle old_DBF = DBFOpen (argv[1], "rb");
-    if(old_DBF == NULL) {
+    DBFHandle old_DBF = DBFOpen(argv[1], "rb");
+    if (old_DBF == NULL)
+    {
         printf("Unable to open old dbf: %s\n", argv[1]);
         return EXIT_FAILURE;
     }
-    SHPHandle old_SHP = SHPOpen (argv[1], "rb");
-    if(old_SHP == NULL) {
+    SHPHandle old_SHP = SHPOpen(argv[1], "rb");
+    if (old_SHP == NULL)
+    {
         printf("Unable to open old shp: %s\n", argv[1]);
         DBFClose(old_DBF);
         return EXIT_FAILURE;
     }
 
     FILE *wkb_file = fopen(argv[2], "wb");
-    if(wkb_file == NULL) {
+    if (wkb_file == NULL)
+    {
         printf("Unable to open wkb_file: %s\n", argv[2]);
         DBFClose(old_DBF);
         SHPClose(old_SHP);
         return EXIT_FAILURE;
     }
 
-    WKBStreamObj *wkbObj = calloc(3, sizeof (int));
+    WKBStreamObj *wkbObj = calloc(3, sizeof(int));
 
     int nEntities;
     int nShapeType;
@@ -64,33 +69,40 @@ int main(int argc, char ** argv ) {
 
     int byRing = 0;
 
-    for( int i = 0; i < nEntities; i++) {
-        SHPObject *psCShape = SHPReadObject( old_SHP, i );
+    for (int i = 0; i < nEntities; i++)
+    {
+        SHPObject *psCShape = SHPReadObject(old_SHP, i);
 
-        if ( byRing == 1 ) {
-          // const int prevStart = psCShape->nVertices;
-          for ( int ring = (psCShape->nParts - 1); ring >= 0; ring-- ) {
-            const int rStart = psCShape->panPartStart[ring];
-	    int numVtx;
-            if (ring == psCShape->nParts - 1) {
-                numVtx = psCShape->nVertices - rStart;
-            } else {
-                numVtx = psCShape->panPartStart[ring+1] - rStart;
-            }
+        if (byRing == 1)
+        {
+            // const int prevStart = psCShape->nVertices;
+            for (int ring = (psCShape->nParts - 1); ring >= 0; ring--)
+            {
+                const int rStart = psCShape->panPartStart[ring];
+                int numVtx;
+                if (ring == psCShape->nParts - 1)
+                {
+                    numVtx = psCShape->nVertices - rStart;
+                }
+                else
+                {
+                    numVtx = psCShape->panPartStart[ring + 1] - rStart;
+                }
 
-            printf("(shpdata) Ring(%d) (%d for %d)\n", ring, rStart, numVtx);
-	    SHPObject *psO = SHPClone(psCShape, ring,  ring + 1);
+                printf("(shpdata) Ring(%d) (%d for %d)\n", ring, rStart,
+                       numVtx);
+                SHPObject *psO = SHPClone(psCShape, ring, ring + 1);
 
-	    SHPDestroyObject (psO);
-            printf ("(shpdata) End Ring\n");
-           }  // (ring) [0,nParts
-        }  // by ring
+                SHPDestroyObject(psO);
+                printf("(shpdata) End Ring\n");
+            }  // (ring) [0,nParts
+        }      // by ring
 
-        printf ("gonna build a wkb\n");
+        printf("gonna build a wkb\n");
         // const int res =
         SHPWriteOGisWKB(wkbObj, psCShape);
-        printf("gonna write a wkb that is %d bytes long\n", wkbObj->StreamPos );
-        fwrite((void*)wkbObj->wStream, 1, wkbObj->StreamPos, wkb_file);
+        printf("gonna write a wkb that is %d bytes long\n", wkbObj->StreamPos);
+        fwrite((void *)wkbObj->wStream, 1, wkbObj->StreamPos, wkb_file);
 
         SHPDestroyObject(psCShape);
     }
@@ -100,7 +112,7 @@ int main(int argc, char ** argv ) {
     DBFClose(old_DBF);
     fclose(wkb_file);
 
-    printf ("\n");
+    printf("\n");
 
     return EXIT_SUCCESS;
 }

--- a/dbfadd.c
+++ b/dbfadd.c
@@ -42,22 +42,26 @@
 
 SHP_CVSID("$Id$")
 
-int main(int argc, char ** argv) {
-    if (argc < 3) {
+int main(int argc, char **argv)
+{
+    if (argc < 3)
+    {
         printf("dbfadd xbase_file field_values\n");
         return EXIT_FAILURE;
     }
 
     DBFHandle hDBF = DBFOpen(argv[1], "r+b");
-    if (hDBF == NULL) {
+    if (hDBF == NULL)
+    {
         printf("DBFOpen(%s,\"rb+\") failed.\n", argv[1]);
         return 2;
     }
 
     // Do we have the correct number of arguments?
-    if (DBFGetFieldCount(hDBF) != argc - 2) {
-        printf("Got %d fields, but require %d\n",
-               argc - 2, DBFGetFieldCount(hDBF));
+    if (DBFGetFieldCount(hDBF) != argc - 2)
+    {
+        printf("Got %d fields, but require %d\n", argc - 2,
+               DBFGetFieldCount(hDBF));
         DBFClose(hDBF);
         return 3;
     }
@@ -65,16 +69,17 @@ int main(int argc, char ** argv) {
     const int iRecord = DBFGetRecordCount(hDBF);
 
     // Loop assigning the new field values.
-    for (int i = 0; i < DBFGetFieldCount(hDBF); i++) {
-        if (strcmp( argv[i+2], "" ) == 0)
+    for (int i = 0; i < DBFGetFieldCount(hDBF); i++)
+    {
+        if (strcmp(argv[i + 2], "") == 0)
             DBFWriteNULLAttribute(hDBF, iRecord, i);
-        else if (DBFGetFieldInfo( hDBF, i, NULL, NULL, NULL ) == FTString)
-            DBFWriteStringAttribute(hDBF, iRecord, i, argv[i+2]);
+        else if (DBFGetFieldInfo(hDBF, i, NULL, NULL, NULL) == FTString)
+            DBFWriteStringAttribute(hDBF, iRecord, i, argv[i + 2]);
         else
-            DBFWriteDoubleAttribute(hDBF, iRecord, i, atof(argv[i+2]));
+            DBFWriteDoubleAttribute(hDBF, iRecord, i, atof(argv[i + 2]));
     }
 
     DBFClose(hDBF);
 
-    return 0 ;
+    return 0;
 }

--- a/dbfcreate.c
+++ b/dbfcreate.c
@@ -41,44 +41,56 @@
 
 SHP_CVSID("$Id$")
 
-int main(int argc, char ** argv) {
+int main(int argc, char **argv)
+{
     // Display a usage message.
-    if( argc < 2 ) {
+    if (argc < 2)
+    {
         printf("dbfcreate xbase_file [[-s field_name width], "
                "[-n field_name width decimals]]...\n");
         return 1;
     }
 
     // Create the database.
-    DBFHandle hDBF = DBFCreate( argv[1] );
-    if( hDBF == NULL ) {
+    DBFHandle hDBF = DBFCreate(argv[1]);
+    if (hDBF == NULL)
+    {
         printf("DBFCreate(%s) failed.\n", argv[1]);
         return 2;
     }
 
     // Loop over the field definitions adding new fields.
-    for( int i = 2; i < argc; i++ ) {
-        if(i < argc - 2 && strcmp(argv[i], "-s") == 0) {
-            const char *field = argv[i+1];
-            const int width = atoi(argv[i+2]);
+    for (int i = 2; i < argc; i++)
+    {
+        if (i < argc - 2 && strcmp(argv[i], "-s") == 0)
+        {
+            const char *field = argv[i + 1];
+            const int width = atoi(argv[i + 2]);
             const int decimals = 0;
-            if(DBFAddField(hDBF, field, FTString, width, decimals) == -1) {
+            if (DBFAddField(hDBF, field, FTString, width, decimals) == -1)
+            {
                 printf("DBFAddField(%s,FTString,%d,0) failed.\n", field, width);
                 DBFClose(hDBF);
                 return 4;
             }
             i += 2;
-        } else if(i < argc - 3 && strcmp(argv[i], "-n") == 0) {
-            const char *field = argv[i+1];
-            const int width = atoi(argv[i+2]);
-            const int decimals = atoi(argv[i+3]);
-            if(DBFAddField(hDBF, field, FTDouble, width, decimals) == -1) {
-                printf("DBFAddField(%s,FTDouble,%d,%d) failed.\n", field, width, decimals);
+        }
+        else if (i < argc - 3 && strcmp(argv[i], "-n") == 0)
+        {
+            const char *field = argv[i + 1];
+            const int width = atoi(argv[i + 2]);
+            const int decimals = atoi(argv[i + 3]);
+            if (DBFAddField(hDBF, field, FTDouble, width, decimals) == -1)
+            {
+                printf("DBFAddField(%s,FTDouble,%d,%d) failed.\n", field, width,
+                       decimals);
                 DBFClose(hDBF);
                 return 4;
             }
             i += 3;
-        } else {
+        }
+        else
+        {
             printf("Argument incomplete, or unrecognised: %s\n", argv[i]);
             DBFClose(hDBF);
             return 3;

--- a/dbfdump.c
+++ b/dbfdump.c
@@ -42,205 +42,212 @@
 
 SHP_CVSID("$Id$")
 
-int main( int argc, char ** argv ) {
-/* -------------------------------------------------------------------- */
-/*      Handle arguments.                                               */
-/* -------------------------------------------------------------------- */
+int main(int argc, char **argv)
+{
+    /* -------------------------------------------------------------------- */
+    /*      Handle arguments.                                               */
+    /* -------------------------------------------------------------------- */
     bool bHeader = false;
     bool bRaw = false;
     bool bMultiLine = false;
     char *pszFilename = NULL;
 
-    for( int i = 1; i < argc; i++ )
+    for (int i = 1; i < argc; i++)
     {
-        if( strcmp(argv[i],"-h") == 0 )
+        if (strcmp(argv[i], "-h") == 0)
             bHeader = true;
-        else if( strcmp(argv[i],"-r") == 0 )
+        else if (strcmp(argv[i], "-r") == 0)
             bRaw = true;
-        else if( strcmp(argv[i],"-m") == 0 )
+        else if (strcmp(argv[i], "-m") == 0)
             bMultiLine = true;
         else
             pszFilename = argv[i];
     }
 
-/* -------------------------------------------------------------------- */
-/*      Display a usage message.                                        */
-/* -------------------------------------------------------------------- */
-    if( pszFilename == NULL )
+    /* -------------------------------------------------------------------- */
+    /*      Display a usage message.                                        */
+    /* -------------------------------------------------------------------- */
+    if (pszFilename == NULL)
     {
-	printf( "dbfdump [-h] [-r] [-m] xbase_file\n" );
-        printf( "        -h: Write header info (field descriptions)\n" );
-        printf( "        -r: Write raw field info, numeric values not reformatted\n" );
-        printf( "        -m: Multiline, one line per field.\n" );
-	exit( 1 );
+        printf("dbfdump [-h] [-r] [-m] xbase_file\n");
+        printf("        -h: Write header info (field descriptions)\n");
+        printf("        -r: Write raw field info, numeric values not "
+               "reformatted\n");
+        printf("        -m: Multiline, one line per field.\n");
+        exit(1);
     }
 
-/* -------------------------------------------------------------------- */
-/*      Open the file.                                                  */
-/* -------------------------------------------------------------------- */
-    DBFHandle hDBF = DBFOpen( pszFilename, "rb" );
-    if( hDBF == NULL )
+    /* -------------------------------------------------------------------- */
+    /*      Open the file.                                                  */
+    /* -------------------------------------------------------------------- */
+    DBFHandle hDBF = DBFOpen(pszFilename, "rb");
+    if (hDBF == NULL)
     {
-	printf( "DBFOpen(%s,\"r\") failed.\n", argv[1] );
-	exit( 2 );
+        printf("DBFOpen(%s,\"r\") failed.\n", argv[1]);
+        exit(2);
     }
 
-/* -------------------------------------------------------------------- */
-/*	If there is no data in this file let the user know.		*/
-/* -------------------------------------------------------------------- */
-    if( DBFGetFieldCount(hDBF) == 0 )
+    /* -------------------------------------------------------------------- */
+    /*	If there is no data in this file let the user know.		*/
+    /* -------------------------------------------------------------------- */
+    if (DBFGetFieldCount(hDBF) == 0)
     {
-	printf( "There are no fields in this table!\n" );
+        printf("There are no fields in this table!\n");
         DBFClose(hDBF);
-	exit( 3 );
+        exit(3);
     }
 
-/* -------------------------------------------------------------------- */
-/*	Dump header definitions.					*/
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*	Dump header definitions.					*/
+    /* -------------------------------------------------------------------- */
     char szTitle[12];
     int nWidth;
     int nDecimals;
 
-    if( bHeader )
+    if (bHeader)
     {
-        for( int i = 0; i < DBFGetFieldCount(hDBF); i++ )
+        for (int i = 0; i < DBFGetFieldCount(hDBF); i++)
         {
-            const char chNativeType = DBFGetNativeFieldType( hDBF, i );
-            const DBFFieldType eType = DBFGetFieldInfo( hDBF, i, szTitle, &nWidth, &nDecimals );
+            const char chNativeType = DBFGetNativeFieldType(hDBF, i);
+            const DBFFieldType eType =
+                DBFGetFieldInfo(hDBF, i, szTitle, &nWidth, &nDecimals);
 
             const char *pszTypeName = NULL;
-            if( eType == FTString )
+            if (eType == FTString)
                 pszTypeName = "String";
-            else if( eType == FTInteger )
+            else if (eType == FTInteger)
                 pszTypeName = "Integer";
-            else if( eType == FTDouble )
+            else if (eType == FTDouble)
                 pszTypeName = "Double";
-            else if( eType == FTInvalid )
+            else if (eType == FTInvalid)
                 pszTypeName = "Invalid";
             // TODO(schwehr): else?
 
-            printf( "Field %d: Type=%c/%s, Title=`%s', Width=%d, Decimals=%d\n",
-                    i, chNativeType, pszTypeName, szTitle, nWidth, nDecimals );
+            printf("Field %d: Type=%c/%s, Title=`%s', Width=%d, Decimals=%d\n",
+                   i, chNativeType, pszTypeName, szTitle, nWidth, nDecimals);
         }
     }
 
-/* -------------------------------------------------------------------- */
-/*	Compute offsets to use when printing each of the field 		*/
-/*	values. We make each field as wide as the field title+1, or 	*/
-/*	the field value + 1. 						*/
-/* -------------------------------------------------------------------- */
-    int *panWidth = (int *) malloc( DBFGetFieldCount( hDBF ) * sizeof(int) );
+    /* -------------------------------------------------------------------- */
+    /*	Compute offsets to use when printing each of the field 		*/
+    /*	values. We make each field as wide as the field title+1, or 	*/
+    /*	the field value + 1. 						*/
+    /* -------------------------------------------------------------------- */
+    int *panWidth = (int *)malloc(DBFGetFieldCount(hDBF) * sizeof(int));
     char szFormat[32];
 
-    for( int i = 0; i < DBFGetFieldCount(hDBF) && !bMultiLine; i++ )
+    for (int i = 0; i < DBFGetFieldCount(hDBF) && !bMultiLine; i++)
     {
-	const DBFFieldType eType = DBFGetFieldInfo( hDBF, i, szTitle, &nWidth, &nDecimals );
-	if( (int) strlen(szTitle) > nWidth )
-	    panWidth[i] = strlen(szTitle);
-	else
-	    panWidth[i] = nWidth;
+        const DBFFieldType eType =
+            DBFGetFieldInfo(hDBF, i, szTitle, &nWidth, &nDecimals);
+        if ((int)strlen(szTitle) > nWidth)
+            panWidth[i] = strlen(szTitle);
+        else
+            panWidth[i] = nWidth;
 
-	if( eType == FTString )
-	    sprintf( szFormat, "%%-%ds ", panWidth[i] );
-	else
-	    sprintf( szFormat, "%%%ds ", panWidth[i] );
-	printf( szFormat, szTitle );
+        if (eType == FTString)
+            sprintf(szFormat, "%%-%ds ", panWidth[i]);
+        else
+            sprintf(szFormat, "%%%ds ", panWidth[i]);
+        printf(szFormat, szTitle);
     }
-    printf( "\n" );
+    printf("\n");
 
-/* -------------------------------------------------------------------- */
-/*	Read all the records 						*/
-/* -------------------------------------------------------------------- */
-    for( int iRecord = 0; iRecord < DBFGetRecordCount(hDBF); iRecord++ )
+    /* -------------------------------------------------------------------- */
+    /*	Read all the records 						*/
+    /* -------------------------------------------------------------------- */
+    for (int iRecord = 0; iRecord < DBFGetRecordCount(hDBF); iRecord++)
     {
-        if( bMultiLine )
-            printf( "Record: %d\n", iRecord );
+        if (bMultiLine)
+            printf("Record: %d\n", iRecord);
 
-	for( int i = 0; i < DBFGetFieldCount(hDBF); i++ )
-	{
-            const DBFFieldType eType = DBFGetFieldInfo( hDBF, i, szTitle, &nWidth, &nDecimals );
+        for (int i = 0; i < DBFGetFieldCount(hDBF); i++)
+        {
+            const DBFFieldType eType =
+                DBFGetFieldInfo(hDBF, i, szTitle, &nWidth, &nDecimals);
 
-            if( bMultiLine )
+            if (bMultiLine)
             {
-                printf( "%s: ", szTitle );
+                printf("%s: ", szTitle);
             }
 
-/* -------------------------------------------------------------------- */
-/*      Print the record according to the type and formatting           */
-/*      information implicit in the DBF field description.              */
-/* -------------------------------------------------------------------- */
-            if( !bRaw )
+            /* -------------------------------------------------------------------- */
+            /*      Print the record according to the type and formatting           */
+            /*      information implicit in the DBF field description.              */
+            /* -------------------------------------------------------------------- */
+            if (!bRaw)
             {
-                if( DBFIsAttributeNULL( hDBF, iRecord, i ) )
+                if (DBFIsAttributeNULL(hDBF, iRecord, i))
                 {
-                    if( eType == FTString )
-                        sprintf( szFormat, "%%-%ds", nWidth );
+                    if (eType == FTString)
+                        sprintf(szFormat, "%%-%ds", nWidth);
                     else
-                        sprintf( szFormat, "%%%ds", nWidth );
+                        sprintf(szFormat, "%%%ds", nWidth);
 
-                    printf( szFormat, "(NULL)" );
+                    printf(szFormat, "(NULL)");
                 }
                 else
                 {
-                    switch( eType )
+                    switch (eType)
                     {
-                      case FTString:
-                        sprintf( szFormat, "%%-%ds", nWidth );
-                        printf( szFormat,
-                                DBFReadStringAttribute( hDBF, iRecord, i ) );
-                        break;
+                        case FTString:
+                            sprintf(szFormat, "%%-%ds", nWidth);
+                            printf(szFormat,
+                                   DBFReadStringAttribute(hDBF, iRecord, i));
+                            break;
 
-                      case FTInteger:
-                        sprintf( szFormat, "%%%dd", nWidth );
-                        printf( szFormat,
-                                DBFReadIntegerAttribute( hDBF, iRecord, i ) );
-                        break;
+                        case FTInteger:
+                            sprintf(szFormat, "%%%dd", nWidth);
+                            printf(szFormat,
+                                   DBFReadIntegerAttribute(hDBF, iRecord, i));
+                            break;
 
-                      case FTDouble:
-                        sprintf( szFormat, "%%%d.%dlf", nWidth, nDecimals );
-                        printf( szFormat,
-                                DBFReadDoubleAttribute( hDBF, iRecord, i ) );
-                        break;
+                        case FTDouble:
+                            sprintf(szFormat, "%%%d.%dlf", nWidth, nDecimals);
+                            printf(szFormat,
+                                   DBFReadDoubleAttribute(hDBF, iRecord, i));
+                            break;
 
-                      default:
-                        break;
+                        default:
+                            break;
                     }
                 }
             }
 
-/* -------------------------------------------------------------------- */
-/*      Just dump in raw form (as formatted in the file).               */
-/* -------------------------------------------------------------------- */
+            /* -------------------------------------------------------------------- */
+            /*      Just dump in raw form (as formatted in the file).               */
+            /* -------------------------------------------------------------------- */
             else
             {
-                sprintf( szFormat, "%%-%ds", nWidth );
-                printf( szFormat,
-                        DBFReadStringAttribute( hDBF, iRecord, i ) );
+                sprintf(szFormat, "%%-%ds", nWidth);
+                printf(szFormat, DBFReadStringAttribute(hDBF, iRecord, i));
             }
 
-/* -------------------------------------------------------------------- */
-/*      Write out any extra spaces required to pad out the field        */
-/*      width.                                                          */
-/* -------------------------------------------------------------------- */
-            if( bMultiLine ) {
-                printf( "\n" );
-            } else {
-		sprintf( szFormat, "%%%ds", panWidth[i] - nWidth + 1 );
-		printf( szFormat, "" );
-	    }
+            /* -------------------------------------------------------------------- */
+            /*      Write out any extra spaces required to pad out the field        */
+            /*      width.                                                          */
+            /* -------------------------------------------------------------------- */
+            if (bMultiLine)
+            {
+                printf("\n");
+            }
+            else
+            {
+                sprintf(szFormat, "%%%ds", panWidth[i] - nWidth + 1);
+                printf(szFormat, "");
+            }
 
-	    fflush( stdout );
-	}
+            fflush(stdout);
+        }
 
-        if( DBFIsRecordDeleted(hDBF, iRecord) )
-            printf( "(DELETED)" );
+        if (DBFIsRecordDeleted(hDBF, iRecord))
+            printf("(DELETED)");
 
-	printf( "\n" );
+        printf("\n");
     }
 
-    DBFClose( hDBF );
-    free( panWidth );
+    DBFClose(hDBF);
+    free(panWidth);
 
-    return( 0 );
+    return (0);
 }

--- a/dbfopen.c
+++ b/dbfopen.c
@@ -47,20 +47,20 @@
 #else
 
 #if defined(WIN32) || defined(_WIN32)
-#    define STRCASECMP(a,b)         (stricmp(a,b))
-#  else
+#define STRCASECMP(a, b) (stricmp(a, b))
+#else
 #include <strings.h>
-#    define STRCASECMP(a,b)         (strcasecmp(a,b))
+#define STRCASECMP(a, b) (strcasecmp(a, b))
 #endif
 
 #if defined(_MSC_VER)
-# if _MSC_VER < 1900
-#     define snprintf _snprintf
-# endif
+#if _MSC_VER < 1900
+#define snprintf _snprintf
+#endif
 #elif defined(WIN32) || defined(_WIN32)
-#  ifndef snprintf
-#     define snprintf _snprintf
-#  endif
+#ifndef snprintf
+#define snprintf _snprintf
+#endif
 #endif
 
 #define CPLsprintf sprintf
@@ -70,33 +70,35 @@
 SHP_CVSID("$Id$")
 
 #ifndef FALSE
-#  define FALSE		0
-#  define TRUE		1
+#define FALSE 0
+#define TRUE 1
 #endif
 
 /* File header size */
-#define XBASE_FILEHDR_SZ         32
+#define XBASE_FILEHDR_SZ 32
 
 #define HEADER_RECORD_TERMINATOR 0x0D
 
 /* See http://www.manmrk.net/tutorials/database/xbase/dbf.html */
-#define END_OF_FILE_CHARACTER    0x1A
+#define END_OF_FILE_CHARACTER 0x1A
 
 #ifdef USE_CPL
-CPL_INLINE static void CPL_IGNORE_RET_VAL_INT(CPL_UNUSED int unused) {}
+CPL_INLINE static void CPL_IGNORE_RET_VAL_INT(CPL_UNUSED int unused)
+{
+}
 #else
 #define CPL_IGNORE_RET_VAL_INT(x) x
 #endif
 
 #ifdef __cplusplus
-#define STATIC_CAST(type,x) static_cast<type>(x)
-#define REINTERPRET_CAST(type,x) reinterpret_cast<type>(x)
-#define CONST_CAST(type,x) const_cast<type>(x)
+#define STATIC_CAST(type, x) static_cast<type>(x)
+#define REINTERPRET_CAST(type, x) reinterpret_cast<type>(x)
+#define CONST_CAST(type, x) const_cast<type>(x)
 #define SHPLIB_NULLPTR nullptr
 #else
-#define STATIC_CAST(type,x) ((type)(x))
-#define REINTERPRET_CAST(type,x) ((type)(x))
-#define CONST_CAST(type,x) ((type)(x))
+#define STATIC_CAST(type, x) ((type)(x))
+#define REINTERPRET_CAST(type, x) ((type)(x))
+#define CONST_CAST(type, x) ((type)(x))
 #define SHPLIB_NULLPTR NULL
 #endif
 
@@ -109,18 +111,19 @@ CPL_INLINE static void CPL_IGNORE_RET_VAL_INT(CPL_UNUSED int unused) {}
 /*      and so forth values.                                            */
 /************************************************************************/
 
-static void DBFWriteHeader(DBFHandle psDBF) {
-    unsigned char abyHeader[XBASE_FILEHDR_SZ] = { 0 };
+static void DBFWriteHeader(DBFHandle psDBF)
+{
+    unsigned char abyHeader[XBASE_FILEHDR_SZ] = {0};
 
-    if( !psDBF->bNoHeader )
+    if (!psDBF->bNoHeader)
         return;
 
     psDBF->bNoHeader = FALSE;
 
-/* -------------------------------------------------------------------- */
-/*	Initialize the file header information.				*/
-/* -------------------------------------------------------------------- */
-    abyHeader[0] = 0x03;		/* memo field? - just copying 	*/
+    /* -------------------------------------------------------------------- */
+    /*	Initialize the file header information.				*/
+    /* -------------------------------------------------------------------- */
+    abyHeader[0] = 0x03; /* memo field? - just copying 	*/
 
     /* write out update date */
     abyHeader[1] = STATIC_CAST(unsigned char, psDBF->nUpdateYearSince1900);
@@ -137,33 +140,33 @@ static void DBFWriteHeader(DBFHandle psDBF) {
 
     abyHeader[29] = STATIC_CAST(unsigned char, psDBF->iLanguageDriver);
 
-/* -------------------------------------------------------------------- */
-/*      Write the initial 32 byte file header, and all the field        */
-/*      descriptions.                                     		*/
-/* -------------------------------------------------------------------- */
-    psDBF->sHooks.FSeek( psDBF->fp, 0, 0 );
-    psDBF->sHooks.FWrite( abyHeader, XBASE_FILEHDR_SZ, 1, psDBF->fp );
-    psDBF->sHooks.FWrite( psDBF->pszHeader, XBASE_FLDHDR_SZ, psDBF->nFields,
-                          psDBF->fp );
+    /* -------------------------------------------------------------------- */
+    /*      Write the initial 32 byte file header, and all the field        */
+    /*      descriptions.                                     		*/
+    /* -------------------------------------------------------------------- */
+    psDBF->sHooks.FSeek(psDBF->fp, 0, 0);
+    psDBF->sHooks.FWrite(abyHeader, XBASE_FILEHDR_SZ, 1, psDBF->fp);
+    psDBF->sHooks.FWrite(psDBF->pszHeader, XBASE_FLDHDR_SZ, psDBF->nFields,
+                         psDBF->fp);
 
-/* -------------------------------------------------------------------- */
-/*      Write out the newline character if there is room for it.        */
-/* -------------------------------------------------------------------- */
-    if( psDBF->nHeaderLength > XBASE_FLDHDR_SZ*psDBF->nFields +
-                               XBASE_FLDHDR_SZ )
+    /* -------------------------------------------------------------------- */
+    /*      Write out the newline character if there is room for it.        */
+    /* -------------------------------------------------------------------- */
+    if (psDBF->nHeaderLength >
+        XBASE_FLDHDR_SZ * psDBF->nFields + XBASE_FLDHDR_SZ)
     {
         char cNewline = HEADER_RECORD_TERMINATOR;
-        psDBF->sHooks.FWrite( &cNewline, 1, 1, psDBF->fp );
+        psDBF->sHooks.FWrite(&cNewline, 1, 1, psDBF->fp);
     }
 
-/* -------------------------------------------------------------------- */
-/*      If the file is new, add a EOF character.                        */
-/* -------------------------------------------------------------------- */
-    if( psDBF->nRecords == 0 && psDBF->bWriteEndOfFileChar )
+    /* -------------------------------------------------------------------- */
+    /*      If the file is new, add a EOF character.                        */
+    /* -------------------------------------------------------------------- */
+    if (psDBF->nRecords == 0 && psDBF->bWriteEndOfFileChar)
     {
         char ch = END_OF_FILE_CHARACTER;
 
-        psDBF->sHooks.FWrite( &ch, 1, 1, psDBF->fp );
+        psDBF->sHooks.FWrite(&ch, 1, 1, psDBF->fp);
     }
 }
 
@@ -173,53 +176,57 @@ static void DBFWriteHeader(DBFHandle psDBF) {
 /*      Write out the current record if there is one.                   */
 /************************************************************************/
 
-static bool DBFFlushRecord( DBFHandle psDBF ) {
-    if( psDBF->bCurrentRecordModified && psDBF->nCurrentRecord > -1 )
+static bool DBFFlushRecord(DBFHandle psDBF)
+{
+    if (psDBF->bCurrentRecordModified && psDBF->nCurrentRecord > -1)
     {
-	psDBF->bCurrentRecordModified = FALSE;
+        psDBF->bCurrentRecordModified = FALSE;
 
         const SAOffset nRecordOffset =
-            psDBF->nRecordLength * STATIC_CAST(SAOffset, psDBF->nCurrentRecord)
-            + psDBF->nHeaderLength;
+            psDBF->nRecordLength *
+                STATIC_CAST(SAOffset, psDBF->nCurrentRecord) +
+            psDBF->nHeaderLength;
 
-/* -------------------------------------------------------------------- */
-/*      Guard FSeek with check for whether we're already at position;   */
-/*      no-op FSeeks defeat network filesystems' write buffering.       */
-/* -------------------------------------------------------------------- */
-        if ( psDBF->bRequireNextWriteSeek ||
-	     psDBF->sHooks.FTell( psDBF->fp ) != nRecordOffset ) {
-            if ( psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 ) != 0 ) {
+        /* -------------------------------------------------------------------- */
+        /*      Guard FSeek with check for whether we're already at position;   */
+        /*      no-op FSeeks defeat network filesystems' write buffering.       */
+        /* -------------------------------------------------------------------- */
+        if (psDBF->bRequireNextWriteSeek ||
+            psDBF->sHooks.FTell(psDBF->fp) != nRecordOffset)
+        {
+            if (psDBF->sHooks.FSeek(psDBF->fp, nRecordOffset, 0) != 0)
+            {
                 char szMessage[128];
-                snprintf( szMessage, sizeof(szMessage),
-                          "Failure seeking to position before writing DBF record %d.",
-                          psDBF->nCurrentRecord );
-                psDBF->sHooks.Error( szMessage );
+                snprintf(
+                    szMessage, sizeof(szMessage),
+                    "Failure seeking to position before writing DBF record %d.",
+                    psDBF->nCurrentRecord);
+                psDBF->sHooks.Error(szMessage);
                 return false;
             }
         }
 
-	if ( psDBF->sHooks.FWrite( psDBF->pszCurrentRecord,
-                                     psDBF->nRecordLength,
-                                     1, psDBF->fp ) != 1 )
+        if (psDBF->sHooks.FWrite(psDBF->pszCurrentRecord, psDBF->nRecordLength,
+                                 1, psDBF->fp) != 1)
         {
             char szMessage[128];
-            snprintf( szMessage, sizeof(szMessage), "Failure writing DBF record %d.",
-                     psDBF->nCurrentRecord );
-            psDBF->sHooks.Error( szMessage );
+            snprintf(szMessage, sizeof(szMessage),
+                     "Failure writing DBF record %d.", psDBF->nCurrentRecord);
+            psDBF->sHooks.Error(szMessage);
             return false;
         }
 
-/* -------------------------------------------------------------------- */
-/*      If next op is also a write, allow possible skipping of FSeek.   */
-/* -------------------------------------------------------------------- */
-	psDBF->bRequireNextWriteSeek = FALSE;
+        /* -------------------------------------------------------------------- */
+        /*      If next op is also a write, allow possible skipping of FSeek.   */
+        /* -------------------------------------------------------------------- */
+        psDBF->bRequireNextWriteSeek = FALSE;
 
-        if( psDBF->nCurrentRecord == psDBF->nRecords - 1 )
+        if (psDBF->nCurrentRecord == psDBF->nRecords - 1)
         {
-            if( psDBF->bWriteEndOfFileChar )
+            if (psDBF->bWriteEndOfFileChar)
             {
                 char ch = END_OF_FILE_CHARACTER;
-                psDBF->sHooks.FWrite( &ch, 1, 1, psDBF->fp );
+                psDBF->sHooks.FWrite(&ch, 1, 1, psDBF->fp);
             }
         }
     }
@@ -231,39 +238,42 @@ static bool DBFFlushRecord( DBFHandle psDBF ) {
 /*                           DBFLoadRecord()                            */
 /************************************************************************/
 
-static bool DBFLoadRecord( DBFHandle psDBF, int iRecord ) {
-    if( psDBF->nCurrentRecord != iRecord )
+static bool DBFLoadRecord(DBFHandle psDBF, int iRecord)
+{
+    if (psDBF->nCurrentRecord != iRecord)
     {
-	if( !DBFFlushRecord( psDBF ) )
+        if (!DBFFlushRecord(psDBF))
             return false;
 
         const SAOffset nRecordOffset =
-            psDBF->nRecordLength * STATIC_CAST(SAOffset,iRecord) + psDBF->nHeaderLength;
+            psDBF->nRecordLength * STATIC_CAST(SAOffset, iRecord) +
+            psDBF->nHeaderLength;
 
-	if( psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, SEEK_SET ) != 0 )
+        if (psDBF->sHooks.FSeek(psDBF->fp, nRecordOffset, SEEK_SET) != 0)
         {
             char szMessage[128];
-            snprintf( szMessage, sizeof(szMessage), "fseek(%ld) failed on DBF file.",
-                      STATIC_CAST(long, nRecordOffset) );
-            psDBF->sHooks.Error( szMessage );
+            snprintf(szMessage, sizeof(szMessage),
+                     "fseek(%ld) failed on DBF file.",
+                     STATIC_CAST(long, nRecordOffset));
+            psDBF->sHooks.Error(szMessage);
             return false;
         }
 
-	if( psDBF->sHooks.FRead( psDBF->pszCurrentRecord,
-                                 psDBF->nRecordLength, 1, psDBF->fp ) != 1 )
+        if (psDBF->sHooks.FRead(psDBF->pszCurrentRecord, psDBF->nRecordLength,
+                                1, psDBF->fp) != 1)
         {
             char szMessage[128];
-            snprintf( szMessage, sizeof(szMessage), "fread(%d) failed on DBF file.",
-                     psDBF->nRecordLength );
-            psDBF->sHooks.Error( szMessage );
+            snprintf(szMessage, sizeof(szMessage),
+                     "fread(%d) failed on DBF file.", psDBF->nRecordLength);
+            psDBF->sHooks.Error(szMessage);
             return false;
         }
 
-	psDBF->nCurrentRecord = iRecord;
-/* -------------------------------------------------------------------- */
-/*      Require a seek for next write in case of mixed R/W operations.  */
-/* -------------------------------------------------------------------- */
-	psDBF->bRequireNextWriteSeek = TRUE;
+        psDBF->nCurrentRecord = iRecord;
+        /* -------------------------------------------------------------------- */
+        /*      Require a seek for next write in case of mixed R/W operations.  */
+        /* -------------------------------------------------------------------- */
+        psDBF->bRequireNextWriteSeek = TRUE;
     }
 
     return true;
@@ -273,39 +283,42 @@ static bool DBFLoadRecord( DBFHandle psDBF, int iRecord ) {
 /*                          DBFUpdateHeader()                           */
 /************************************************************************/
 
-void SHPAPI_CALL
-DBFUpdateHeader( DBFHandle psDBF ) {
-    if( psDBF->bNoHeader )
-        DBFWriteHeader( psDBF );
+void SHPAPI_CALL DBFUpdateHeader(DBFHandle psDBF)
+{
+    if (psDBF->bNoHeader)
+        DBFWriteHeader(psDBF);
 
-    if( !DBFFlushRecord( psDBF ) )
+    if (!DBFFlushRecord(psDBF))
         return;
 
-    psDBF->sHooks.FSeek( psDBF->fp, 0, 0 );
+    psDBF->sHooks.FSeek(psDBF->fp, 0, 0);
 
     unsigned char abyFileHeader[XBASE_FILEHDR_SZ] = {0};
-    psDBF->sHooks.FRead( abyFileHeader, 1, sizeof(abyFileHeader), psDBF->fp );
+    psDBF->sHooks.FRead(abyFileHeader, 1, sizeof(abyFileHeader), psDBF->fp);
 
     abyFileHeader[1] = STATIC_CAST(unsigned char, psDBF->nUpdateYearSince1900);
     abyFileHeader[2] = STATIC_CAST(unsigned char, psDBF->nUpdateMonth);
     abyFileHeader[3] = STATIC_CAST(unsigned char, psDBF->nUpdateDay);
     abyFileHeader[4] = STATIC_CAST(unsigned char, psDBF->nRecords & 0xFF);
-    abyFileHeader[5] = STATIC_CAST(unsigned char, (psDBF->nRecords>>8) & 0xFF);
-    abyFileHeader[6] = STATIC_CAST(unsigned char, (psDBF->nRecords>>16) & 0xFF);
-    abyFileHeader[7] = STATIC_CAST(unsigned char, (psDBF->nRecords>>24) & 0xFF);
+    abyFileHeader[5] =
+        STATIC_CAST(unsigned char, (psDBF->nRecords >> 8) & 0xFF);
+    abyFileHeader[6] =
+        STATIC_CAST(unsigned char, (psDBF->nRecords >> 16) & 0xFF);
+    abyFileHeader[7] =
+        STATIC_CAST(unsigned char, (psDBF->nRecords >> 24) & 0xFF);
 
-    psDBF->sHooks.FSeek( psDBF->fp, 0, 0 );
-    psDBF->sHooks.FWrite( abyFileHeader, sizeof(abyFileHeader), 1, psDBF->fp );
+    psDBF->sHooks.FSeek(psDBF->fp, 0, 0);
+    psDBF->sHooks.FWrite(abyFileHeader, sizeof(abyFileHeader), 1, psDBF->fp);
 
-    psDBF->sHooks.FFlush( psDBF->fp );
+    psDBF->sHooks.FFlush(psDBF->fp);
 }
 
 /************************************************************************/
 /*                       DBFSetLastModifiedDate()                       */
 /************************************************************************/
 
-void SHPAPI_CALL
-DBFSetLastModifiedDate( DBFHandle psDBF, int nYYSince1900, int nMM, int nDD )
+void SHPAPI_CALL DBFSetLastModifiedDate(DBFHandle psDBF, int nYYSince1900,
+                                        int nMM, int nDD)
 {
     psDBF->nUpdateYearSince1900 = nYYSince1900;
     psDBF->nUpdateMonth = nMM;
@@ -318,28 +331,27 @@ DBFSetLastModifiedDate( DBFHandle psDBF, int nYYSince1900, int nMM, int nDD )
 /*      Open a .dbf file.                                               */
 /************************************************************************/
 
-DBFHandle SHPAPI_CALL
-DBFOpen( const char * pszFilename, const char * pszAccess )
+DBFHandle SHPAPI_CALL DBFOpen(const char *pszFilename, const char *pszAccess)
 
 {
     SAHooks sHooks;
 
-    SASetupDefaultHooks( &sHooks );
+    SASetupDefaultHooks(&sHooks);
 
-    return DBFOpenLL( pszFilename, pszAccess, &sHooks );
+    return DBFOpenLL(pszFilename, pszAccess, &sHooks);
 }
 
 /************************************************************************/
 /*                      DBFGetLenWithoutExtension()                     */
 /************************************************************************/
 
-static int DBFGetLenWithoutExtension(const char* pszBasename) {
+static int DBFGetLenWithoutExtension(const char *pszBasename)
+{
     const int nLen = STATIC_CAST(int, strlen(pszBasename));
-    for( int i = nLen-1;
-         i > 0 && pszBasename[i] != '/' && pszBasename[i] != '\\';
-         i-- )
+    for (int i = nLen - 1;
+         i > 0 && pszBasename[i] != '/' && pszBasename[i] != '\\'; i--)
     {
-        if( pszBasename[i] == '.' )
+        if (pszBasename[i] == '.')
         {
             return i;
         }
@@ -353,55 +365,57 @@ static int DBFGetLenWithoutExtension(const char* pszBasename) {
 /*      Open a .dbf file.                                               */
 /************************************************************************/
 
-DBFHandle SHPAPI_CALL
-DBFOpenLL( const char * pszFilename, const char * pszAccess, SAHooks *psHooks ) {
-/* -------------------------------------------------------------------- */
-/*      We only allow the access strings "rb" and "r+".                  */
-/* -------------------------------------------------------------------- */
-    if( strcmp(pszAccess,"r") != 0 && strcmp(pszAccess,"r+") != 0
-        && strcmp(pszAccess,"rb") != 0 && strcmp(pszAccess,"rb+") != 0
-        && strcmp(pszAccess,"r+b") != 0 )
+DBFHandle SHPAPI_CALL DBFOpenLL(const char *pszFilename, const char *pszAccess,
+                                SAHooks *psHooks)
+{
+    /* -------------------------------------------------------------------- */
+    /*      We only allow the access strings "rb" and "r+".                  */
+    /* -------------------------------------------------------------------- */
+    if (strcmp(pszAccess, "r") != 0 && strcmp(pszAccess, "r+") != 0 &&
+        strcmp(pszAccess, "rb") != 0 && strcmp(pszAccess, "rb+") != 0 &&
+        strcmp(pszAccess, "r+b") != 0)
         return SHPLIB_NULLPTR;
 
-    if( strcmp(pszAccess,"r") == 0 )
+    if (strcmp(pszAccess, "r") == 0)
         pszAccess = "rb";
 
-    if( strcmp(pszAccess,"r+") == 0 )
+    if (strcmp(pszAccess, "r+") == 0)
         pszAccess = "rb+";
 
-/* -------------------------------------------------------------------- */
-/*	Compute the base (layer) name.  If there is any extension	*/
-/*	on the passed in filename we will strip it off.			*/
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*	Compute the base (layer) name.  If there is any extension	*/
+    /*	on the passed in filename we will strip it off.			*/
+    /* -------------------------------------------------------------------- */
     const int nLenWithoutExtension = DBFGetLenWithoutExtension(pszFilename);
     char *pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
     memcpy(pszFullname, pszFilename, nLenWithoutExtension);
     memcpy(pszFullname + nLenWithoutExtension, ".dbf", 5);
 
-    DBFHandle psDBF = STATIC_CAST(DBFHandle, calloc( 1, sizeof(DBFInfo) ));
-    psDBF->fp = psHooks->FOpen( pszFullname, pszAccess );
-    memcpy( &(psDBF->sHooks), psHooks, sizeof(SAHooks) );
+    DBFHandle psDBF = STATIC_CAST(DBFHandle, calloc(1, sizeof(DBFInfo)));
+    psDBF->fp = psHooks->FOpen(pszFullname, pszAccess);
+    memcpy(&(psDBF->sHooks), psHooks, sizeof(SAHooks));
 
-    if( psDBF->fp == SHPLIB_NULLPTR )
+    if (psDBF->fp == SHPLIB_NULLPTR)
     {
         memcpy(pszFullname + nLenWithoutExtension, ".DBF", 5);
-        psDBF->fp = psDBF->sHooks.FOpen(pszFullname, pszAccess );
+        psDBF->fp = psDBF->sHooks.FOpen(pszFullname, pszAccess);
     }
 
     memcpy(pszFullname + nLenWithoutExtension, ".cpg", 5);
-    SAFile pfCPG = psHooks->FOpen( pszFullname, "r" );
-    if( pfCPG == SHPLIB_NULLPTR )
+    SAFile pfCPG = psHooks->FOpen(pszFullname, "r");
+    if (pfCPG == SHPLIB_NULLPTR)
     {
         memcpy(pszFullname + nLenWithoutExtension, ".CPG", 5);
-        pfCPG = psHooks->FOpen( pszFullname, "r" );
+        pfCPG = psHooks->FOpen(pszFullname, "r");
     }
 
-    free( pszFullname );
+    free(pszFullname);
 
-    if( psDBF->fp == SHPLIB_NULLPTR )
+    if (psDBF->fp == SHPLIB_NULLPTR)
     {
-        free( psDBF );
-        if( pfCPG ) psHooks->FClose( pfCPG );
+        free(psDBF);
+        if (pfCPG)
+            psHooks->FClose(pfCPG);
         return SHPLIB_NULLPTR;
     }
 
@@ -409,36 +423,38 @@ DBFOpenLL( const char * pszFilename, const char * pszAccess, SAHooks *psHooks ) 
     psDBF->nCurrentRecord = -1;
     psDBF->bCurrentRecordModified = FALSE;
 
-/* -------------------------------------------------------------------- */
-/*  Read Table Header info                                              */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*  Read Table Header info                                              */
+    /* -------------------------------------------------------------------- */
     const int nBufSize = 500;
     unsigned char *pabyBuf = STATIC_CAST(unsigned char *, malloc(nBufSize));
-    if( psDBF->sHooks.FRead( pabyBuf, XBASE_FILEHDR_SZ, 1, psDBF->fp ) != 1 )
+    if (psDBF->sHooks.FRead(pabyBuf, XBASE_FILEHDR_SZ, 1, psDBF->fp) != 1)
     {
-        psDBF->sHooks.FClose( psDBF->fp );
-        if( pfCPG ) psDBF->sHooks.FClose( pfCPG );
-        free( pabyBuf );
-        free( psDBF );
+        psDBF->sHooks.FClose(psDBF->fp);
+        if (pfCPG)
+            psDBF->sHooks.FClose(pfCPG);
+        free(pabyBuf);
+        free(psDBF);
         return SHPLIB_NULLPTR;
     }
 
     DBFSetLastModifiedDate(psDBF, pabyBuf[1], pabyBuf[2], pabyBuf[3]);
 
-    psDBF->nRecords =
-     pabyBuf[4]|(pabyBuf[5]<<8)|(pabyBuf[6]<<16)|((pabyBuf[7]&0x7f)<<24);
+    psDBF->nRecords = pabyBuf[4] | (pabyBuf[5] << 8) | (pabyBuf[6] << 16) |
+                      ((pabyBuf[7] & 0x7f) << 24);
 
-    const int nHeadLen = pabyBuf[8]|(pabyBuf[9]<<8);
+    const int nHeadLen = pabyBuf[8] | (pabyBuf[9] << 8);
     psDBF->nHeaderLength = nHeadLen;
-    psDBF->nRecordLength = pabyBuf[10]|(pabyBuf[11]<<8);
+    psDBF->nRecordLength = pabyBuf[10] | (pabyBuf[11] << 8);
     psDBF->iLanguageDriver = pabyBuf[29];
 
     if (psDBF->nRecordLength == 0 || nHeadLen < XBASE_FILEHDR_SZ)
     {
-        psDBF->sHooks.FClose( psDBF->fp );
-        if( pfCPG ) psDBF->sHooks.FClose( pfCPG );
-        free( pabyBuf );
-        free( psDBF );
+        psDBF->sHooks.FClose(psDBF->fp);
+        if (pfCPG)
+            psDBF->sHooks.FClose(pfCPG);
+        free(pabyBuf);
+        free(psDBF);
         return SHPLIB_NULLPTR;
     }
 
@@ -448,45 +464,47 @@ DBFOpenLL( const char * pszFilename, const char * pszAccess, SAHooks *psHooks ) 
     /* coverity[tainted_data] */
     psDBF->pszCurrentRecord = STATIC_CAST(char *, malloc(psDBF->nRecordLength));
 
-/* -------------------------------------------------------------------- */
-/*  Figure out the code page from the LDID and CPG                      */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*  Figure out the code page from the LDID and CPG                      */
+    /* -------------------------------------------------------------------- */
     psDBF->pszCodePage = SHPLIB_NULLPTR;
-    if( pfCPG )
+    if (pfCPG)
     {
-        memset( pabyBuf, 0, nBufSize);
+        memset(pabyBuf, 0, nBufSize);
         psDBF->sHooks.FRead(pabyBuf, 1, nBufSize - 1, pfCPG);
-        const size_t n = strcspn( REINTERPRET_CAST(char *, pabyBuf), "\n\r" );
-        if( n > 0 )
+        const size_t n = strcspn(REINTERPRET_CAST(char *, pabyBuf), "\n\r");
+        if (n > 0)
         {
             pabyBuf[n] = '\0';
             psDBF->pszCodePage = STATIC_CAST(char *, malloc(n + 1));
-            memcpy( psDBF->pszCodePage, pabyBuf, n + 1 );
+            memcpy(psDBF->pszCodePage, pabyBuf, n + 1);
         }
-		psDBF->sHooks.FClose( pfCPG );
+        psDBF->sHooks.FClose(pfCPG);
     }
-    if( psDBF->pszCodePage == SHPLIB_NULLPTR && pabyBuf[29] != 0 )
+    if (psDBF->pszCodePage == SHPLIB_NULLPTR && pabyBuf[29] != 0)
     {
-        snprintf( REINTERPRET_CAST(char *, pabyBuf), nBufSize, "LDID/%d", psDBF->iLanguageDriver );
-        psDBF->pszCodePage = STATIC_CAST(char *, malloc(strlen(REINTERPRET_CAST(char*, pabyBuf)) + 1));
-        strcpy( psDBF->pszCodePage, REINTERPRET_CAST(char *, pabyBuf) );
+        snprintf(REINTERPRET_CAST(char *, pabyBuf), nBufSize, "LDID/%d",
+                 psDBF->iLanguageDriver);
+        psDBF->pszCodePage = STATIC_CAST(
+            char *, malloc(strlen(REINTERPRET_CAST(char *, pabyBuf)) + 1));
+        strcpy(psDBF->pszCodePage, REINTERPRET_CAST(char *, pabyBuf));
     }
 
-/* -------------------------------------------------------------------- */
-/*  Read in Field Definitions                                           */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*  Read in Field Definitions                                           */
+    /* -------------------------------------------------------------------- */
     pabyBuf = STATIC_CAST(unsigned char *, realloc(pabyBuf, nHeadLen));
     psDBF->pszHeader = REINTERPRET_CAST(char *, pabyBuf);
 
-    psDBF->sHooks.FSeek( psDBF->fp, XBASE_FILEHDR_SZ, 0 );
-    if( psDBF->sHooks.FRead( pabyBuf, nHeadLen-XBASE_FILEHDR_SZ, 1,
-                             psDBF->fp ) != 1 )
+    psDBF->sHooks.FSeek(psDBF->fp, XBASE_FILEHDR_SZ, 0);
+    if (psDBF->sHooks.FRead(pabyBuf, nHeadLen - XBASE_FILEHDR_SZ, 1,
+                            psDBF->fp) != 1)
     {
-        psDBF->sHooks.FClose( psDBF->fp );
-        free( pabyBuf );
-        free( psDBF->pszCurrentRecord );
-        free( psDBF->pszCodePage );
-        free( psDBF );
+        psDBF->sHooks.FClose(psDBF->fp);
+        free(pabyBuf);
+        free(psDBF->pszCurrentRecord);
+        free(psDBF->pszCodePage);
+        free(psDBF);
         return SHPLIB_NULLPTR;
     }
 
@@ -495,26 +513,26 @@ DBFOpenLL( const char * pszFilename, const char * pszAccess, SAHooks *psHooks ) 
     psDBF->panFieldDecimals = STATIC_CAST(int *, malloc(sizeof(int) * nFields));
     psDBF->pachFieldType = STATIC_CAST(char *, malloc(sizeof(char) * nFields));
 
-    for( int iField = 0; iField < nFields; iField++ )
+    for (int iField = 0; iField < nFields; iField++)
     {
-	unsigned char *pabyFInfo = pabyBuf+iField*XBASE_FLDHDR_SZ;
-        if( pabyFInfo[0] == HEADER_RECORD_TERMINATOR )
+        unsigned char *pabyFInfo = pabyBuf + iField * XBASE_FLDHDR_SZ;
+        if (pabyFInfo[0] == HEADER_RECORD_TERMINATOR)
         {
             psDBF->nFields = iField;
             break;
         }
 
-	if( pabyFInfo[11] == 'N' || pabyFInfo[11] == 'F' )
-	{
-	    psDBF->panFieldSize[iField] = pabyFInfo[16];
-	    psDBF->panFieldDecimals[iField] = pabyFInfo[17];
-	}
-	else
-	{
-	    psDBF->panFieldSize[iField] = pabyFInfo[16];
-	    psDBF->panFieldDecimals[iField] = 0;
+        if (pabyFInfo[11] == 'N' || pabyFInfo[11] == 'F')
+        {
+            psDBF->panFieldSize[iField] = pabyFInfo[16];
+            psDBF->panFieldDecimals[iField] = pabyFInfo[17];
+        }
+        else
+        {
+            psDBF->panFieldSize[iField] = pabyFInfo[16];
+            psDBF->panFieldDecimals[iField] = 0;
 
-/*
+            /*
 ** The following seemed to be used sometimes to handle files with long
 ** string fields, but in other cases (such as bug 1202) the decimals field
 ** just seems to indicate some sort of preferred formatting, not very
@@ -522,78 +540,77 @@ DBFOpenLL( const char * pszFilename, const char * pszAccess, SAHooks *psHooks ) 
 	    psDBF->panFieldSize[iField] = pabyFInfo[16] + pabyFInfo[17]*256;
 	    psDBF->panFieldDecimals[iField] = 0;
 */
-	}
+        }
 
-	psDBF->pachFieldType[iField] = STATIC_CAST(char, pabyFInfo[11]);
-	if( iField == 0 )
-	    psDBF->panFieldOffset[iField] = 1;
-	else
-	    psDBF->panFieldOffset[iField] =
-	      psDBF->panFieldOffset[iField-1] + psDBF->panFieldSize[iField-1];
+        psDBF->pachFieldType[iField] = STATIC_CAST(char, pabyFInfo[11]);
+        if (iField == 0)
+            psDBF->panFieldOffset[iField] = 1;
+        else
+            psDBF->panFieldOffset[iField] = psDBF->panFieldOffset[iField - 1] +
+                                            psDBF->panFieldSize[iField - 1];
     }
 
     /* Check that the total width of fields does not exceed the record width */
-    if( psDBF->nFields > 0 &&
-        psDBF->panFieldOffset[psDBF->nFields-1] +
-            psDBF->panFieldSize[psDBF->nFields-1] > psDBF->nRecordLength )
+    if (psDBF->nFields > 0 && psDBF->panFieldOffset[psDBF->nFields - 1] +
+                                      psDBF->panFieldSize[psDBF->nFields - 1] >
+                                  psDBF->nRecordLength)
     {
-        DBFClose( psDBF );
+        DBFClose(psDBF);
         return SHPLIB_NULLPTR;
     }
 
-    DBFSetWriteEndOfFileChar( psDBF, TRUE );
+    DBFSetWriteEndOfFileChar(psDBF, TRUE);
 
     psDBF->bRequireNextWriteSeek = TRUE;
 
-    return( psDBF );
+    return (psDBF);
 }
 
 /************************************************************************/
 /*                              DBFClose()                              */
 /************************************************************************/
 
-void SHPAPI_CALL
-DBFClose(DBFHandle psDBF)
+void SHPAPI_CALL DBFClose(DBFHandle psDBF)
 {
-    if( psDBF == SHPLIB_NULLPTR )
+    if (psDBF == SHPLIB_NULLPTR)
         return;
 
-/* -------------------------------------------------------------------- */
-/*      Write out header if not already written.                        */
-/* -------------------------------------------------------------------- */
-    if( psDBF->bNoHeader )
-        DBFWriteHeader( psDBF );
+    /* -------------------------------------------------------------------- */
+    /*      Write out header if not already written.                        */
+    /* -------------------------------------------------------------------- */
+    if (psDBF->bNoHeader)
+        DBFWriteHeader(psDBF);
 
-    CPL_IGNORE_RET_VAL_INT(DBFFlushRecord( psDBF ));
+    CPL_IGNORE_RET_VAL_INT(DBFFlushRecord(psDBF));
 
-/* -------------------------------------------------------------------- */
-/*      Update last access date, and number of records if we have	*/
-/*	write access.                					*/
-/* -------------------------------------------------------------------- */
-    if( psDBF->bUpdated )
-        DBFUpdateHeader( psDBF );
+    /* -------------------------------------------------------------------- */
+    /*      Update last access date, and number of records if we have	*/
+    /*	write access.                					*/
+    /* -------------------------------------------------------------------- */
+    if (psDBF->bUpdated)
+        DBFUpdateHeader(psDBF);
 
-/* -------------------------------------------------------------------- */
-/*      Close, and free resources.                                      */
-/* -------------------------------------------------------------------- */
-    psDBF->sHooks.FClose( psDBF->fp );
+    /* -------------------------------------------------------------------- */
+    /*      Close, and free resources.                                      */
+    /* -------------------------------------------------------------------- */
+    psDBF->sHooks.FClose(psDBF->fp);
 
-    if( psDBF->panFieldOffset != SHPLIB_NULLPTR )
+    if (psDBF->panFieldOffset != SHPLIB_NULLPTR)
     {
-        free( psDBF->panFieldOffset );
-        free( psDBF->panFieldSize );
-        free( psDBF->panFieldDecimals );
-        free( psDBF->pachFieldType );
+        free(psDBF->panFieldOffset);
+        free(psDBF->panFieldSize);
+        free(psDBF->panFieldDecimals);
+        free(psDBF->pachFieldType);
     }
 
-    if( psDBF->pszWorkField != SHPLIB_NULLPTR )
-        free( psDBF->pszWorkField );
+    if (psDBF->pszWorkField != SHPLIB_NULLPTR)
+        free(psDBF->pszWorkField);
 
-    free( psDBF->pszHeader );
-    free( psDBF->pszCurrentRecord );
-    free( psDBF->pszCodePage );
+    free(psDBF->pszHeader);
+    free(psDBF->pszCurrentRecord);
+    free(psDBF->pszCodePage);
 
-    free( psDBF );
+    free(psDBF);
 }
 
 /************************************************************************/
@@ -602,9 +619,9 @@ DBFClose(DBFHandle psDBF)
 /* Create a new .dbf file with default code page LDID/87 (0x57)         */
 /************************************************************************/
 
-DBFHandle SHPAPI_CALL
-DBFCreate( const char * pszFilename ) {
-    return DBFCreateEx( pszFilename, "LDID/87" ); // 0x57
+DBFHandle SHPAPI_CALL DBFCreate(const char *pszFilename)
+{
+    return DBFCreateEx(pszFilename, "LDID/87");  // 0x57
 }
 
 /************************************************************************/
@@ -613,13 +630,14 @@ DBFCreate( const char * pszFilename ) {
 /*      Create a new .dbf file.                                         */
 /************************************************************************/
 
-DBFHandle SHPAPI_CALL
-DBFCreateEx( const char * pszFilename, const char* pszCodePage ) {
+DBFHandle SHPAPI_CALL DBFCreateEx(const char *pszFilename,
+                                  const char *pszCodePage)
+{
     SAHooks sHooks;
 
-    SASetupDefaultHooks( &sHooks );
+    SASetupDefaultHooks(&sHooks);
 
-    return DBFCreateLL( pszFilename, pszCodePage , &sHooks );
+    return DBFCreateLL(pszFilename, pszCodePage, &sHooks);
 }
 
 /************************************************************************/
@@ -628,73 +646,78 @@ DBFCreateEx( const char * pszFilename, const char* pszCodePage ) {
 /*      Create a new .dbf file.                                         */
 /************************************************************************/
 
-DBFHandle SHPAPI_CALL
-DBFCreateLL( const char * pszFilename, const char * pszCodePage, SAHooks *psHooks ) {
-/* -------------------------------------------------------------------- */
-/*	Compute the base (layer) name.  If there is any extension	*/
-/*	on the passed in filename we will strip it off.			*/
-/* -------------------------------------------------------------------- */
+DBFHandle SHPAPI_CALL DBFCreateLL(const char *pszFilename,
+                                  const char *pszCodePage, SAHooks *psHooks)
+{
+    /* -------------------------------------------------------------------- */
+    /*	Compute the base (layer) name.  If there is any extension	*/
+    /*	on the passed in filename we will strip it off.			*/
+    /* -------------------------------------------------------------------- */
     const int nLenWithoutExtension = DBFGetLenWithoutExtension(pszFilename);
     char *pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
     memcpy(pszFullname, pszFilename, nLenWithoutExtension);
     memcpy(pszFullname + nLenWithoutExtension, ".dbf", 5);
 
-/* -------------------------------------------------------------------- */
-/*      Create the file.                                                */
-/* -------------------------------------------------------------------- */
-    SAFile fp = psHooks->FOpen( pszFullname, "wb" );
-    if( fp == SHPLIB_NULLPTR )
+    /* -------------------------------------------------------------------- */
+    /*      Create the file.                                                */
+    /* -------------------------------------------------------------------- */
+    SAFile fp = psHooks->FOpen(pszFullname, "wb");
+    if (fp == SHPLIB_NULLPTR)
     {
-        free( pszFullname );
+        free(pszFullname);
         return SHPLIB_NULLPTR;
     }
 
     char chZero = '\0';
-    psHooks->FWrite( &chZero, 1, 1, fp );
-    psHooks->FClose( fp );
+    psHooks->FWrite(&chZero, 1, 1, fp);
+    psHooks->FClose(fp);
 
-    fp = psHooks->FOpen( pszFullname, "rb+" );
-    if( fp == SHPLIB_NULLPTR )
+    fp = psHooks->FOpen(pszFullname, "rb+");
+    if (fp == SHPLIB_NULLPTR)
     {
-        free( pszFullname );
+        free(pszFullname);
         return SHPLIB_NULLPTR;
     }
 
     memcpy(pszFullname + nLenWithoutExtension, ".cpg", 5);
     int ldid = -1;
-    if( pszCodePage != SHPLIB_NULLPTR )
+    if (pszCodePage != SHPLIB_NULLPTR)
     {
-        if( strncmp( pszCodePage, "LDID/", 5 ) == 0 )
+        if (strncmp(pszCodePage, "LDID/", 5) == 0)
         {
-            ldid = atoi( pszCodePage + 5 );
-            if( ldid > 255 )
-                ldid = -1; // don't use 0 to indicate out of range as LDID/0 is a valid one
+            ldid = atoi(pszCodePage + 5);
+            if (ldid > 255)
+                ldid =
+                    -1;  // don't use 0 to indicate out of range as LDID/0 is a valid one
         }
-        if( ldid < 0 )
+        if (ldid < 0)
         {
-            SAFile fpCPG = psHooks->FOpen( pszFullname, "w" );
-            psHooks->FWrite( CONST_CAST(void*, STATIC_CAST(const void*, pszCodePage)), strlen(pszCodePage), 1, fpCPG );
-            psHooks->FClose( fpCPG );
+            SAFile fpCPG = psHooks->FOpen(pszFullname, "w");
+            psHooks->FWrite(
+                CONST_CAST(void *, STATIC_CAST(const void *, pszCodePage)),
+                strlen(pszCodePage), 1, fpCPG);
+            psHooks->FClose(fpCPG);
         }
     }
-    if( pszCodePage == SHPLIB_NULLPTR || ldid >= 0 )
+    if (pszCodePage == SHPLIB_NULLPTR || ldid >= 0)
     {
-        psHooks->Remove( pszFullname );
+        psHooks->Remove(pszFullname);
     }
 
-    free( pszFullname );
+    free(pszFullname);
 
-/* -------------------------------------------------------------------- */
-/*	Create the info structure.					*/
-/* -------------------------------------------------------------------- */
-    DBFHandle psDBF = STATIC_CAST(DBFHandle, calloc(1,sizeof(DBFInfo)));
+    /* -------------------------------------------------------------------- */
+    /*	Create the info structure.					*/
+    /* -------------------------------------------------------------------- */
+    DBFHandle psDBF = STATIC_CAST(DBFHandle, calloc(1, sizeof(DBFInfo)));
 
-    memcpy( &(psDBF->sHooks), psHooks, sizeof(SAHooks) );
+    memcpy(&(psDBF->sHooks), psHooks, sizeof(SAHooks));
     psDBF->fp = fp;
     psDBF->nRecords = 0;
     psDBF->nFields = 0;
     psDBF->nRecordLength = 1;
-    psDBF->nHeaderLength = XBASE_FILEHDR_SZ + 1; /* + 1 for HEADER_RECORD_TERMINATOR */
+    psDBF->nHeaderLength =
+        XBASE_FILEHDR_SZ + 1; /* + 1 for HEADER_RECORD_TERMINATOR */
 
     psDBF->panFieldOffset = SHPLIB_NULLPTR;
     psDBF->panFieldSize = SHPLIB_NULLPTR;
@@ -710,10 +733,11 @@ DBFCreateLL( const char * pszFilename, const char * pszCodePage, SAHooks *psHook
 
     psDBF->iLanguageDriver = ldid > 0 ? ldid : 0;
     psDBF->pszCodePage = SHPLIB_NULLPTR;
-    if( pszCodePage )
+    if (pszCodePage)
     {
-        psDBF->pszCodePage = STATIC_CAST(char *, malloc( strlen(pszCodePage) + 1 ));
-        strcpy( psDBF->pszCodePage, pszCodePage );
+        psDBF->pszCodePage =
+            STATIC_CAST(char *, malloc(strlen(pszCodePage) + 1));
+        strcpy(psDBF->pszCodePage, pszCodePage);
     }
     DBFSetLastModifiedDate(psDBF, 95, 7, 26); /* dummy date */
 
@@ -721,7 +745,7 @@ DBFCreateLL( const char * pszFilename, const char * pszCodePage, SAHooks *psHook
 
     psDBF->bRequireNextWriteSeek = TRUE;
 
-    return( psDBF );
+    return (psDBF);
 }
 
 /************************************************************************/
@@ -730,40 +754,41 @@ DBFCreateLL( const char * pszFilename, const char * pszCodePage, SAHooks *psHook
 /*      Add a field to a newly created .dbf or to an existing one       */
 /************************************************************************/
 
-int SHPAPI_CALL
-DBFAddField(DBFHandle psDBF, const char * pszFieldName,
-            DBFFieldType eType, int nWidth, int nDecimals ) {
+int SHPAPI_CALL DBFAddField(DBFHandle psDBF, const char *pszFieldName,
+                            DBFFieldType eType, int nWidth, int nDecimals)
+{
     char chNativeType;
 
-    if( eType == FTLogical )
+    if (eType == FTLogical)
         chNativeType = 'L';
-    else if( eType == FTDate )
-	chNativeType = 'D';
-    else if( eType == FTString )
+    else if (eType == FTDate)
+        chNativeType = 'D';
+    else if (eType == FTString)
         chNativeType = 'C';
     else
         chNativeType = 'N';
 
-    return DBFAddNativeFieldType( psDBF, pszFieldName, chNativeType,
-                                  nWidth, nDecimals );
+    return DBFAddNativeFieldType(psDBF, pszFieldName, chNativeType, nWidth,
+                                 nDecimals);
 }
 
 /************************************************************************/
 /*                        DBFGetNullCharacter()                         */
 /************************************************************************/
 
-static char DBFGetNullCharacter(char chType) {
+static char DBFGetNullCharacter(char chType)
+{
     switch (chType)
     {
-      case 'N':
-      case 'F':
-        return '*';
-      case 'D':
-        return '0';
-      case 'L':
-       return '?';
-      default:
-       return ' ';
+        case 'N':
+        case 'F':
+            return '*';
+        case 'D':
+            return '0';
+        case 'L':
+            return '?';
+        default:
+            return ' ';
     }
 }
 
@@ -774,93 +799,93 @@ static char DBFGetNullCharacter(char chType) {
 /*      are written.                                                    */
 /************************************************************************/
 
-int SHPAPI_CALL
-DBFAddNativeFieldType(DBFHandle psDBF, const char * pszFieldName,
-                      char chType, int nWidth, int nDecimals ) {
+int SHPAPI_CALL DBFAddNativeFieldType(DBFHandle psDBF, const char *pszFieldName,
+                                      char chType, int nWidth, int nDecimals)
+{
     /* make sure that everything is written in .dbf */
-    if( !DBFFlushRecord( psDBF ) )
+    if (!DBFFlushRecord(psDBF))
         return -1;
 
-    if( psDBF->nHeaderLength + XBASE_FLDHDR_SZ > 65535 )
+    if (psDBF->nHeaderLength + XBASE_FLDHDR_SZ > 65535)
     {
         char szMessage[128];
-        snprintf( szMessage, sizeof(szMessage),
-                  "Cannot add field %s. Header length limit reached "
-                  "(max 65535 bytes, 2046 fields).",
-                  pszFieldName );
-        psDBF->sHooks.Error( szMessage );
+        snprintf(szMessage, sizeof(szMessage),
+                 "Cannot add field %s. Header length limit reached "
+                 "(max 65535 bytes, 2046 fields).",
+                 pszFieldName);
+        psDBF->sHooks.Error(szMessage);
         return -1;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Do some checking to ensure we can add records to this file.     */
-/* -------------------------------------------------------------------- */
-    if( nWidth < 1 )
+    /* -------------------------------------------------------------------- */
+    /*      Do some checking to ensure we can add records to this file.     */
+    /* -------------------------------------------------------------------- */
+    if (nWidth < 1)
         return -1;
 
-    if( nWidth > XBASE_FLD_MAX_WIDTH )
+    if (nWidth > XBASE_FLD_MAX_WIDTH)
         nWidth = XBASE_FLD_MAX_WIDTH;
 
-    if( psDBF->nRecordLength + nWidth > 65535 )
+    if (psDBF->nRecordLength + nWidth > 65535)
     {
         char szMessage[128];
-        snprintf( szMessage, sizeof(szMessage),
-                  "Cannot add field %s. Record length limit reached "
-                  "(max 65535 bytes).",
-                  pszFieldName );
-        psDBF->sHooks.Error( szMessage );
+        snprintf(szMessage, sizeof(szMessage),
+                 "Cannot add field %s. Record length limit reached "
+                 "(max 65535 bytes).",
+                 pszFieldName);
+        psDBF->sHooks.Error(szMessage);
         return -1;
     }
 
     const int nOldRecordLength = psDBF->nRecordLength;
     const int nOldHeaderLength = psDBF->nHeaderLength;
 
-/* -------------------------------------------------------------------- */
-/*      realloc all the arrays larger to hold the additional field      */
-/*      information.                                                    */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      realloc all the arrays larger to hold the additional field      */
+    /*      information.                                                    */
+    /* -------------------------------------------------------------------- */
     psDBF->nFields++;
 
-    psDBF->panFieldOffset = STATIC_CAST(int *,
-        realloc( psDBF->panFieldOffset, sizeof(int) * psDBF->nFields ));
+    psDBF->panFieldOffset = STATIC_CAST(
+        int *, realloc(psDBF->panFieldOffset, sizeof(int) * psDBF->nFields));
 
-    psDBF->panFieldSize = STATIC_CAST(int *,
-        realloc( psDBF->panFieldSize, sizeof(int) * psDBF->nFields ));
+    psDBF->panFieldSize = STATIC_CAST(
+        int *, realloc(psDBF->panFieldSize, sizeof(int) * psDBF->nFields));
 
-    psDBF->panFieldDecimals = STATIC_CAST(int *,
-        realloc( psDBF->panFieldDecimals, sizeof(int) * psDBF->nFields ));
+    psDBF->panFieldDecimals = STATIC_CAST(
+        int *, realloc(psDBF->panFieldDecimals, sizeof(int) * psDBF->nFields));
 
-    psDBF->pachFieldType = STATIC_CAST(char *,
-        realloc( psDBF->pachFieldType, sizeof(char) * psDBF->nFields ));
+    psDBF->pachFieldType = STATIC_CAST(
+        char *, realloc(psDBF->pachFieldType, sizeof(char) * psDBF->nFields));
 
-/* -------------------------------------------------------------------- */
-/*      Assign the new field information fields.                        */
-/* -------------------------------------------------------------------- */
-    psDBF->panFieldOffset[psDBF->nFields-1] = psDBF->nRecordLength;
+    /* -------------------------------------------------------------------- */
+    /*      Assign the new field information fields.                        */
+    /* -------------------------------------------------------------------- */
+    psDBF->panFieldOffset[psDBF->nFields - 1] = psDBF->nRecordLength;
     psDBF->nRecordLength += nWidth;
-    psDBF->panFieldSize[psDBF->nFields-1] = nWidth;
-    psDBF->panFieldDecimals[psDBF->nFields-1] = nDecimals;
-    psDBF->pachFieldType[psDBF->nFields-1] = chType;
+    psDBF->panFieldSize[psDBF->nFields - 1] = nWidth;
+    psDBF->panFieldDecimals[psDBF->nFields - 1] = nDecimals;
+    psDBF->pachFieldType[psDBF->nFields - 1] = chType;
 
-/* -------------------------------------------------------------------- */
-/*      Extend the required header information.                         */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Extend the required header information.                         */
+    /* -------------------------------------------------------------------- */
     psDBF->nHeaderLength += XBASE_FLDHDR_SZ;
     psDBF->bUpdated = FALSE;
 
-    psDBF->pszHeader = STATIC_CAST(char *, realloc(psDBF->pszHeader,
-                                          psDBF->nFields*XBASE_FLDHDR_SZ));
+    psDBF->pszHeader = STATIC_CAST(
+        char *, realloc(psDBF->pszHeader, psDBF->nFields * XBASE_FLDHDR_SZ));
 
-    char *pszFInfo = psDBF->pszHeader + XBASE_FLDHDR_SZ * (psDBF->nFields-1);
+    char *pszFInfo = psDBF->pszHeader + XBASE_FLDHDR_SZ * (psDBF->nFields - 1);
 
-    for( int i = 0; i < XBASE_FLDHDR_SZ; i++ )
+    for (int i = 0; i < XBASE_FLDHDR_SZ; i++)
         pszFInfo[i] = '\0';
 
-    strncpy( pszFInfo, pszFieldName, XBASE_FLDNAME_LEN_WRITE );
+    strncpy(pszFInfo, pszFieldName, XBASE_FLDNAME_LEN_WRITE);
 
-    pszFInfo[11] = psDBF->pachFieldType[psDBF->nFields-1];
+    pszFInfo[11] = psDBF->pachFieldType[psDBF->nFields - 1];
 
-    if( chType == 'C' )
+    if (chType == 'C')
     {
         pszFInfo[16] = STATIC_CAST(unsigned char, nWidth % 256);
         pszFInfo[17] = STATIC_CAST(unsigned char, nWidth / 256);
@@ -871,56 +896,61 @@ DBFAddNativeFieldType(DBFHandle psDBF, const char * pszFieldName,
         pszFInfo[17] = STATIC_CAST(unsigned char, nDecimals);
     }
 
-/* -------------------------------------------------------------------- */
-/*      Make the current record buffer appropriately larger.            */
-/* -------------------------------------------------------------------- */
-    psDBF->pszCurrentRecord = STATIC_CAST(char *, realloc(psDBF->pszCurrentRecord,
-                                                 psDBF->nRecordLength));
+    /* -------------------------------------------------------------------- */
+    /*      Make the current record buffer appropriately larger.            */
+    /* -------------------------------------------------------------------- */
+    psDBF->pszCurrentRecord = STATIC_CAST(
+        char *, realloc(psDBF->pszCurrentRecord, psDBF->nRecordLength));
 
     /* we're done if dealing with new .dbf */
-    if( psDBF->bNoHeader )
-        return( psDBF->nFields - 1 );
+    if (psDBF->bNoHeader)
+        return (psDBF->nFields - 1);
 
-/* -------------------------------------------------------------------- */
-/*      For existing .dbf file, shift records                           */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      For existing .dbf file, shift records                           */
+    /* -------------------------------------------------------------------- */
 
     /* alloc record */
-    char *pszRecord = STATIC_CAST(char *, malloc(sizeof(char) * psDBF->nRecordLength));
+    char *pszRecord =
+        STATIC_CAST(char *, malloc(sizeof(char) * psDBF->nRecordLength));
 
     const char chFieldFill = DBFGetNullCharacter(chType);
 
     SAOffset nRecordOffset;
-    for (int i = psDBF->nRecords-1; i >= 0; --i)
+    for (int i = psDBF->nRecords - 1; i >= 0; --i)
     {
-        nRecordOffset = nOldRecordLength * STATIC_CAST(SAOffset, i) + nOldHeaderLength;
+        nRecordOffset =
+            nOldRecordLength * STATIC_CAST(SAOffset, i) + nOldHeaderLength;
 
         /* load record */
-        psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
-        if (psDBF->sHooks.FRead(pszRecord, nOldRecordLength, 1, psDBF->fp) != 1) {
-          free(pszRecord);
-          return -1;
+        psDBF->sHooks.FSeek(psDBF->fp, nRecordOffset, 0);
+        if (psDBF->sHooks.FRead(pszRecord, nOldRecordLength, 1, psDBF->fp) != 1)
+        {
+            free(pszRecord);
+            return -1;
         }
 
         /* set new field's value to NULL */
         memset(pszRecord + nOldRecordLength, chFieldFill, nWidth);
 
-        nRecordOffset = psDBF->nRecordLength * STATIC_CAST(SAOffset, i) + psDBF->nHeaderLength;
+        nRecordOffset = psDBF->nRecordLength * STATIC_CAST(SAOffset, i) +
+                        psDBF->nHeaderLength;
 
         /* move record to the new place*/
-        psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
-        psDBF->sHooks.FWrite( pszRecord, psDBF->nRecordLength, 1, psDBF->fp );
+        psDBF->sHooks.FSeek(psDBF->fp, nRecordOffset, 0);
+        psDBF->sHooks.FWrite(pszRecord, psDBF->nRecordLength, 1, psDBF->fp);
     }
 
-    if( psDBF->bWriteEndOfFileChar )
+    if (psDBF->bWriteEndOfFileChar)
     {
         char ch = END_OF_FILE_CHARACTER;
 
         nRecordOffset =
-            psDBF->nRecordLength * STATIC_CAST(SAOffset,psDBF->nRecords) + psDBF->nHeaderLength;
+            psDBF->nRecordLength * STATIC_CAST(SAOffset, psDBF->nRecords) +
+            psDBF->nHeaderLength;
 
-        psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
-        psDBF->sHooks.FWrite( &ch, 1, 1, psDBF->fp );
+        psDBF->sHooks.FSeek(psDBF->fp, nRecordOffset, 0);
+        psDBF->sHooks.FWrite(&ch, 1, 1, psDBF->fp);
     }
 
     /* free record */
@@ -928,13 +958,13 @@ DBFAddNativeFieldType(DBFHandle psDBF, const char * pszFieldName,
 
     /* force update of header with new header, record length and new field */
     psDBF->bNoHeader = TRUE;
-    DBFUpdateHeader( psDBF );
+    DBFUpdateHeader(psDBF);
 
     psDBF->nCurrentRecord = -1;
     psDBF->bCurrentRecordModified = FALSE;
     psDBF->bUpdated = TRUE;
 
-    return( psDBF->nFields-1 );
+    return (psDBF->nFields - 1);
 }
 
 /************************************************************************/
@@ -944,59 +974,64 @@ DBFAddNativeFieldType(DBFHandle psDBF, const char * pszFieldName,
 /************************************************************************/
 
 static void *DBFReadAttribute(DBFHandle psDBF, int hEntity, int iField,
-                              char chReqType ) {
-/* -------------------------------------------------------------------- */
-/*      Verify selection.                                               */
-/* -------------------------------------------------------------------- */
-    if( hEntity < 0 || hEntity >= psDBF->nRecords )
+                              char chReqType)
+{
+    /* -------------------------------------------------------------------- */
+    /*      Verify selection.                                               */
+    /* -------------------------------------------------------------------- */
+    if (hEntity < 0 || hEntity >= psDBF->nRecords)
         return SHPLIB_NULLPTR;
 
-    if( iField < 0 || iField >= psDBF->nFields )
+    if (iField < 0 || iField >= psDBF->nFields)
         return SHPLIB_NULLPTR;
 
-/* -------------------------------------------------------------------- */
-/*	Have we read the record?					*/
-/* -------------------------------------------------------------------- */
-    if( !DBFLoadRecord( psDBF, hEntity ) )
+    /* -------------------------------------------------------------------- */
+    /*	Have we read the record?					*/
+    /* -------------------------------------------------------------------- */
+    if (!DBFLoadRecord(psDBF, hEntity))
         return SHPLIB_NULLPTR;
 
-    unsigned char *pabyRec = REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
+    unsigned char *pabyRec =
+        REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
 
-/* -------------------------------------------------------------------- */
-/*      Ensure we have room to extract the target field.                */
-/* -------------------------------------------------------------------- */
-    if( psDBF->panFieldSize[iField] >= psDBF->nWorkFieldLength )
+    /* -------------------------------------------------------------------- */
+    /*      Ensure we have room to extract the target field.                */
+    /* -------------------------------------------------------------------- */
+    if (psDBF->panFieldSize[iField] >= psDBF->nWorkFieldLength)
     {
         psDBF->nWorkFieldLength = psDBF->panFieldSize[iField] + 100;
-        if( psDBF->pszWorkField == SHPLIB_NULLPTR )
-            psDBF->pszWorkField = STATIC_CAST(char *, malloc(psDBF->nWorkFieldLength));
+        if (psDBF->pszWorkField == SHPLIB_NULLPTR)
+            psDBF->pszWorkField =
+                STATIC_CAST(char *, malloc(psDBF->nWorkFieldLength));
         else
-            psDBF->pszWorkField = STATIC_CAST(char *, realloc(psDBF->pszWorkField,
-                                                   psDBF->nWorkFieldLength));
+            psDBF->pszWorkField = STATIC_CAST(
+                char *, realloc(psDBF->pszWorkField, psDBF->nWorkFieldLength));
     }
 
-/* -------------------------------------------------------------------- */
-/*	Extract the requested field.					*/
-/* -------------------------------------------------------------------- */
-    memcpy( psDBF->pszWorkField,
-	     REINTERPRET_CAST(const char *, pabyRec) + psDBF->panFieldOffset[iField],
-	     psDBF->panFieldSize[iField] );
+    /* -------------------------------------------------------------------- */
+    /*	Extract the requested field.					*/
+    /* -------------------------------------------------------------------- */
+    memcpy(psDBF->pszWorkField,
+           REINTERPRET_CAST(const char *, pabyRec) +
+               psDBF->panFieldOffset[iField],
+           psDBF->panFieldSize[iField]);
     psDBF->pszWorkField[psDBF->panFieldSize[iField]] = '\0';
 
     void *pReturnField = psDBF->pszWorkField;
 
-/* -------------------------------------------------------------------- */
-/*      Decode the field.                                               */
-/* -------------------------------------------------------------------- */
-    if( chReqType == 'I' )
+    /* -------------------------------------------------------------------- */
+    /*      Decode the field.                                               */
+    /* -------------------------------------------------------------------- */
+    if (chReqType == 'I')
     {
         psDBF->fieldValue.nIntField = atoi(psDBF->pszWorkField);
 
         pReturnField = &(psDBF->fieldValue.nIntField);
     }
-    else if( chReqType == 'N' )
+    else if (chReqType == 'N')
     {
-        psDBF->fieldValue.dfDoubleField = psDBF->sHooks.Atof(psDBF->pszWorkField);
+        psDBF->fieldValue.dfDoubleField =
+            psDBF->sHooks.Atof(psDBF->pszWorkField);
 
         pReturnField = &(psDBF->fieldValue.dfDoubleField);
     }
@@ -1010,14 +1045,14 @@ static void *DBFReadAttribute(DBFHandle psDBF, int hEntity, int iField,
         char *pchSrc = psDBF->pszWorkField;
         char *pchDst = pchSrc;
 
-        while( *pchSrc == ' ' )
+        while (*pchSrc == ' ')
             pchSrc++;
 
-        while( *pchSrc != '\0' )
+        while (*pchSrc != '\0')
             *(pchDst++) = *(pchSrc++);
         *pchDst = '\0';
 
-        while( pchDst != psDBF->pszWorkField && *(--pchDst) == ' ' )
+        while (pchDst != psDBF->pszWorkField && *(--pchDst) == ' ')
             *pchDst = '\0';
     }
 #endif
@@ -1031,11 +1066,13 @@ static void *DBFReadAttribute(DBFHandle psDBF, int hEntity, int iField,
 /*      Read an integer attribute.                                      */
 /************************************************************************/
 
-int SHPAPI_CALL
-DBFReadIntegerAttribute( DBFHandle psDBF, int iRecord, int iField ) {
-    int	*pnValue = STATIC_CAST(int *, DBFReadAttribute( psDBF, iRecord, iField, 'I' ));
+int SHPAPI_CALL DBFReadIntegerAttribute(DBFHandle psDBF, int iRecord,
+                                        int iField)
+{
+    int *pnValue =
+        STATIC_CAST(int *, DBFReadAttribute(psDBF, iRecord, iField, 'I'));
 
-    if( pnValue == SHPLIB_NULLPTR )
+    if (pnValue == SHPLIB_NULLPTR)
         return 0;
     else
         return *pnValue;
@@ -1047,14 +1084,16 @@ DBFReadIntegerAttribute( DBFHandle psDBF, int iRecord, int iField ) {
 /*      Read a double attribute.                                        */
 /************************************************************************/
 
-double SHPAPI_CALL
-DBFReadDoubleAttribute( DBFHandle psDBF, int iRecord, int iField ) {
-    double *pdValue = STATIC_CAST(double *, DBFReadAttribute( psDBF, iRecord, iField, 'N' ));
+double SHPAPI_CALL DBFReadDoubleAttribute(DBFHandle psDBF, int iRecord,
+                                          int iField)
+{
+    double *pdValue =
+        STATIC_CAST(double *, DBFReadAttribute(psDBF, iRecord, iField, 'N'));
 
-    if( pdValue == SHPLIB_NULLPTR )
+    if (pdValue == SHPLIB_NULLPTR)
         return 0.0;
     else
-        return *pdValue ;
+        return *pdValue;
 }
 
 /************************************************************************/
@@ -1064,10 +1103,11 @@ DBFReadDoubleAttribute( DBFHandle psDBF, int iRecord, int iField ) {
 /************************************************************************/
 
 const char SHPAPI_CALL1(*)
-DBFReadStringAttribute( DBFHandle psDBF, int iRecord, int iField )
+    DBFReadStringAttribute(DBFHandle psDBF, int iRecord, int iField)
 
 {
-    return STATIC_CAST(const char *, DBFReadAttribute( psDBF, iRecord, iField, 'C' ) );
+    return STATIC_CAST(const char *,
+                       DBFReadAttribute(psDBF, iRecord, iField, 'C'));
 }
 
 /************************************************************************/
@@ -1077,12 +1117,12 @@ DBFReadStringAttribute( DBFHandle psDBF, int iRecord, int iField )
 /************************************************************************/
 
 const char SHPAPI_CALL1(*)
-DBFReadLogicalAttribute( DBFHandle psDBF, int iRecord, int iField )
+    DBFReadLogicalAttribute(DBFHandle psDBF, int iRecord, int iField)
 
 {
-    return STATIC_CAST(const char *, DBFReadAttribute( psDBF, iRecord, iField, 'L' ) );
+    return STATIC_CAST(const char *,
+                       DBFReadAttribute(psDBF, iRecord, iField, 'L'));
 }
-
 
 /************************************************************************/
 /*                         DBFIsValueNULL()                             */
@@ -1090,40 +1130,41 @@ DBFReadLogicalAttribute( DBFHandle psDBF, int iRecord, int iField )
 /*      Return TRUE if the passed string is NULL.                       */
 /************************************************************************/
 
-static bool DBFIsValueNULL( char chType, const char* pszValue ) {
-    if( pszValue == SHPLIB_NULLPTR )
+static bool DBFIsValueNULL(char chType, const char *pszValue)
+{
+    if (pszValue == SHPLIB_NULLPTR)
         return true;
 
-    switch(chType)
+    switch (chType)
     {
-      case 'N':
-      case 'F':
-        /*
+        case 'N':
+        case 'F':
+            /*
         ** We accept all asterisks or all blanks as NULL
         ** though according to the spec I think it should be all
         ** asterisks.
         */
-        if( pszValue[0] == '*' )
+            if (pszValue[0] == '*')
+                return true;
+
+            for (int i = 0; pszValue[i] != '\0'; i++)
+            {
+                if (pszValue[i] != ' ')
+                    return false;
+            }
             return true;
 
-        for( int i = 0; pszValue[i] != '\0'; i++ )
-        {
-            if( pszValue[i] != ' ' )
-                return false;
-        }
-        return true;
+        case 'D':
+            /* NULL date fields have value "00000000" */
+            return strncmp(pszValue, "00000000", 8) == 0;
 
-      case 'D':
-        /* NULL date fields have value "00000000" */
-        return strncmp(pszValue,"00000000",8) == 0;
+        case 'L':
+            /* NULL boolean fields have value "?" */
+            return pszValue[0] == '?';
 
-      case 'L':
-        /* NULL boolean fields have value "?" */
-        return pszValue[0] == '?';
-
-      default:
-        /* empty string fields are considered NULL */
-        return strlen(pszValue) == 0;
+        default:
+            /* empty string fields are considered NULL */
+            return strlen(pszValue) == 0;
     }
 }
 
@@ -1135,14 +1176,14 @@ static bool DBFIsValueNULL( char chType, const char* pszValue ) {
 /*      Contributed by Jim Matthews.                                    */
 /************************************************************************/
 
-int SHPAPI_CALL
-DBFIsAttributeNULL( DBFHandle psDBF, int iRecord, int iField ) {
-    const char *pszValue = DBFReadStringAttribute( psDBF, iRecord, iField );
+int SHPAPI_CALL DBFIsAttributeNULL(DBFHandle psDBF, int iRecord, int iField)
+{
+    const char *pszValue = DBFReadStringAttribute(psDBF, iRecord, iField);
 
-    if( pszValue == SHPLIB_NULLPTR )
+    if (pszValue == SHPLIB_NULLPTR)
         return TRUE;
 
-    return DBFIsValueNULL( psDBF->pachFieldType[iField], pszValue );
+    return DBFIsValueNULL(psDBF->pachFieldType[iField], pszValue);
 }
 
 /************************************************************************/
@@ -1151,11 +1192,10 @@ DBFIsAttributeNULL( DBFHandle psDBF, int iRecord, int iField ) {
 /*      Return the number of fields in this table.                      */
 /************************************************************************/
 
-int SHPAPI_CALL
-DBFGetFieldCount( DBFHandle psDBF )
+int SHPAPI_CALL DBFGetFieldCount(DBFHandle psDBF)
 
 {
-    return( psDBF->nFields );
+    return (psDBF->nFields);
 }
 
 /************************************************************************/
@@ -1164,11 +1204,10 @@ DBFGetFieldCount( DBFHandle psDBF )
 /*      Return the number of records in this table.                     */
 /************************************************************************/
 
-int SHPAPI_CALL
-DBFGetRecordCount( DBFHandle psDBF )
+int SHPAPI_CALL DBFGetRecordCount(DBFHandle psDBF)
 
 {
-    return( psDBF->nRecords );
+    return (psDBF->nRecords);
 }
 
 /************************************************************************/
@@ -1179,47 +1218,50 @@ DBFGetRecordCount( DBFHandle psDBF )
 /*      bytes long.                                                     */
 /************************************************************************/
 
-DBFFieldType SHPAPI_CALL
-DBFGetFieldInfo( DBFHandle psDBF, int iField, char * pszFieldName,
-                 int * pnWidth, int * pnDecimals )
+DBFFieldType SHPAPI_CALL DBFGetFieldInfo(DBFHandle psDBF, int iField,
+                                         char *pszFieldName, int *pnWidth,
+                                         int *pnDecimals)
 
 {
-    if( iField < 0 || iField >= psDBF->nFields )
-        return( FTInvalid );
+    if (iField < 0 || iField >= psDBF->nFields)
+        return (FTInvalid);
 
-    if( pnWidth != SHPLIB_NULLPTR )
+    if (pnWidth != SHPLIB_NULLPTR)
         *pnWidth = psDBF->panFieldSize[iField];
 
-    if( pnDecimals != SHPLIB_NULLPTR )
+    if (pnDecimals != SHPLIB_NULLPTR)
         *pnDecimals = psDBF->panFieldDecimals[iField];
 
-    if( pszFieldName != SHPLIB_NULLPTR )
+    if (pszFieldName != SHPLIB_NULLPTR)
     {
-	strncpy( pszFieldName, STATIC_CAST(char *,psDBF->pszHeader)+iField*XBASE_FLDHDR_SZ,
-                 XBASE_FLDNAME_LEN_READ );
-	pszFieldName[XBASE_FLDNAME_LEN_READ] = '\0';
-	for( int i = XBASE_FLDNAME_LEN_READ - 1; i > 0 && pszFieldName[i] == ' '; i-- )
-	    pszFieldName[i] = '\0';
+        strncpy(pszFieldName,
+                STATIC_CAST(char *, psDBF->pszHeader) +
+                    iField * XBASE_FLDHDR_SZ,
+                XBASE_FLDNAME_LEN_READ);
+        pszFieldName[XBASE_FLDNAME_LEN_READ] = '\0';
+        for (int i = XBASE_FLDNAME_LEN_READ - 1;
+             i > 0 && pszFieldName[i] == ' '; i--)
+            pszFieldName[i] = '\0';
     }
 
-    if ( psDBF->pachFieldType[iField] == 'L' )
-	return( FTLogical );
+    if (psDBF->pachFieldType[iField] == 'L')
+        return (FTLogical);
 
-    else if( psDBF->pachFieldType[iField] == 'D' )
-	return( FTDate );
+    else if (psDBF->pachFieldType[iField] == 'D')
+        return (FTDate);
 
-    else if( psDBF->pachFieldType[iField] == 'N'
-             || psDBF->pachFieldType[iField] == 'F' )
+    else if (psDBF->pachFieldType[iField] == 'N' ||
+             psDBF->pachFieldType[iField] == 'F')
     {
-	if( psDBF->panFieldDecimals[iField] > 0
-            || psDBF->panFieldSize[iField] >= 10 )
-	    return( FTDouble );
-	else
-	    return( FTInteger );
+        if (psDBF->panFieldDecimals[iField] > 0 ||
+            psDBF->panFieldSize[iField] >= 10)
+            return (FTDouble);
+        else
+            return (FTInteger);
     }
     else
     {
-	return( FTString );
+        return (FTString);
     }
 }
 
@@ -1230,113 +1272,122 @@ DBFGetFieldInfo( DBFHandle psDBF, int iField, char * pszFieldName,
 /************************************************************************/
 
 static bool DBFWriteAttribute(DBFHandle psDBF, int hEntity, int iField,
-			     void * pValue ) {
-/* -------------------------------------------------------------------- */
-/*	Is this a valid record?						*/
-/* -------------------------------------------------------------------- */
-    if( hEntity < 0 || hEntity > psDBF->nRecords )
+                              void *pValue)
+{
+    /* -------------------------------------------------------------------- */
+    /*	Is this a valid record?						*/
+    /* -------------------------------------------------------------------- */
+    if (hEntity < 0 || hEntity > psDBF->nRecords)
         return false;
 
-    if( psDBF->bNoHeader )
+    if (psDBF->bNoHeader)
         DBFWriteHeader(psDBF);
 
-/* -------------------------------------------------------------------- */
-/*      Is this a brand new record?                                     */
-/* -------------------------------------------------------------------- */
-    if( hEntity == psDBF->nRecords )
+    /* -------------------------------------------------------------------- */
+    /*      Is this a brand new record?                                     */
+    /* -------------------------------------------------------------------- */
+    if (hEntity == psDBF->nRecords)
     {
-	if( !DBFFlushRecord( psDBF ) )
+        if (!DBFFlushRecord(psDBF))
             return false;
 
-	psDBF->nRecords++;
-	for( int i = 0; i < psDBF->nRecordLength; i++ )
-	    psDBF->pszCurrentRecord[i] = ' ';
+        psDBF->nRecords++;
+        for (int i = 0; i < psDBF->nRecordLength; i++)
+            psDBF->pszCurrentRecord[i] = ' ';
 
-	psDBF->nCurrentRecord = hEntity;
+        psDBF->nCurrentRecord = hEntity;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Is this an existing record, but different than the last one     */
-/*      we accessed?                                                    */
-/* -------------------------------------------------------------------- */
-    if( !DBFLoadRecord( psDBF, hEntity ) )
+    /* -------------------------------------------------------------------- */
+    /*      Is this an existing record, but different than the last one     */
+    /*      we accessed?                                                    */
+    /* -------------------------------------------------------------------- */
+    if (!DBFLoadRecord(psDBF, hEntity))
         return false;
 
-    unsigned char *pabyRec = REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
+    unsigned char *pabyRec =
+        REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
 
     psDBF->bCurrentRecordModified = TRUE;
     psDBF->bUpdated = TRUE;
 
-/* -------------------------------------------------------------------- */
-/*      Translate NULL value to valid DBF file representation.          */
-/*                                                                      */
-/*      Contributed by Jim Matthews.                                    */
-/* -------------------------------------------------------------------- */
-    if( pValue == SHPLIB_NULLPTR )
+    /* -------------------------------------------------------------------- */
+    /*      Translate NULL value to valid DBF file representation.          */
+    /*                                                                      */
+    /*      Contributed by Jim Matthews.                                    */
+    /* -------------------------------------------------------------------- */
+    if (pValue == SHPLIB_NULLPTR)
     {
-        memset( pabyRec+psDBF->panFieldOffset[iField],
-                DBFGetNullCharacter(psDBF->pachFieldType[iField]),
-                psDBF->panFieldSize[iField] );
+        memset(pabyRec + psDBF->panFieldOffset[iField],
+               DBFGetNullCharacter(psDBF->pachFieldType[iField]),
+               psDBF->panFieldSize[iField]);
         return true;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Assign all the record fields.                                   */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Assign all the record fields.                                   */
+    /* -------------------------------------------------------------------- */
     bool nRetResult = true;
 
-    switch( psDBF->pachFieldType[iField] )
+    switch (psDBF->pachFieldType[iField])
     {
-      case 'D':
-      case 'N':
-      case 'F':
-      {
-        int nWidth = psDBF->panFieldSize[iField];
-
-        char szSField[XBASE_FLD_MAX_WIDTH+1];
-        if( STATIC_CAST(int,sizeof(szSField))-2 < nWidth )
-            nWidth = sizeof(szSField)-2;
-
-        char szFormat[20];
-        snprintf( szFormat, sizeof(szFormat), "%%%d.%df",
-                    nWidth, psDBF->panFieldDecimals[iField] );
-        CPLsnprintf(szSField, sizeof(szSField), szFormat, *STATIC_CAST(double *, pValue) );
-        szSField[sizeof(szSField)-1] = '\0';
-        if( STATIC_CAST(int,strlen(szSField)) > psDBF->panFieldSize[iField] )
+        case 'D':
+        case 'N':
+        case 'F':
         {
-            szSField[psDBF->panFieldSize[iField]] = '\0';
-            nRetResult = false;
-        }
-        memcpy(REINTERPRET_CAST(char *, pabyRec+psDBF->panFieldOffset[iField]),
-            szSField, strlen(szSField) );
-        break;
-      }
+            int nWidth = psDBF->panFieldSize[iField];
 
-      case 'L':
-        if (psDBF->panFieldSize[iField] >= 1  &&
-            (*STATIC_CAST(char*,pValue) == 'F' || *STATIC_CAST(char*,pValue) == 'T'))
-            *(pabyRec+psDBF->panFieldOffset[iField]) = *STATIC_CAST(char*,pValue);
-        break;
+            char szSField[XBASE_FLD_MAX_WIDTH + 1];
+            if (STATIC_CAST(int, sizeof(szSField)) - 2 < nWidth)
+                nWidth = sizeof(szSField) - 2;
 
-      default:
-      {
-        int j;
-	if( STATIC_CAST(int, strlen(STATIC_CAST(char *,pValue))) > psDBF->panFieldSize[iField] )
-        {
-	    j = psDBF->panFieldSize[iField];
-            nRetResult = false;
-        }
-	else
-        {
-            memset( pabyRec+psDBF->panFieldOffset[iField], ' ',
-                    psDBF->panFieldSize[iField] );
-	    j = STATIC_CAST(int, strlen(STATIC_CAST(char *,pValue)));
+            char szFormat[20];
+            snprintf(szFormat, sizeof(szFormat), "%%%d.%df", nWidth,
+                     psDBF->panFieldDecimals[iField]);
+            CPLsnprintf(szSField, sizeof(szSField), szFormat,
+                        *STATIC_CAST(double *, pValue));
+            szSField[sizeof(szSField) - 1] = '\0';
+            if (STATIC_CAST(int, strlen(szSField)) >
+                psDBF->panFieldSize[iField])
+            {
+                szSField[psDBF->panFieldSize[iField]] = '\0';
+                nRetResult = false;
+            }
+            memcpy(REINTERPRET_CAST(char *,
+                                    pabyRec + psDBF->panFieldOffset[iField]),
+                   szSField, strlen(szSField));
+            break;
         }
 
-	strncpy(REINTERPRET_CAST(char *, pabyRec+psDBF->panFieldOffset[iField]),
-		STATIC_CAST(const char *, pValue), j );
-	break;
-      }
+        case 'L':
+            if (psDBF->panFieldSize[iField] >= 1 &&
+                (*STATIC_CAST(char *, pValue) == 'F' ||
+                 *STATIC_CAST(char *, pValue) == 'T'))
+                *(pabyRec + psDBF->panFieldOffset[iField]) =
+                    *STATIC_CAST(char *, pValue);
+            break;
+
+        default:
+        {
+            int j;
+            if (STATIC_CAST(int, strlen(STATIC_CAST(char *, pValue))) >
+                psDBF->panFieldSize[iField])
+            {
+                j = psDBF->panFieldSize[iField];
+                nRetResult = false;
+            }
+            else
+            {
+                memset(pabyRec + psDBF->panFieldOffset[iField], ' ',
+                       psDBF->panFieldSize[iField]);
+                j = STATIC_CAST(int, strlen(STATIC_CAST(char *, pValue)));
+            }
+
+            strncpy(REINTERPRET_CAST(char *,
+                                     pabyRec + psDBF->panFieldOffset[iField]),
+                    STATIC_CAST(const char *, pValue), j);
+            break;
+        }
     }
 
     return nRetResult;
@@ -1350,62 +1401,64 @@ static bool DBFWriteAttribute(DBFHandle psDBF, int hEntity, int iField,
 /*      as is to the field position in the record.                      */
 /************************************************************************/
 
-int SHPAPI_CALL
-DBFWriteAttributeDirectly(DBFHandle psDBF, int hEntity, int iField,
-                              void * pValue ) {
-/* -------------------------------------------------------------------- */
-/*	Is this a valid record?						*/
-/* -------------------------------------------------------------------- */
-    if( hEntity < 0 || hEntity > psDBF->nRecords )
-        return( FALSE );
+int SHPAPI_CALL DBFWriteAttributeDirectly(DBFHandle psDBF, int hEntity,
+                                          int iField, void *pValue)
+{
+    /* -------------------------------------------------------------------- */
+    /*	Is this a valid record?						*/
+    /* -------------------------------------------------------------------- */
+    if (hEntity < 0 || hEntity > psDBF->nRecords)
+        return (FALSE);
 
-    if( psDBF->bNoHeader )
+    if (psDBF->bNoHeader)
         DBFWriteHeader(psDBF);
 
-/* -------------------------------------------------------------------- */
-/*      Is this a brand new record?                                     */
-/* -------------------------------------------------------------------- */
-    if( hEntity == psDBF->nRecords )
+    /* -------------------------------------------------------------------- */
+    /*      Is this a brand new record?                                     */
+    /* -------------------------------------------------------------------- */
+    if (hEntity == psDBF->nRecords)
     {
-	if( !DBFFlushRecord( psDBF ) )
+        if (!DBFFlushRecord(psDBF))
             return FALSE;
 
-	psDBF->nRecords++;
-	for( int i = 0; i < psDBF->nRecordLength; i++ )
-	    psDBF->pszCurrentRecord[i] = ' ';
+        psDBF->nRecords++;
+        for (int i = 0; i < psDBF->nRecordLength; i++)
+            psDBF->pszCurrentRecord[i] = ' ';
 
-	psDBF->nCurrentRecord = hEntity;
+        psDBF->nCurrentRecord = hEntity;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Is this an existing record, but different than the last one     */
-/*      we accessed?                                                    */
-/* -------------------------------------------------------------------- */
-    if( !DBFLoadRecord( psDBF, hEntity ) )
+    /* -------------------------------------------------------------------- */
+    /*      Is this an existing record, but different than the last one     */
+    /*      we accessed?                                                    */
+    /* -------------------------------------------------------------------- */
+    if (!DBFLoadRecord(psDBF, hEntity))
         return FALSE;
 
-    unsigned char *pabyRec = REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
+    unsigned char *pabyRec =
+        REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
 
-/* -------------------------------------------------------------------- */
-/*      Assign all the record fields.                                   */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Assign all the record fields.                                   */
+    /* -------------------------------------------------------------------- */
     int j;
-    if( STATIC_CAST(int, strlen(STATIC_CAST(char *, pValue))) > psDBF->panFieldSize[iField] )
+    if (STATIC_CAST(int, strlen(STATIC_CAST(char *, pValue))) >
+        psDBF->panFieldSize[iField])
         j = psDBF->panFieldSize[iField];
     else
     {
-        memset( pabyRec+psDBF->panFieldOffset[iField], ' ',
-                psDBF->panFieldSize[iField] );
+        memset(pabyRec + psDBF->panFieldOffset[iField], ' ',
+               psDBF->panFieldSize[iField]);
         j = STATIC_CAST(int, strlen(STATIC_CAST(char *, pValue)));
     }
 
-    strncpy(REINTERPRET_CAST(char *, pabyRec+psDBF->panFieldOffset[iField]),
-            STATIC_CAST(const char *, pValue), j );
+    strncpy(REINTERPRET_CAST(char *, pabyRec + psDBF->panFieldOffset[iField]),
+            STATIC_CAST(const char *, pValue), j);
 
     psDBF->bCurrentRecordModified = TRUE;
     psDBF->bUpdated = TRUE;
 
-    return( TRUE );
+    return (TRUE);
 }
 
 /************************************************************************/
@@ -1414,10 +1467,11 @@ DBFWriteAttributeDirectly(DBFHandle psDBF, int hEntity, int iField,
 /*      Write a double attribute.                                       */
 /************************************************************************/
 
-int SHPAPI_CALL
-DBFWriteDoubleAttribute( DBFHandle psDBF, int iRecord, int iField,
-                         double dValue ) {
-    return( DBFWriteAttribute( psDBF, iRecord, iField, STATIC_CAST(void *, &dValue) ) );
+int SHPAPI_CALL DBFWriteDoubleAttribute(DBFHandle psDBF, int iRecord,
+                                        int iField, double dValue)
+{
+    return (DBFWriteAttribute(psDBF, iRecord, iField,
+                              STATIC_CAST(void *, &dValue)));
 }
 
 /************************************************************************/
@@ -1426,12 +1480,13 @@ DBFWriteDoubleAttribute( DBFHandle psDBF, int iRecord, int iField,
 /*      Write a integer attribute.                                      */
 /************************************************************************/
 
-int SHPAPI_CALL
-DBFWriteIntegerAttribute( DBFHandle psDBF, int iRecord, int iField,
-                          int nValue ) {
+int SHPAPI_CALL DBFWriteIntegerAttribute(DBFHandle psDBF, int iRecord,
+                                         int iField, int nValue)
+{
     double dValue = nValue;
 
-    return( DBFWriteAttribute( psDBF, iRecord, iField, STATIC_CAST(void *, &dValue) ) );
+    return (DBFWriteAttribute(psDBF, iRecord, iField,
+                              STATIC_CAST(void *, &dValue)));
 }
 
 /************************************************************************/
@@ -1440,12 +1495,13 @@ DBFWriteIntegerAttribute( DBFHandle psDBF, int iRecord, int iField,
 /*      Write a string attribute.                                       */
 /************************************************************************/
 
-int SHPAPI_CALL
-DBFWriteStringAttribute( DBFHandle psDBF, int iRecord, int iField,
-                         const char * pszValue )
+int SHPAPI_CALL DBFWriteStringAttribute(DBFHandle psDBF, int iRecord,
+                                        int iField, const char *pszValue)
 
 {
-    return( DBFWriteAttribute( psDBF, iRecord, iField, STATIC_CAST(void *, CONST_CAST(char*, pszValue))) );
+    return (
+        DBFWriteAttribute(psDBF, iRecord, iField,
+                          STATIC_CAST(void *, CONST_CAST(char *, pszValue))));
 }
 
 /************************************************************************/
@@ -1454,11 +1510,10 @@ DBFWriteStringAttribute( DBFHandle psDBF, int iRecord, int iField,
 /*      Write a string attribute.                                       */
 /************************************************************************/
 
-int SHPAPI_CALL
-DBFWriteNULLAttribute( DBFHandle psDBF, int iRecord, int iField )
+int SHPAPI_CALL DBFWriteNULLAttribute(DBFHandle psDBF, int iRecord, int iField)
 
 {
-    return( DBFWriteAttribute( psDBF, iRecord, iField, SHPLIB_NULLPTR ) );
+    return (DBFWriteAttribute(psDBF, iRecord, iField, SHPLIB_NULLPTR));
 }
 
 /************************************************************************/
@@ -1467,12 +1522,13 @@ DBFWriteNULLAttribute( DBFHandle psDBF, int iRecord, int iField )
 /*      Write a logical attribute.                                      */
 /************************************************************************/
 
-int SHPAPI_CALL
-DBFWriteLogicalAttribute( DBFHandle psDBF, int iRecord, int iField,
-		       const char lValue)
+int SHPAPI_CALL DBFWriteLogicalAttribute(DBFHandle psDBF, int iRecord,
+                                         int iField, const char lValue)
 
 {
-    return( DBFWriteAttribute( psDBF, iRecord, iField, STATIC_CAST(void *, CONST_CAST(char*, &lValue)) ) );
+    return (
+        DBFWriteAttribute(psDBF, iRecord, iField,
+                          STATIC_CAST(void *, CONST_CAST(char *, &lValue))));
 }
 
 /************************************************************************/
@@ -1481,47 +1537,48 @@ DBFWriteLogicalAttribute( DBFHandle psDBF, int iRecord, int iField,
 /*	Write an attribute record to the file.				*/
 /************************************************************************/
 
-int SHPAPI_CALL
-DBFWriteTuple(DBFHandle psDBF, int hEntity, void * pRawTuple ) {
-/* -------------------------------------------------------------------- */
-/*	Is this a valid record?						*/
-/* -------------------------------------------------------------------- */
-    if( hEntity < 0 || hEntity > psDBF->nRecords )
-        return( FALSE );
+int SHPAPI_CALL DBFWriteTuple(DBFHandle psDBF, int hEntity, void *pRawTuple)
+{
+    /* -------------------------------------------------------------------- */
+    /*	Is this a valid record?						*/
+    /* -------------------------------------------------------------------- */
+    if (hEntity < 0 || hEntity > psDBF->nRecords)
+        return (FALSE);
 
-    if( psDBF->bNoHeader )
+    if (psDBF->bNoHeader)
         DBFWriteHeader(psDBF);
 
-/* -------------------------------------------------------------------- */
-/*      Is this a brand new record?                                     */
-/* -------------------------------------------------------------------- */
-    if( hEntity == psDBF->nRecords )
+    /* -------------------------------------------------------------------- */
+    /*      Is this a brand new record?                                     */
+    /* -------------------------------------------------------------------- */
+    if (hEntity == psDBF->nRecords)
     {
-	if( !DBFFlushRecord( psDBF ) )
+        if (!DBFFlushRecord(psDBF))
             return FALSE;
 
-	psDBF->nRecords++;
-	for( int i = 0; i < psDBF->nRecordLength; i++ )
-	    psDBF->pszCurrentRecord[i] = ' ';
+        psDBF->nRecords++;
+        for (int i = 0; i < psDBF->nRecordLength; i++)
+            psDBF->pszCurrentRecord[i] = ' ';
 
-	psDBF->nCurrentRecord = hEntity;
+        psDBF->nCurrentRecord = hEntity;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Is this an existing record, but different than the last one     */
-/*      we accessed?                                                    */
-/* -------------------------------------------------------------------- */
-    if( !DBFLoadRecord( psDBF, hEntity ) )
+    /* -------------------------------------------------------------------- */
+    /*      Is this an existing record, but different than the last one     */
+    /*      we accessed?                                                    */
+    /* -------------------------------------------------------------------- */
+    if (!DBFLoadRecord(psDBF, hEntity))
         return FALSE;
 
-    unsigned char *pabyRec = REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
+    unsigned char *pabyRec =
+        REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
 
-    memcpy ( pabyRec, pRawTuple,  psDBF->nRecordLength );
+    memcpy(pabyRec, pRawTuple, psDBF->nRecordLength);
 
     psDBF->bCurrentRecordModified = TRUE;
     psDBF->bUpdated = TRUE;
 
-    return( TRUE );
+    return (TRUE);
 }
 
 /************************************************************************/
@@ -1531,14 +1588,13 @@ DBFWriteTuple(DBFHandle psDBF, int hEntity, void * pRawTuple ) {
 /*      till the next record read for any reason.                       */
 /************************************************************************/
 
-const char SHPAPI_CALL1(*)
-DBFReadTuple(DBFHandle psDBF, int hEntity )
+const char SHPAPI_CALL1(*) DBFReadTuple(DBFHandle psDBF, int hEntity)
 
 {
-    if( hEntity < 0 || hEntity >= psDBF->nRecords )
+    if (hEntity < 0 || hEntity >= psDBF->nRecords)
         return SHPLIB_NULLPTR;
 
-    if( !DBFLoadRecord( psDBF, hEntity ) )
+    if (!DBFLoadRecord(psDBF, hEntity))
         return SHPLIB_NULLPTR;
 
     return STATIC_CAST(const char *, psDBF->pszCurrentRecord);
@@ -1550,41 +1606,52 @@ DBFReadTuple(DBFHandle psDBF, int hEntity )
 /*      Read one of the attribute fields of a record.                   */
 /************************************************************************/
 
-DBFHandle SHPAPI_CALL
-DBFCloneEmpty(DBFHandle psDBF, const char * pszFilename ) {
-   DBFHandle newDBF = DBFCreateEx ( pszFilename, psDBF->pszCodePage );
-   if ( newDBF == SHPLIB_NULLPTR ) return SHPLIB_NULLPTR;
+DBFHandle SHPAPI_CALL DBFCloneEmpty(DBFHandle psDBF, const char *pszFilename)
+{
+    DBFHandle newDBF = DBFCreateEx(pszFilename, psDBF->pszCodePage);
+    if (newDBF == SHPLIB_NULLPTR)
+        return SHPLIB_NULLPTR;
 
-   newDBF->nFields = psDBF->nFields;
-   newDBF->nRecordLength = psDBF->nRecordLength;
-   newDBF->nHeaderLength = psDBF->nHeaderLength;
+    newDBF->nFields = psDBF->nFields;
+    newDBF->nRecordLength = psDBF->nRecordLength;
+    newDBF->nHeaderLength = psDBF->nHeaderLength;
 
-   if( psDBF->pszHeader )
-   {
-        newDBF->pszHeader = STATIC_CAST(char *, malloc ( XBASE_FLDHDR_SZ * psDBF->nFields ));
-        memcpy ( newDBF->pszHeader, psDBF->pszHeader, XBASE_FLDHDR_SZ * psDBF->nFields );
-   }
+    if (psDBF->pszHeader)
+    {
+        newDBF->pszHeader =
+            STATIC_CAST(char *, malloc(XBASE_FLDHDR_SZ * psDBF->nFields));
+        memcpy(newDBF->pszHeader, psDBF->pszHeader,
+               XBASE_FLDHDR_SZ * psDBF->nFields);
+    }
 
-   newDBF->panFieldOffset = STATIC_CAST(int *, malloc ( sizeof(int) * psDBF->nFields ));
-   memcpy ( newDBF->panFieldOffset, psDBF->panFieldOffset, sizeof(int) * psDBF->nFields );
-   newDBF->panFieldSize = STATIC_CAST(int *, malloc ( sizeof(int) * psDBF->nFields ));
-   memcpy ( newDBF->panFieldSize, psDBF->panFieldSize, sizeof(int) * psDBF->nFields );
-   newDBF->panFieldDecimals = STATIC_CAST(int *, malloc ( sizeof(int) * psDBF->nFields ));
-   memcpy ( newDBF->panFieldDecimals, psDBF->panFieldDecimals, sizeof(int) * psDBF->nFields );
-   newDBF->pachFieldType = STATIC_CAST(char *, malloc ( sizeof(char) * psDBF->nFields ));
-   memcpy ( newDBF->pachFieldType, psDBF->pachFieldType, sizeof(char)*psDBF->nFields );
+    newDBF->panFieldOffset =
+        STATIC_CAST(int *, malloc(sizeof(int) * psDBF->nFields));
+    memcpy(newDBF->panFieldOffset, psDBF->panFieldOffset,
+           sizeof(int) * psDBF->nFields);
+    newDBF->panFieldSize =
+        STATIC_CAST(int *, malloc(sizeof(int) * psDBF->nFields));
+    memcpy(newDBF->panFieldSize, psDBF->panFieldSize,
+           sizeof(int) * psDBF->nFields);
+    newDBF->panFieldDecimals =
+        STATIC_CAST(int *, malloc(sizeof(int) * psDBF->nFields));
+    memcpy(newDBF->panFieldDecimals, psDBF->panFieldDecimals,
+           sizeof(int) * psDBF->nFields);
+    newDBF->pachFieldType =
+        STATIC_CAST(char *, malloc(sizeof(char) * psDBF->nFields));
+    memcpy(newDBF->pachFieldType, psDBF->pachFieldType,
+           sizeof(char) * psDBF->nFields);
 
-   newDBF->bNoHeader = TRUE;
-   newDBF->bUpdated = TRUE;
-   newDBF->bWriteEndOfFileChar = psDBF->bWriteEndOfFileChar;
+    newDBF->bNoHeader = TRUE;
+    newDBF->bUpdated = TRUE;
+    newDBF->bWriteEndOfFileChar = psDBF->bWriteEndOfFileChar;
 
-   DBFWriteHeader ( newDBF );
-   DBFClose ( newDBF );
+    DBFWriteHeader(newDBF);
+    DBFClose(newDBF);
 
-   newDBF = DBFOpen ( pszFilename, "rb+" );
-   newDBF->bWriteEndOfFileChar = psDBF->bWriteEndOfFileChar;
+    newDBF = DBFOpen(pszFilename, "rb+");
+    newDBF->bWriteEndOfFileChar = psDBF->bWriteEndOfFileChar;
 
-   return ( newDBF );
+    return (newDBF);
 }
 
 /************************************************************************/
@@ -1598,14 +1665,13 @@ DBFCloneEmpty(DBFHandle psDBF, const char * pszFilename ) {
 /*                           'M' (Memo: 10 digits .DBT block ptr)       */
 /************************************************************************/
 
-char SHPAPI_CALL
-DBFGetNativeFieldType( DBFHandle psDBF, int iField )
+char SHPAPI_CALL DBFGetNativeFieldType(DBFHandle psDBF, int iField)
 
 {
-    if( iField >=0 && iField < psDBF->nFields )
+    if (iField >= 0 && iField < psDBF->nFields)
         return psDBF->pachFieldType[iField];
 
-    return  ' ';
+    return ' ';
 }
 
 /************************************************************************/
@@ -1616,17 +1682,17 @@ DBFGetNativeFieldType( DBFHandle psDBF, int iField )
 /*      Contributed by Jim Matthews.                                    */
 /************************************************************************/
 
-int SHPAPI_CALL
-DBFGetFieldIndex(DBFHandle psDBF, const char *pszFieldName) {
-    char name[XBASE_FLDNAME_LEN_READ+1];
+int SHPAPI_CALL DBFGetFieldIndex(DBFHandle psDBF, const char *pszFieldName)
+{
+    char name[XBASE_FLDNAME_LEN_READ + 1];
 
-    for( int i = 0; i < DBFGetFieldCount(psDBF); i++ )
+    for (int i = 0; i < DBFGetFieldCount(psDBF); i++)
     {
-        DBFGetFieldInfo( psDBF, i, name, SHPLIB_NULLPTR, SHPLIB_NULLPTR );
-        if(!STRCASECMP(pszFieldName,name))
-            return(i);
+        DBFGetFieldInfo(psDBF, i, name, SHPLIB_NULLPTR, SHPLIB_NULLPTR);
+        if (!STRCASECMP(pszFieldName, name))
+            return (i);
     }
-    return(-1);
+    return (-1);
 }
 
 /************************************************************************/
@@ -1636,22 +1702,23 @@ DBFGetFieldIndex(DBFHandle psDBF, const char *pszFieldName) {
 /*      it returns FALSE.                                               */
 /************************************************************************/
 
-int SHPAPI_CALL DBFIsRecordDeleted( DBFHandle psDBF, int iShape ) {
-/* -------------------------------------------------------------------- */
-/*      Verify selection.                                               */
-/* -------------------------------------------------------------------- */
-    if( iShape < 0 || iShape >= psDBF->nRecords )
+int SHPAPI_CALL DBFIsRecordDeleted(DBFHandle psDBF, int iShape)
+{
+    /* -------------------------------------------------------------------- */
+    /*      Verify selection.                                               */
+    /* -------------------------------------------------------------------- */
+    if (iShape < 0 || iShape >= psDBF->nRecords)
         return TRUE;
 
-/* -------------------------------------------------------------------- */
-/*	Have we read the record?					*/
-/* -------------------------------------------------------------------- */
-    if( !DBFLoadRecord( psDBF, iShape ) )
+    /* -------------------------------------------------------------------- */
+    /*	Have we read the record?					*/
+    /* -------------------------------------------------------------------- */
+    if (!DBFLoadRecord(psDBF, iShape))
         return FALSE;
 
-/* -------------------------------------------------------------------- */
-/*      '*' means deleted.                                              */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      '*' means deleted.                                              */
+    /* -------------------------------------------------------------------- */
     return psDBF->pszCurrentRecord[0] == '*';
 }
 
@@ -1659,31 +1726,32 @@ int SHPAPI_CALL DBFIsRecordDeleted( DBFHandle psDBF, int iShape ) {
 /*                        DBFMarkRecordDeleted()                        */
 /************************************************************************/
 
-int SHPAPI_CALL DBFMarkRecordDeleted( DBFHandle psDBF, int iShape,
-                                      int bIsDeleted ) {
-/* -------------------------------------------------------------------- */
-/*      Verify selection.                                               */
-/* -------------------------------------------------------------------- */
-    if( iShape < 0 || iShape >= psDBF->nRecords )
+int SHPAPI_CALL DBFMarkRecordDeleted(DBFHandle psDBF, int iShape,
+                                     int bIsDeleted)
+{
+    /* -------------------------------------------------------------------- */
+    /*      Verify selection.                                               */
+    /* -------------------------------------------------------------------- */
+    if (iShape < 0 || iShape >= psDBF->nRecords)
         return FALSE;
 
-/* -------------------------------------------------------------------- */
-/*      Is this an existing record, but different than the last one     */
-/*      we accessed?                                                    */
-/* -------------------------------------------------------------------- */
-    if( !DBFLoadRecord( psDBF, iShape ) )
+    /* -------------------------------------------------------------------- */
+    /*      Is this an existing record, but different than the last one     */
+    /*      we accessed?                                                    */
+    /* -------------------------------------------------------------------- */
+    if (!DBFLoadRecord(psDBF, iShape))
         return FALSE;
 
-/* -------------------------------------------------------------------- */
-/*      Assign value, marking record as dirty if it changes.            */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Assign value, marking record as dirty if it changes.            */
+    /* -------------------------------------------------------------------- */
     char chNewFlag;
-    if( bIsDeleted )
+    if (bIsDeleted)
         chNewFlag = '*';
     else
         chNewFlag = ' ';
 
-    if( psDBF->pszCurrentRecord[0] != chNewFlag )
+    if (psDBF->pszCurrentRecord[0] != chNewFlag)
     {
         psDBF->bCurrentRecordModified = TRUE;
         psDBF->bUpdated = TRUE;
@@ -1697,10 +1765,9 @@ int SHPAPI_CALL DBFMarkRecordDeleted( DBFHandle psDBF, int iShape,
 /*                            DBFGetCodePage                            */
 /************************************************************************/
 
-const char SHPAPI_CALL1(*)
-DBFGetCodePage(DBFHandle psDBF )
+const char SHPAPI_CALL1(*) DBFGetCodePage(DBFHandle psDBF)
 {
-    if( psDBF == SHPLIB_NULLPTR )
+    if (psDBF == SHPLIB_NULLPTR)
         return SHPLIB_NULLPTR;
     return psDBF->pszCodePage;
 }
@@ -1711,13 +1778,13 @@ DBFGetCodePage(DBFHandle psDBF )
 /*      Remove a field from a .dbf file                                 */
 /************************************************************************/
 
-int SHPAPI_CALL
-DBFDeleteField(DBFHandle psDBF, int iField) {
+int SHPAPI_CALL DBFDeleteField(DBFHandle psDBF, int iField)
+{
     if (iField < 0 || iField >= psDBF->nFields)
         return FALSE;
 
     /* make sure that everything is written in .dbf */
-    if( !DBFFlushRecord( psDBF ) )
+    if (!DBFFlushRecord(psDBF))
         return FALSE;
 
     /* get information about field to be deleted */
@@ -1729,87 +1796,92 @@ DBFDeleteField(DBFHandle psDBF, int iField) {
     /* update fields info */
     for (int i = iField + 1; i < psDBF->nFields; i++)
     {
-        psDBF->panFieldOffset[i-1] = psDBF->panFieldOffset[i] - nDeletedFieldSize;
-        psDBF->panFieldSize[i-1] = psDBF->panFieldSize[i];
-        psDBF->panFieldDecimals[i-1] = psDBF->panFieldDecimals[i];
-        psDBF->pachFieldType[i-1] = psDBF->pachFieldType[i];
+        psDBF->panFieldOffset[i - 1] =
+            psDBF->panFieldOffset[i] - nDeletedFieldSize;
+        psDBF->panFieldSize[i - 1] = psDBF->panFieldSize[i];
+        psDBF->panFieldDecimals[i - 1] = psDBF->panFieldDecimals[i];
+        psDBF->pachFieldType[i - 1] = psDBF->pachFieldType[i];
     }
 
     /* resize fields arrays */
     psDBF->nFields--;
 
-    psDBF->panFieldOffset = STATIC_CAST(int *,
-        realloc( psDBF->panFieldOffset, sizeof(int) * psDBF->nFields ));
+    psDBF->panFieldOffset = STATIC_CAST(
+        int *, realloc(psDBF->panFieldOffset, sizeof(int) * psDBF->nFields));
 
-    psDBF->panFieldSize = STATIC_CAST(int *,
-        realloc( psDBF->panFieldSize, sizeof(int) * psDBF->nFields ));
+    psDBF->panFieldSize = STATIC_CAST(
+        int *, realloc(psDBF->panFieldSize, sizeof(int) * psDBF->nFields));
 
-    psDBF->panFieldDecimals = STATIC_CAST(int *,
-        realloc( psDBF->panFieldDecimals, sizeof(int) * psDBF->nFields ));
+    psDBF->panFieldDecimals = STATIC_CAST(
+        int *, realloc(psDBF->panFieldDecimals, sizeof(int) * psDBF->nFields));
 
-    psDBF->pachFieldType = STATIC_CAST(char *,
-        realloc( psDBF->pachFieldType, sizeof(char) * psDBF->nFields ));
+    psDBF->pachFieldType = STATIC_CAST(
+        char *, realloc(psDBF->pachFieldType, sizeof(char) * psDBF->nFields));
 
     /* update header information */
     psDBF->nHeaderLength -= XBASE_FLDHDR_SZ;
     psDBF->nRecordLength -= nDeletedFieldSize;
 
     /* overwrite field information in header */
-    memmove(psDBF->pszHeader + iField*XBASE_FLDHDR_SZ,
-           psDBF->pszHeader + (iField+1)*XBASE_FLDHDR_SZ,
-           sizeof(char) * (psDBF->nFields - iField)*XBASE_FLDHDR_SZ);
+    memmove(psDBF->pszHeader + iField * XBASE_FLDHDR_SZ,
+            psDBF->pszHeader + (iField + 1) * XBASE_FLDHDR_SZ,
+            sizeof(char) * (psDBF->nFields - iField) * XBASE_FLDHDR_SZ);
 
-    psDBF->pszHeader = STATIC_CAST(char *, realloc(psDBF->pszHeader,
-                                          psDBF->nFields*XBASE_FLDHDR_SZ));
+    psDBF->pszHeader = STATIC_CAST(
+        char *, realloc(psDBF->pszHeader, psDBF->nFields * XBASE_FLDHDR_SZ));
 
     /* update size of current record appropriately */
-    psDBF->pszCurrentRecord = STATIC_CAST(char *, realloc(psDBF->pszCurrentRecord,
-                                                 psDBF->nRecordLength));
+    psDBF->pszCurrentRecord = STATIC_CAST(
+        char *, realloc(psDBF->pszCurrentRecord, psDBF->nRecordLength));
 
     /* we're done if we're dealing with not yet created .dbf */
-    if ( psDBF->bNoHeader && psDBF->nRecords == 0 )
+    if (psDBF->bNoHeader && psDBF->nRecords == 0)
         return TRUE;
 
     /* force update of header with new header and record length */
     psDBF->bNoHeader = TRUE;
-    DBFUpdateHeader( psDBF );
+    DBFUpdateHeader(psDBF);
 
     /* alloc record */
-    char *pszRecord = STATIC_CAST(char *, malloc(sizeof(char) * nOldRecordLength));
+    char *pszRecord =
+        STATIC_CAST(char *, malloc(sizeof(char) * nOldRecordLength));
 
     /* shift records to their new positions */
     for (int iRecord = 0; iRecord < psDBF->nRecords; iRecord++)
     {
         SAOffset nRecordOffset =
-            nOldRecordLength * STATIC_CAST(SAOffset,iRecord) + nOldHeaderLength;
+            nOldRecordLength * STATIC_CAST(SAOffset, iRecord) +
+            nOldHeaderLength;
 
         /* load record */
-        psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
-        if (psDBF->sHooks.FRead(pszRecord, nOldRecordLength, 1, psDBF->fp) != 1) {
-          free(pszRecord);
-          return FALSE;
+        psDBF->sHooks.FSeek(psDBF->fp, nRecordOffset, 0);
+        if (psDBF->sHooks.FRead(pszRecord, nOldRecordLength, 1, psDBF->fp) != 1)
+        {
+            free(pszRecord);
+            return FALSE;
         }
 
-        nRecordOffset =
-            psDBF->nRecordLength * STATIC_CAST(SAOffset,iRecord) + psDBF->nHeaderLength;
+        nRecordOffset = psDBF->nRecordLength * STATIC_CAST(SAOffset, iRecord) +
+                        psDBF->nHeaderLength;
 
         /* move record in two steps */
-        psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
-        psDBF->sHooks.FWrite( pszRecord, nDeletedFieldOffset, 1, psDBF->fp );
-        psDBF->sHooks.FWrite( pszRecord + nDeletedFieldOffset + nDeletedFieldSize,
-                              nOldRecordLength - nDeletedFieldOffset - nDeletedFieldSize,
-                              1, psDBF->fp );
-
+        psDBF->sHooks.FSeek(psDBF->fp, nRecordOffset, 0);
+        psDBF->sHooks.FWrite(pszRecord, nDeletedFieldOffset, 1, psDBF->fp);
+        psDBF->sHooks.FWrite(
+            pszRecord + nDeletedFieldOffset + nDeletedFieldSize,
+            nOldRecordLength - nDeletedFieldOffset - nDeletedFieldSize, 1,
+            psDBF->fp);
     }
 
-    if( psDBF->bWriteEndOfFileChar )
+    if (psDBF->bWriteEndOfFileChar)
     {
         char ch = END_OF_FILE_CHARACTER;
         SAOffset nEOFOffset =
-            psDBF->nRecordLength * STATIC_CAST(SAOffset,psDBF->nRecords) + psDBF->nHeaderLength;
+            psDBF->nRecordLength * STATIC_CAST(SAOffset, psDBF->nRecords) +
+            psDBF->nHeaderLength;
 
-        psDBF->sHooks.FSeek( psDBF->fp, nEOFOffset, 0 );
-        psDBF->sHooks.FWrite( &ch, 1, 1, psDBF->fp );
+        psDBF->sHooks.FSeek(psDBF->fp, nEOFOffset, 0);
+        psDBF->sHooks.FWrite(&ch, 1, 1, psDBF->fp);
     }
 
     /* TODO: truncate file */
@@ -1834,25 +1906,29 @@ DBFDeleteField(DBFHandle psDBF, int iField) {
 /* code of DBFReorderFields.                                            */
 /************************************************************************/
 
-int SHPAPI_CALL
-DBFReorderFields( DBFHandle psDBF, int* panMap ) {
-    if ( psDBF->nFields == 0 )
+int SHPAPI_CALL DBFReorderFields(DBFHandle psDBF, int *panMap)
+{
+    if (psDBF->nFields == 0)
         return TRUE;
 
     /* make sure that everything is written in .dbf */
-    if( !DBFFlushRecord( psDBF ) )
+    if (!DBFFlushRecord(psDBF))
         return FALSE;
 
     /* a simple malloc() would be enough, but calloc() helps clang static analyzer */
-    int *panFieldOffsetNew = STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
-    int *panFieldSizeNew = STATIC_CAST(int *, calloc(sizeof(int),  psDBF->nFields));
-    int *panFieldDecimalsNew = STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
-    char *pachFieldTypeNew = STATIC_CAST(char *, calloc(sizeof(char), psDBF->nFields));
-    char *pszHeaderNew = STATIC_CAST(char*, malloc(sizeof(char) * XBASE_FLDHDR_SZ *
-                                  psDBF->nFields));
+    int *panFieldOffsetNew =
+        STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
+    int *panFieldSizeNew =
+        STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
+    int *panFieldDecimalsNew =
+        STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
+    char *pachFieldTypeNew =
+        STATIC_CAST(char *, calloc(sizeof(char), psDBF->nFields));
+    char *pszHeaderNew = STATIC_CAST(
+        char *, malloc(sizeof(char) * XBASE_FLDHDR_SZ * psDBF->nFields));
 
     /* shuffle fields definitions */
-    for(int i = 0; i < psDBF->nFields; i++)
+    for (int i = 0; i < psDBF->nFields; i++)
     {
         panFieldSizeNew[i] = psDBF->panFieldSize[panMap[i]];
         panFieldDecimalsNew[i] = psDBF->panFieldDecimals[panMap[i]];
@@ -1861,9 +1937,10 @@ DBFReorderFields( DBFHandle psDBF, int* panMap ) {
                psDBF->pszHeader + panMap[i] * XBASE_FLDHDR_SZ, XBASE_FLDHDR_SZ);
     }
     panFieldOffsetNew[0] = 1;
-    for(int i = 1; i < psDBF->nFields; i++)
+    for (int i = 1; i < psDBF->nFields; i++)
     {
-        panFieldOffsetNew[i] = panFieldOffsetNew[i - 1] + panFieldSizeNew[i - 1];
+        panFieldOffsetNew[i] =
+            panFieldOffsetNew[i - 1] + panFieldSizeNew[i - 1];
     }
 
     free(psDBF->pszHeader);
@@ -1872,32 +1949,37 @@ DBFReorderFields( DBFHandle psDBF, int* panMap ) {
     bool errorAbort = false;
 
     /* we're done if we're dealing with not yet created .dbf */
-    if ( !(psDBF->bNoHeader && psDBF->nRecords == 0) )
+    if (!(psDBF->bNoHeader && psDBF->nRecords == 0))
     {
         /* force update of header with new header and record length */
         psDBF->bNoHeader = TRUE;
-        DBFUpdateHeader( psDBF );
+        DBFUpdateHeader(psDBF);
 
         /* alloc record */
-        char *pszRecord = STATIC_CAST(char *, malloc(sizeof(char) * psDBF->nRecordLength));
-        char *pszRecordNew = STATIC_CAST(char *, malloc(sizeof(char) * psDBF->nRecordLength));
+        char *pszRecord =
+            STATIC_CAST(char *, malloc(sizeof(char) * psDBF->nRecordLength));
+        char *pszRecordNew =
+            STATIC_CAST(char *, malloc(sizeof(char) * psDBF->nRecordLength));
 
         /* shuffle fields in records */
         for (int iRecord = 0; iRecord < psDBF->nRecords; iRecord++)
         {
             const SAOffset nRecordOffset =
-                psDBF->nRecordLength * STATIC_CAST(SAOffset,iRecord) + psDBF->nHeaderLength;
+                psDBF->nRecordLength * STATIC_CAST(SAOffset, iRecord) +
+                psDBF->nHeaderLength;
 
             /* load record */
-            psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
-            if (psDBF->sHooks.FRead(pszRecord, psDBF->nRecordLength, 1, psDBF->fp) != 1) {
-              errorAbort = true;
-              break;
+            psDBF->sHooks.FSeek(psDBF->fp, nRecordOffset, 0);
+            if (psDBF->sHooks.FRead(pszRecord, psDBF->nRecordLength, 1,
+                                    psDBF->fp) != 1)
+            {
+                errorAbort = true;
+                break;
             }
 
             pszRecordNew[0] = pszRecord[0];
 
-            for(int i = 0; i < psDBF->nFields; i++)
+            for (int i = 0; i < psDBF->nFields; i++)
             {
                 memcpy(pszRecordNew + panFieldOffsetNew[i],
                        pszRecord + psDBF->panFieldOffset[panMap[i]],
@@ -1905,8 +1987,9 @@ DBFReorderFields( DBFHandle psDBF, int* panMap ) {
             }
 
             /* write record */
-            psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
-            psDBF->sHooks.FWrite( pszRecordNew, psDBF->nRecordLength, 1, psDBF->fp );
+            psDBF->sHooks.FSeek(psDBF->fp, nRecordOffset, 0);
+            psDBF->sHooks.FWrite(pszRecordNew, psDBF->nRecordLength, 1,
+                                 psDBF->fp);
         }
 
         /* free record */
@@ -1914,15 +1997,16 @@ DBFReorderFields( DBFHandle psDBF, int* panMap ) {
         free(pszRecordNew);
     }
 
-    if (errorAbort) {
-      free(panFieldOffsetNew);
-      free(panFieldSizeNew);
-      free(panFieldDecimalsNew);
-      free(pachFieldTypeNew);
-      psDBF->nCurrentRecord = -1;
-      psDBF->bCurrentRecordModified = FALSE;
-      psDBF->bUpdated = FALSE;
-      return FALSE;
+    if (errorAbort)
+    {
+        free(panFieldOffsetNew);
+        free(panFieldSizeNew);
+        free(panFieldDecimalsNew);
+        free(pachFieldTypeNew);
+        psDBF->nCurrentRecord = -1;
+        psDBF->bCurrentRecordModified = FALSE;
+        psDBF->bUpdated = FALSE;
+        return FALSE;
     }
 
     free(psDBF->panFieldOffset);
@@ -1932,7 +2016,7 @@ DBFReorderFields( DBFHandle psDBF, int* panMap ) {
 
     psDBF->panFieldOffset = panFieldOffsetNew;
     psDBF->panFieldSize = panFieldSizeNew;
-    psDBF->panFieldDecimals =panFieldDecimalsNew;
+    psDBF->panFieldDecimals = panFieldDecimalsNew;
     psDBF->pachFieldType = pachFieldTypeNew;
 
     psDBF->nCurrentRecord = -1;
@@ -1942,21 +2026,21 @@ DBFReorderFields( DBFHandle psDBF, int* panMap ) {
     return TRUE;
 }
 
-
 /************************************************************************/
 /*                          DBFAlterFieldDefn()                         */
 /*                                                                      */
 /*      Alter a field definition in a .dbf file                         */
 /************************************************************************/
 
-int SHPAPI_CALL
-DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
-                    char chType, int nWidth, int nDecimals ) {
+int SHPAPI_CALL DBFAlterFieldDefn(DBFHandle psDBF, int iField,
+                                  const char *pszFieldName, char chType,
+                                  int nWidth, int nDecimals)
+{
     if (iField < 0 || iField >= psDBF->nFields)
         return FALSE;
 
     /* make sure that everything is written in .dbf */
-    if( !DBFFlushRecord( psDBF ) )
+    if (!DBFFlushRecord(psDBF))
         return FALSE;
 
     const char chFieldFill = DBFGetNullCharacter(chType);
@@ -1966,35 +2050,35 @@ DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
     const int nOldWidth = psDBF->panFieldSize[iField];
     const int nOldRecordLength = psDBF->nRecordLength;
 
-/* -------------------------------------------------------------------- */
-/*      Do some checking to ensure we can add records to this file.     */
-/* -------------------------------------------------------------------- */
-    if( nWidth < 1 )
+    /* -------------------------------------------------------------------- */
+    /*      Do some checking to ensure we can add records to this file.     */
+    /* -------------------------------------------------------------------- */
+    if (nWidth < 1)
         return -1;
 
-    if( nWidth > XBASE_FLD_MAX_WIDTH )
+    if (nWidth > XBASE_FLD_MAX_WIDTH)
         nWidth = XBASE_FLD_MAX_WIDTH;
 
-/* -------------------------------------------------------------------- */
-/*      Assign the new field information fields.                        */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Assign the new field information fields.                        */
+    /* -------------------------------------------------------------------- */
     psDBF->panFieldSize[iField] = nWidth;
     psDBF->panFieldDecimals[iField] = nDecimals;
     psDBF->pachFieldType[iField] = chType;
 
-/* -------------------------------------------------------------------- */
-/*      Update the header information.                                  */
-/* -------------------------------------------------------------------- */
-    char* pszFInfo = psDBF->pszHeader + XBASE_FLDHDR_SZ * iField;
+    /* -------------------------------------------------------------------- */
+    /*      Update the header information.                                  */
+    /* -------------------------------------------------------------------- */
+    char *pszFInfo = psDBF->pszHeader + XBASE_FLDHDR_SZ * iField;
 
-    for( int i = 0; i < XBASE_FLDHDR_SZ; i++ )
+    for (int i = 0; i < XBASE_FLDHDR_SZ; i++)
         pszFInfo[i] = '\0';
 
-    strncpy( pszFInfo, pszFieldName, XBASE_FLDNAME_LEN_WRITE );
+    strncpy(pszFInfo, pszFieldName, XBASE_FLDNAME_LEN_WRITE);
 
     pszFInfo[11] = psDBF->pachFieldType[iField];
 
-    if( chType == 'C' )
+    if (chType == 'C')
     {
         pszFInfo[16] = STATIC_CAST(unsigned char, nWidth % 256);
         pszFInfo[17] = STATIC_CAST(unsigned char, nWidth / 256);
@@ -2005,33 +2089,35 @@ DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
         pszFInfo[17] = STATIC_CAST(unsigned char, nDecimals);
     }
 
-/* -------------------------------------------------------------------- */
-/*      Update offsets                                                  */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Update offsets                                                  */
+    /* -------------------------------------------------------------------- */
     if (nWidth != nOldWidth)
     {
         for (int i = iField + 1; i < psDBF->nFields; i++)
-             psDBF->panFieldOffset[i] += nWidth - nOldWidth;
+            psDBF->panFieldOffset[i] += nWidth - nOldWidth;
         psDBF->nRecordLength += nWidth - nOldWidth;
 
-        psDBF->pszCurrentRecord = STATIC_CAST(char *, realloc(psDBF->pszCurrentRecord,
-                                                     psDBF->nRecordLength));
+        psDBF->pszCurrentRecord = STATIC_CAST(
+            char *, realloc(psDBF->pszCurrentRecord, psDBF->nRecordLength));
     }
 
     /* we're done if we're dealing with not yet created .dbf */
-    if ( psDBF->bNoHeader && psDBF->nRecords == 0 )
+    if (psDBF->bNoHeader && psDBF->nRecords == 0)
         return TRUE;
 
     /* force update of header with new header and record length */
     psDBF->bNoHeader = TRUE;
-    DBFUpdateHeader( psDBF );
+    DBFUpdateHeader(psDBF);
 
     bool errorAbort = false;
 
     if (nWidth < nOldWidth || (nWidth == nOldWidth && chType != chOldType))
     {
-        char* pszRecord = STATIC_CAST(char *, malloc(sizeof(char) * nOldRecordLength));
-        char* pszOldField = STATIC_CAST(char *, malloc(sizeof(char) * (nOldWidth + 1)));
+        char *pszRecord =
+            STATIC_CAST(char *, malloc(sizeof(char) * nOldRecordLength));
+        char *pszOldField =
+            STATIC_CAST(char *, malloc(sizeof(char) * (nOldWidth + 1)));
 
         /* cppcheck-suppress uninitdata */
         pszOldField[nOldWidth] = 0;
@@ -2040,30 +2126,34 @@ DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
         for (int iRecord = 0; iRecord < psDBF->nRecords; iRecord++)
         {
             SAOffset nRecordOffset =
-                nOldRecordLength * STATIC_CAST(SAOffset,iRecord) + psDBF->nHeaderLength;
+                nOldRecordLength * STATIC_CAST(SAOffset, iRecord) +
+                psDBF->nHeaderLength;
 
             /* load record */
-            psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
-            if (psDBF->sHooks.FRead( pszRecord, nOldRecordLength, 1, psDBF->fp ) != 1) {
-              errorAbort = true;
-              break;
+            psDBF->sHooks.FSeek(psDBF->fp, nRecordOffset, 0);
+            if (psDBF->sHooks.FRead(pszRecord, nOldRecordLength, 1,
+                                    psDBF->fp) != 1)
+            {
+                errorAbort = true;
+                break;
             }
 
             memcpy(pszOldField, pszRecord + nOffset, nOldWidth);
-            const bool bIsNULL = DBFIsValueNULL( chOldType, pszOldField );
+            const bool bIsNULL = DBFIsValueNULL(chOldType, pszOldField);
 
             if (nWidth != nOldWidth)
             {
-                if ((chOldType == 'N' || chOldType == 'F' || chOldType == 'D') && pszOldField[0] == ' ')
+                if ((chOldType == 'N' || chOldType == 'F' ||
+                     chOldType == 'D') &&
+                    pszOldField[0] == ' ')
                 {
                     /* Strip leading spaces when truncating a numeric field */
-                    memmove( pszRecord + nOffset,
-                            pszRecord + nOffset + nOldWidth - nWidth,
-                            nWidth );
+                    memmove(pszRecord + nOffset,
+                            pszRecord + nOffset + nOldWidth - nWidth, nWidth);
                 }
                 if (nOffset + nOldWidth < nOldRecordLength)
                 {
-                    memmove( pszRecord + nOffset + nWidth,
+                    memmove(pszRecord + nOffset + nWidth,
                             pszRecord + nOffset + nOldWidth,
                             nOldRecordLength - (nOffset + nOldWidth));
                 }
@@ -2072,26 +2162,28 @@ DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
             /* Convert null value to the appropriate value of the new type */
             if (bIsNULL)
             {
-                memset( pszRecord + nOffset, chFieldFill, nWidth);
+                memset(pszRecord + nOffset, chFieldFill, nWidth);
             }
 
             nRecordOffset =
-                psDBF->nRecordLength * STATIC_CAST(SAOffset,iRecord) + psDBF->nHeaderLength;
+                psDBF->nRecordLength * STATIC_CAST(SAOffset, iRecord) +
+                psDBF->nHeaderLength;
 
             /* write record */
-            psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
-            psDBF->sHooks.FWrite( pszRecord, psDBF->nRecordLength, 1, psDBF->fp );
+            psDBF->sHooks.FSeek(psDBF->fp, nRecordOffset, 0);
+            psDBF->sHooks.FWrite(pszRecord, psDBF->nRecordLength, 1, psDBF->fp);
         }
 
-        if( !errorAbort && psDBF->bWriteEndOfFileChar )
+        if (!errorAbort && psDBF->bWriteEndOfFileChar)
         {
             char ch = END_OF_FILE_CHARACTER;
 
             SAOffset nRecordOffset =
-                psDBF->nRecordLength * STATIC_CAST(SAOffset,psDBF->nRecords) + psDBF->nHeaderLength;
+                psDBF->nRecordLength * STATIC_CAST(SAOffset, psDBF->nRecords) +
+                psDBF->nHeaderLength;
 
-            psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
-            psDBF->sHooks.FWrite( &ch, 1, 1, psDBF->fp );
+            psDBF->sHooks.FSeek(psDBF->fp, nRecordOffset, 0);
+            psDBF->sHooks.FWrite(&ch, 1, 1, psDBF->fp);
         }
         /* TODO: truncate file */
 
@@ -2100,8 +2192,10 @@ DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
     }
     else if (nWidth > nOldWidth)
     {
-        char* pszRecord = STATIC_CAST(char *, malloc(sizeof(char) * psDBF->nRecordLength));
-        char* pszOldField = STATIC_CAST(char *, malloc(sizeof(char) * (nOldWidth + 1)));
+        char *pszRecord =
+            STATIC_CAST(char *, malloc(sizeof(char) * psDBF->nRecordLength));
+        char *pszOldField =
+            STATIC_CAST(char *, malloc(sizeof(char) * (nOldWidth + 1)));
 
         /* cppcheck-suppress uninitdata */
         pszOldField[nOldWidth] = 0;
@@ -2110,75 +2204,82 @@ DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
         for (int iRecord = psDBF->nRecords - 1; iRecord >= 0; iRecord--)
         {
             SAOffset nRecordOffset =
-                nOldRecordLength * STATIC_CAST(SAOffset,iRecord) + psDBF->nHeaderLength;
+                nOldRecordLength * STATIC_CAST(SAOffset, iRecord) +
+                psDBF->nHeaderLength;
 
             /* load record */
-            psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
-            if (psDBF->sHooks.FRead( pszRecord, nOldRecordLength, 1, psDBF->fp )!= 1) {
-              errorAbort = true;
-              break;
+            psDBF->sHooks.FSeek(psDBF->fp, nRecordOffset, 0);
+            if (psDBF->sHooks.FRead(pszRecord, nOldRecordLength, 1,
+                                    psDBF->fp) != 1)
+            {
+                errorAbort = true;
+                break;
             }
 
             memcpy(pszOldField, pszRecord + nOffset, nOldWidth);
-            const bool bIsNULL = DBFIsValueNULL( chOldType, pszOldField );
+            const bool bIsNULL = DBFIsValueNULL(chOldType, pszOldField);
 
             if (nOffset + nOldWidth < nOldRecordLength)
             {
-                memmove( pszRecord + nOffset + nWidth,
-                         pszRecord + nOffset + nOldWidth,
-                         nOldRecordLength - (nOffset + nOldWidth));
+                memmove(pszRecord + nOffset + nWidth,
+                        pszRecord + nOffset + nOldWidth,
+                        nOldRecordLength - (nOffset + nOldWidth));
             }
 
             /* Convert null value to the appropriate value of the new type */
             if (bIsNULL)
             {
-                memset( pszRecord + nOffset, chFieldFill, nWidth);
+                memset(pszRecord + nOffset, chFieldFill, nWidth);
             }
             else
             {
                 if ((chOldType == 'N' || chOldType == 'F'))
                 {
                     /* Add leading spaces when expanding a numeric field */
-                    memmove( pszRecord + nOffset + nWidth - nOldWidth,
-                             pszRecord + nOffset, nOldWidth );
-                    memset( pszRecord + nOffset, ' ', nWidth - nOldWidth );
+                    memmove(pszRecord + nOffset + nWidth - nOldWidth,
+                            pszRecord + nOffset, nOldWidth);
+                    memset(pszRecord + nOffset, ' ', nWidth - nOldWidth);
                 }
                 else
                 {
                     /* Add trailing spaces */
-                    memset(pszRecord + nOffset + nOldWidth, ' ', nWidth - nOldWidth);
+                    memset(pszRecord + nOffset + nOldWidth, ' ',
+                           nWidth - nOldWidth);
                 }
             }
 
             nRecordOffset =
-                psDBF->nRecordLength * STATIC_CAST(SAOffset,iRecord) + psDBF->nHeaderLength;
+                psDBF->nRecordLength * STATIC_CAST(SAOffset, iRecord) +
+                psDBF->nHeaderLength;
 
             /* write record */
-            psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
-            psDBF->sHooks.FWrite( pszRecord, psDBF->nRecordLength, 1, psDBF->fp );
+            psDBF->sHooks.FSeek(psDBF->fp, nRecordOffset, 0);
+            psDBF->sHooks.FWrite(pszRecord, psDBF->nRecordLength, 1, psDBF->fp);
         }
 
-        if( !errorAbort && psDBF->bWriteEndOfFileChar )
+        if (!errorAbort && psDBF->bWriteEndOfFileChar)
         {
             char ch = END_OF_FILE_CHARACTER;
 
             SAOffset nRecordOffset =
-                psDBF->nRecordLength * STATIC_CAST(SAOffset,psDBF->nRecords) + psDBF->nHeaderLength;
+                psDBF->nRecordLength * STATIC_CAST(SAOffset, psDBF->nRecords) +
+                psDBF->nHeaderLength;
 
-            psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
-            psDBF->sHooks.FWrite( &ch, 1, 1, psDBF->fp );
+            psDBF->sHooks.FSeek(psDBF->fp, nRecordOffset, 0);
+            psDBF->sHooks.FWrite(&ch, 1, 1, psDBF->fp);
         }
 
         free(pszRecord);
         free(pszOldField);
     }
 
-    if (errorAbort) {
-      psDBF->nCurrentRecord = -1;
-      psDBF->bCurrentRecordModified = TRUE;
-      psDBF->bUpdated = FALSE;
+    if (errorAbort)
+    {
+        psDBF->nCurrentRecord = -1;
+        psDBF->bCurrentRecordModified = TRUE;
+        psDBF->bUpdated = FALSE;
 
-      return FALSE;
+        return FALSE;
     }
     psDBF->nCurrentRecord = -1;
     psDBF->bCurrentRecordModified = FALSE;
@@ -2191,7 +2292,7 @@ DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
 /*                    DBFSetWriteEndOfFileChar()                        */
 /************************************************************************/
 
-void SHPAPI_CALL DBFSetWriteEndOfFileChar( DBFHandle psDBF, int bWriteFlag )
+void SHPAPI_CALL DBFSetWriteEndOfFileChar(DBFHandle psDBF, int bWriteFlag)
 {
     psDBF->bWriteEndOfFileChar = bWriteFlag;
 }

--- a/safileio.c
+++ b/safileio.c
@@ -46,77 +46,93 @@
 SHP_CVSID("$Id$");
 
 #ifdef SHPAPI_UTF8_HOOKS
-#   ifdef SHPAPI_WINDOWS
-#       define WIN32_LEAN_AND_MEAN
-#       define NOMINMAX
-#       include <windows.h>
-#       pragma comment(lib, "kernel32.lib")
-#   endif
+#ifdef SHPAPI_WINDOWS
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#pragma comment(lib, "kernel32.lib")
+#endif
 #endif
 
-static SAFile SADFOpen(const char *pszFilename, const char *pszAccess) {
+static SAFile SADFOpen(const char *pszFilename, const char *pszAccess)
+{
     return (SAFile)fopen(pszFilename, pszAccess);
 }
 
-static SAOffset SADFRead(void *p, SAOffset size, SAOffset nmemb, SAFile file) {
-    return (SAOffset)fread( p, (size_t)size, (size_t)nmemb, (FILE *)file);
+static SAOffset SADFRead(void *p, SAOffset size, SAOffset nmemb, SAFile file)
+{
+    return (SAOffset)fread(p, (size_t)size, (size_t)nmemb, (FILE *)file);
 }
 
-static SAOffset SADFWrite(void *p, SAOffset size, SAOffset nmemb, SAFile file) {
+static SAOffset SADFWrite(void *p, SAOffset size, SAOffset nmemb, SAFile file)
+{
     return (SAOffset)fwrite(p, (size_t)size, (size_t)nmemb, (FILE *)file);
 }
 
-static SAOffset SADFSeek(SAFile file, SAOffset offset, int whence) {
-    return (SAOffset)fseek((FILE *) file, (long) offset, whence);
+static SAOffset SADFSeek(SAFile file, SAOffset offset, int whence)
+{
+    return (SAOffset)fseek((FILE *)file, (long)offset, whence);
 }
 
-static SAOffset SADFTell(SAFile file) {
+static SAOffset SADFTell(SAFile file)
+{
     return (SAOffset)ftell((FILE *)file);
 }
 
-static int SADFFlush(SAFile file) {
-    return fflush((FILE *) file);
+static int SADFFlush(SAFile file)
+{
+    return fflush((FILE *)file);
 }
 
-static int SADFClose(SAFile file) {
-    return fclose((FILE *) file);
+static int SADFClose(SAFile file)
+{
+    return fclose((FILE *)file);
 }
 
-static int SADRemove(const char *filename) {
+static int SADRemove(const char *filename)
+{
     return remove(filename);
 }
 
-static void SADError(const char *message) {
+static void SADError(const char *message)
+{
     fprintf(stderr, "%s\n", message);
 }
 
-void SASetupDefaultHooks(SAHooks *psHooks) {
-    psHooks->FOpen   = SADFOpen;
-    psHooks->FRead   = SADFRead;
-    psHooks->FWrite  = SADFWrite;
-    psHooks->FSeek   = SADFSeek;
-    psHooks->FTell   = SADFTell;
-    psHooks->FFlush  = SADFFlush;
-    psHooks->FClose  = SADFClose;
-    psHooks->Remove  = SADRemove;
+void SASetupDefaultHooks(SAHooks *psHooks)
+{
+    psHooks->FOpen = SADFOpen;
+    psHooks->FRead = SADFRead;
+    psHooks->FWrite = SADFWrite;
+    psHooks->FSeek = SADFSeek;
+    psHooks->FTell = SADFTell;
+    psHooks->FFlush = SADFFlush;
+    psHooks->FClose = SADFClose;
+    psHooks->Remove = SADRemove;
 
-    psHooks->Error   = SADError;
-    psHooks->Atof    = atof;
+    psHooks->Error = SADError;
+    psHooks->Atof = atof;
 }
 
 #ifdef SHPAPI_WINDOWS
 
-const wchar_t* Utf8ToWideChar(const char *pszFilename) {
+const wchar_t *Utf8ToWideChar(const char *pszFilename)
+{
     const int nMulti = strlen(pszFilename) + 1;
-    const int nWide = MultiByteToWideChar( CP_UTF8, 0, pszFilename, nMulti, 0, 0);
-    if (nWide == 0) {
+    const int nWide =
+        MultiByteToWideChar(CP_UTF8, 0, pszFilename, nMulti, 0, 0);
+    if (nWide == 0)
+    {
         return NULL;
     }
-    wchar_t *pwszFileName = (wchar_t*) malloc(nWide * sizeof(wchar_t));
-    if (pwszFileName == NULL) {
+    wchar_t *pwszFileName = (wchar_t *)malloc(nWide * sizeof(wchar_t));
+    if (pwszFileName == NULL)
+    {
         return NULL;
     }
-    if (MultiByteToWideChar(CP_UTF8, 0, pszFilename, nMulti, pwszFileName, nWide) == 0) {
+    if (MultiByteToWideChar(CP_UTF8, 0, pszFilename, nMulti, pwszFileName,
+                            nWide) == 0)
+    {
         free(pwszFileName);
         return NULL;
     }
@@ -127,22 +143,26 @@ const wchar_t* Utf8ToWideChar(const char *pszFilename) {
 /*                           SAUtf8WFOpen                               */
 /************************************************************************/
 
-SAFile SAUtf8WFOpen(const char *pszFilename, const char *pszAccess) {
+SAFile SAUtf8WFOpen(const char *pszFilename, const char *pszAccess)
+{
     SAFile file = NULL;
-    wchar_t *pwszFileName = Utf8ToWideChar( pszFilename );
-    wchar_t *pwszAccess = Utf8ToWideChar( pszAccess );
-    if (pwszFileName != NULL && pwszAccess != NULL) {
-        file = (SAFile) _wfopen( pwszFileName, pwszAccess );
+    wchar_t *pwszFileName = Utf8ToWideChar(pszFilename);
+    wchar_t *pwszAccess = Utf8ToWideChar(pszAccess);
+    if (pwszFileName != NULL && pwszAccess != NULL)
+    {
+        file = (SAFile)_wfopen(pwszFileName, pwszAccess);
     }
     free(pwszFileName);
     free(pwszAccess);
     return file;
 }
 
-int SAUtf8WRemove(const char *pszFilename) {
+int SAUtf8WRemove(const char *pszFilename)
+{
     wchar_t *pwszFileName = Utf8ToWideChar(pszFilename);
     int rc = -1;
-    if (pwszFileName != NULL) {
+    if (pwszFileName != NULL)
+    {
         rc = _wremove(pwszFileName);
     }
     free(pwszFileName);
@@ -153,20 +173,21 @@ int SAUtf8WRemove(const char *pszFilename) {
 
 #ifdef SHPAPI_UTF8_HOOKS
 #ifndef SHPAPI_WINDOWS
-#  error "no implementations of UTF-8 hooks available for this platform"
+#error "no implementations of UTF-8 hooks available for this platform"
 #endif
 
-void SASetupUtf8Hooks(SAHooks *psHooks) {
-    psHooks->FOpen   = SAUtf8WFOpen;
-    psHooks->Remove  = SAUtf8WRemove;
-    psHooks->FRead   = SADFRead;
-    psHooks->FWrite  = SADFWrite;
-    psHooks->FSeek   = SADFSeek;
-    psHooks->FTell   = SADFTell;
-    psHooks->FFlush  = SADFFlush;
-    psHooks->FClose  = SADFClose;
+void SASetupUtf8Hooks(SAHooks *psHooks)
+{
+    psHooks->FOpen = SAUtf8WFOpen;
+    psHooks->Remove = SAUtf8WRemove;
+    psHooks->FRead = SADFRead;
+    psHooks->FWrite = SADFWrite;
+    psHooks->FSeek = SADFSeek;
+    psHooks->FTell = SADFTell;
+    psHooks->FFlush = SADFFlush;
+    psHooks->FClose = SADFClose;
 
-    psHooks->Error   = SADError;
-    psHooks->Atof    = atof;
+    psHooks->Error = SADError;
+    psHooks->Atof = atof;
 }
 #endif

--- a/sbnsearch.c
+++ b/sbnsearch.c
@@ -45,32 +45,33 @@ SHP_CVSID("$Id$")
 
 #ifndef USE_CPL
 #if defined(_MSC_VER)
-# if _MSC_VER < 1900
-#     define snprintf _snprintf
-# endif
+#if _MSC_VER < 1900
+#define snprintf _snprintf
+#endif
 #elif defined(WIN32) || defined(_WIN32)
-#  ifndef snprintf
-#     define snprintf _snprintf
-#  endif
+#ifndef snprintf
+#define snprintf _snprintf
+#endif
 #endif
 #endif
 
-#define CACHED_DEPTH_LIMIT      8
+#define CACHED_DEPTH_LIMIT 8
 
 #ifdef __cplusplus
-#define STATIC_CAST(type,x) static_cast<type>(x)
-#define REINTERPRET_CAST(type,x) reinterpret_cast<type>(x)
-#define CONST_CAST(type,x) const_cast<type>(x)
+#define STATIC_CAST(type, x) static_cast<type>(x)
+#define REINTERPRET_CAST(type, x) reinterpret_cast<type>(x)
+#define CONST_CAST(type, x) const_cast<type>(x)
 #define SHPLIB_NULLPTR nullptr
 #else
-#define STATIC_CAST(type,x) ((type)(x))
-#define REINTERPRET_CAST(type,x) ((type)(x))
-#define CONST_CAST(type,x) ((type)(x))
+#define STATIC_CAST(type, x) ((type)(x))
+#define REINTERPRET_CAST(type, x) ((type)(x))
+#define CONST_CAST(type, x) ((type)(x))
 #define SHPLIB_NULLPTR NULL
 #endif
 
-#define READ_MSB_INT(ptr) \
-        STATIC_CAST(int, (((STATIC_CAST(unsigned, (ptr)[0])) << 24) | ((ptr)[1] << 16) | ((ptr)[2] << 8) | (ptr)[3]))
+#define READ_MSB_INT(ptr)                                                      \
+    STATIC_CAST(int, (((STATIC_CAST(unsigned, (ptr)[0])) << 24) |              \
+                      ((ptr)[1] << 16) | ((ptr)[2] << 8) | (ptr)[3]))
 
 typedef unsigned char uchar;
 
@@ -79,33 +80,35 @@ typedef int coord;
 
 typedef struct
 {
-    uchar  *pabyShapeDesc;  /* Cache of (nShapeCount * 8) bytes of the bins. May be NULL. */
-    int     nBinStart;      /* Index of first bin for this node. */
-    int     nShapeCount;    /* Number of shapes attached to this node. */
-    int     nBinCount;      /* Number of bins for this node. May be 0 if node is empty. */
-    int     nBinOffset;     /* Offset in file of the start of the first bin. May be 0 if node is empty. */
+    uchar *
+        pabyShapeDesc; /* Cache of (nShapeCount * 8) bytes of the bins. May be NULL. */
+    int nBinStart;   /* Index of first bin for this node. */
+    int nShapeCount; /* Number of shapes attached to this node. */
+    int nBinCount; /* Number of bins for this node. May be 0 if node is empty. */
+    int nBinOffset; /* Offset in file of the start of the first bin. May be 0 if node is empty. */
 
-    bool    bBBoxInit;      /* true if the following bounding box has been computed. */
-    coord   bMinX;          /* Bounding box of the shapes directly attached to this node. */
-    coord   bMinY;          /* This is *not* the theoretical footprint of the node. */
-    coord   bMaxX;
-    coord   bMaxY;
+    bool bBBoxInit; /* true if the following bounding box has been computed. */
+    coord
+        bMinX; /* Bounding box of the shapes directly attached to this node. */
+    coord bMinY; /* This is *not* the theoretical footprint of the node. */
+    coord bMaxX;
+    coord bMaxY;
 } SBNNodeDescriptor;
 
 struct SBNSearchInfo
 {
-    SAHooks            sHooks;
-    SAFile             fpSBN;
+    SAHooks sHooks;
+    SAFile fpSBN;
     SBNNodeDescriptor *pasNodeDescriptor;
-    int                nShapeCount;         /* Total number of shapes */
-    int                nMaxDepth;           /* Tree depth */
-    double             dfMinX;              /* Bounding box of all shapes */
-    double             dfMaxX;
-    double             dfMinY;
-    double             dfMaxY;
+    int nShapeCount; /* Total number of shapes */
+    int nMaxDepth;   /* Tree depth */
+    double dfMinX;   /* Bounding box of all shapes */
+    double dfMaxX;
+    double dfMinY;
+    double dfMaxY;
 
 #ifdef DEBUG_IO
-    int                nTotalBytesRead;
+    int nTotalBytesRead;
 #endif
 };
 
@@ -113,19 +116,19 @@ typedef struct
 {
     SBNSearchHandle hSBN;
 
-    coord               bMinX;    /* Search bounding box */
-    coord               bMinY;
-    coord               bMaxX;
-    coord               bMaxY;
+    coord bMinX; /* Search bounding box */
+    coord bMinY;
+    coord bMaxX;
+    coord bMaxY;
 
-    int                 nShapeCount;
-    int                 nShapeAlloc;
-    int                *panShapeId; /* 0 based */
+    int nShapeCount;
+    int nShapeAlloc;
+    int *panShapeId; /* 0 based */
 
-    uchar               abyBinShape[8 * 100];
+    uchar abyBinShape[8 * 100];
 
 #ifdef DEBUG_IO
-    int                 nBytesRead;
+    int nBytesRead;
 #endif
 } SearchStruct;
 
@@ -135,12 +138,14 @@ typedef struct
 /*      Swap a 2, 4 or 8 byte word.                                     */
 /************************************************************************/
 
-static void SwapWord( int length, void * wordP ) {
-    for( int i=0; i < length/2; i++ )
+static void SwapWord(int length, void *wordP)
+{
+    for (int i = 0; i < length / 2; i++)
     {
-        const uchar temp = STATIC_CAST(uchar*, wordP)[i];
-        STATIC_CAST(uchar*, wordP)[i] = STATIC_CAST(uchar*, wordP)[length-i-1];
-        STATIC_CAST(uchar*, wordP)[length-i-1] = temp;
+        const uchar temp = STATIC_CAST(uchar *, wordP)[i];
+        STATIC_CAST(uchar *, wordP)
+        [i] = STATIC_CAST(uchar *, wordP)[length - i - 1];
+        STATIC_CAST(uchar *, wordP)[length - i - 1] = temp;
     }
 }
 
@@ -148,30 +153,30 @@ static void SwapWord( int length, void * wordP ) {
 /*                         SBNOpenDiskTree()                            */
 /************************************************************************/
 
-SBNSearchHandle SBNOpenDiskTree( const char* pszSBNFilename,
-                                 SAHooks *psHooks ) {
-/* -------------------------------------------------------------------- */
-/*  Establish the byte order on this machine.                           */
-/* -------------------------------------------------------------------- */
+SBNSearchHandle SBNOpenDiskTree(const char *pszSBNFilename, SAHooks *psHooks)
+{
+    /* -------------------------------------------------------------------- */
+    /*  Establish the byte order on this machine.                           */
+    /* -------------------------------------------------------------------- */
     bool bBigEndian;
     {
-    int i = 1;
-    if( *REINTERPRET_CAST(unsigned char *, &i) == 1 )
-        bBigEndian = false;
-    else
-        bBigEndian = true;
+        int i = 1;
+        if (*REINTERPRET_CAST(unsigned char *, &i) == 1)
+            bBigEndian = false;
+        else
+            bBigEndian = true;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Initialize the handle structure.                                */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Initialize the handle structure.                                */
+    /* -------------------------------------------------------------------- */
     SBNSearchHandle hSBN =
         STATIC_CAST(SBNSearchHandle, calloc(sizeof(struct SBNSearchInfo), 1));
 
     if (psHooks == SHPLIB_NULLPTR)
-        SASetupDefaultHooks( &(hSBN->sHooks) );
+        SASetupDefaultHooks(&(hSBN->sHooks));
     else
-        memcpy( &(hSBN->sHooks), psHooks, sizeof(SAHooks) );
+        memcpy(&(hSBN->sHooks), psHooks, sizeof(SAHooks));
 
     hSBN->fpSBN = hSBN->sHooks.FOpen(pszSBNFilename, "rb");
     if (hSBN->fpSBN == SHPLIB_NULLPTR)
@@ -180,35 +185,31 @@ SBNSearchHandle SBNOpenDiskTree( const char* pszSBNFilename,
         return SHPLIB_NULLPTR;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Check file header signature.                                    */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Check file header signature.                                    */
+    /* -------------------------------------------------------------------- */
     uchar abyHeader[108];
     if (hSBN->sHooks.FRead(abyHeader, 108, 1, hSBN->fpSBN) != 1 ||
-        abyHeader[0] != 0 ||
-        abyHeader[1] != 0 ||
-        abyHeader[2] != 0x27 ||
+        abyHeader[0] != 0 || abyHeader[1] != 0 || abyHeader[2] != 0x27 ||
         (abyHeader[3] != 0x0A && abyHeader[3] != 0x0D) ||
-        abyHeader[4] != 0xFF ||
-        abyHeader[5] != 0xFF ||
-        abyHeader[6] != 0xFE ||
+        abyHeader[4] != 0xFF || abyHeader[5] != 0xFF || abyHeader[6] != 0xFE ||
         abyHeader[7] != 0x70)
     {
-        hSBN->sHooks.Error( ".sbn file is unreadable, or corrupt." );
+        hSBN->sHooks.Error(".sbn file is unreadable, or corrupt.");
         SBNCloseDiskTree(hSBN);
         return SHPLIB_NULLPTR;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Read shapes bounding box.                                       */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Read shapes bounding box.                                       */
+    /* -------------------------------------------------------------------- */
 
     memcpy(&hSBN->dfMinX, abyHeader + 32, 8);
     memcpy(&hSBN->dfMinY, abyHeader + 40, 8);
     memcpy(&hSBN->dfMaxX, abyHeader + 48, 8);
     memcpy(&hSBN->dfMaxY, abyHeader + 56, 8);
 
-    if( !bBigEndian )
+    if (!bBigEndian)
     {
         SwapWord(8, &hSBN->dfMinX);
         SwapWord(8, &hSBN->dfMinY);
@@ -216,123 +217,121 @@ SBNSearchHandle SBNOpenDiskTree( const char* pszSBNFilename,
         SwapWord(8, &hSBN->dfMaxY);
     }
 
-    if( hSBN->dfMinX > hSBN->dfMaxX ||
-        hSBN->dfMinY > hSBN->dfMaxY )
+    if (hSBN->dfMinX > hSBN->dfMaxX || hSBN->dfMinY > hSBN->dfMaxY)
     {
-        hSBN->sHooks.Error( "Invalid extent in .sbn file." );
+        hSBN->sHooks.Error("Invalid extent in .sbn file.");
         SBNCloseDiskTree(hSBN);
         return SHPLIB_NULLPTR;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Read and check number of shapes.                                */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Read and check number of shapes.                                */
+    /* -------------------------------------------------------------------- */
     const int nShapeCount = READ_MSB_INT(abyHeader + 28);
     hSBN->nShapeCount = nShapeCount;
-    if (nShapeCount < 0 || nShapeCount > 256000000 )
+    if (nShapeCount < 0 || nShapeCount > 256000000)
     {
         char szErrorMsg[64];
         snprintf(szErrorMsg, sizeof(szErrorMsg),
-                "Invalid shape count in .sbn : %d", nShapeCount );
-        hSBN->sHooks.Error( szErrorMsg );
+                 "Invalid shape count in .sbn : %d", nShapeCount);
+        hSBN->sHooks.Error(szErrorMsg);
         SBNCloseDiskTree(hSBN);
         return SHPLIB_NULLPTR;
     }
 
     /* Empty spatial index */
-    if( nShapeCount == 0 )
+    if (nShapeCount == 0)
     {
         return hSBN;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Compute tree depth.                                             */
-/*      It is computed such as in average there are not more than 8     */
-/*      shapes per node. With a minimum depth of 2, and a maximum of 24 */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Compute tree depth.                                             */
+    /*      It is computed such as in average there are not more than 8     */
+    /*      shapes per node. With a minimum depth of 2, and a maximum of 24 */
+    /* -------------------------------------------------------------------- */
     int nMaxDepth = 2;
-    while( nMaxDepth < 24 && nShapeCount > ((1 << nMaxDepth) - 1) * 8 )
-        nMaxDepth ++;
+    while (nMaxDepth < 24 && nShapeCount > ((1 << nMaxDepth) - 1) * 8)
+        nMaxDepth++;
     hSBN->nMaxDepth = nMaxDepth;
     const int nMaxNodes = (1 << nMaxDepth) - 1;
 
-/* -------------------------------------------------------------------- */
-/*      Check that the first bin id is 1.                               */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Check that the first bin id is 1.                               */
+    /* -------------------------------------------------------------------- */
 
-    if( READ_MSB_INT(abyHeader + 100) != 1 )
+    if (READ_MSB_INT(abyHeader + 100) != 1)
     {
-        hSBN->sHooks.Error( "Unexpected bin id" );
+        hSBN->sHooks.Error("Unexpected bin id");
         SBNCloseDiskTree(hSBN);
         return SHPLIB_NULLPTR;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Read and check number of node descriptors to be read.           */
-/*      There are at most (2^nMaxDepth) - 1, but all are not necessary  */
-/*      described. Non described nodes are empty.                       */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Read and check number of node descriptors to be read.           */
+    /*      There are at most (2^nMaxDepth) - 1, but all are not necessary  */
+    /*      described. Non described nodes are empty.                       */
+    /* -------------------------------------------------------------------- */
     int nNodeDescSize = READ_MSB_INT(abyHeader + 104);
     nNodeDescSize *= 2; /* 16-bit words */
 
     /* each bin descriptor is made of 2 ints */
     const int nNodeDescCount = nNodeDescSize / 8;
 
-    if ((nNodeDescSize % 8) != 0 ||
-        nNodeDescCount < 0 || nNodeDescCount > nMaxNodes )
+    if ((nNodeDescSize % 8) != 0 || nNodeDescCount < 0 ||
+        nNodeDescCount > nMaxNodes)
     {
         char szErrorMsg[64];
         snprintf(szErrorMsg, sizeof(szErrorMsg),
-                "Invalid node descriptor size in .sbn : %d", nNodeDescSize );
-        hSBN->sHooks.Error( szErrorMsg );
+                 "Invalid node descriptor size in .sbn : %d", nNodeDescSize);
+        hSBN->sHooks.Error(szErrorMsg);
         SBNCloseDiskTree(hSBN);
         return SHPLIB_NULLPTR;
     }
 
     /* coverity[tainted_data] */
-    uchar *pabyData = STATIC_CAST(uchar*, malloc( nNodeDescSize ));
-    SBNNodeDescriptor *pasNodeDescriptor = STATIC_CAST(SBNNodeDescriptor*,
-                calloc ( nMaxNodes, sizeof(SBNNodeDescriptor) ));
+    uchar *pabyData = STATIC_CAST(uchar *, malloc(nNodeDescSize));
+    SBNNodeDescriptor *pasNodeDescriptor = STATIC_CAST(
+        SBNNodeDescriptor *, calloc(nMaxNodes, sizeof(SBNNodeDescriptor)));
     if (pabyData == SHPLIB_NULLPTR || pasNodeDescriptor == SHPLIB_NULLPTR)
     {
         free(pabyData);
         free(pasNodeDescriptor);
-        hSBN->sHooks.Error( "Out of memory error" );
+        hSBN->sHooks.Error("Out of memory error");
         SBNCloseDiskTree(hSBN);
         return SHPLIB_NULLPTR;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Read node descriptors.                                          */
-/* -------------------------------------------------------------------- */
-    if (hSBN->sHooks.FRead(pabyData, nNodeDescSize, 1,
-                                  hSBN->fpSBN) != 1)
+    /* -------------------------------------------------------------------- */
+    /*      Read node descriptors.                                          */
+    /* -------------------------------------------------------------------- */
+    if (hSBN->sHooks.FRead(pabyData, nNodeDescSize, 1, hSBN->fpSBN) != 1)
     {
         free(pabyData);
         free(pasNodeDescriptor);
-        hSBN->sHooks.Error( "Cannot read node descriptors" );
+        hSBN->sHooks.Error("Cannot read node descriptors");
         SBNCloseDiskTree(hSBN);
         return SHPLIB_NULLPTR;
     }
 
     hSBN->pasNodeDescriptor = pasNodeDescriptor;
 
-    for(int i = 0; i < nNodeDescCount; i++)
+    for (int i = 0; i < nNodeDescCount; i++)
     {
-/* -------------------------------------------------------------------- */
-/*      Each node descriptor contains the index of the first bin that   */
-/*      described it, and the number of shapes in this first bin and    */
-/*      the following bins (in the relevant case).                      */
-/* -------------------------------------------------------------------- */
+        /* -------------------------------------------------------------------- */
+        /*      Each node descriptor contains the index of the first bin that   */
+        /*      described it, and the number of shapes in this first bin and    */
+        /*      the following bins (in the relevant case).                      */
+        /* -------------------------------------------------------------------- */
         int nBinStart = READ_MSB_INT(pabyData + 8 * i);
         int nNodeShapeCount = READ_MSB_INT(pabyData + 8 * i + 4);
         pasNodeDescriptor[i].nBinStart = nBinStart > 0 ? nBinStart : 0;
         pasNodeDescriptor[i].nShapeCount = nNodeShapeCount;
 
-        if ((nBinStart > 0 && nNodeShapeCount == 0) ||
-            nNodeShapeCount < 0 || nNodeShapeCount > nShapeCount)
+        if ((nBinStart > 0 && nNodeShapeCount == 0) || nNodeShapeCount < 0 ||
+            nNodeShapeCount > nShapeCount)
         {
-            hSBN->sHooks.Error( "Inconsistent shape count in bin" );
+            hSBN->sHooks.Error("Inconsistent shape count in bin");
             SBNCloseDiskTree(hSBN);
             return SHPLIB_NULLPTR;
         }
@@ -343,12 +342,12 @@ SBNSearchHandle SBNOpenDiskTree( const char* pszSBNFilename,
 
     /* Locate first non-empty node */
     int nCurNode = 0;
-    while(nCurNode < nMaxNodes && pasNodeDescriptor[nCurNode].nBinStart <= 0)
-        nCurNode ++;
+    while (nCurNode < nMaxNodes && pasNodeDescriptor[nCurNode].nBinStart <= 0)
+        nCurNode++;
 
-    if( nCurNode >= nMaxNodes)
+    if (nCurNode >= nMaxNodes)
     {
-        hSBN->sHooks.Error( "All nodes are empty" );
+        hSBN->sHooks.Error("All nodes are empty");
         SBNCloseDiskTree(hSBN);
         return SHPLIB_NULLPTR;
     }
@@ -358,21 +357,20 @@ SBNSearchHandle SBNOpenDiskTree( const char* pszSBNFilename,
 
     /* Compute the index of the next non empty node. */
     int nNextNonEmptyNode = nCurNode + 1;
-    while(nNextNonEmptyNode < nMaxNodes &&
-        pasNodeDescriptor[nNextNonEmptyNode].nBinStart <= 0)
-        nNextNonEmptyNode ++;
+    while (nNextNonEmptyNode < nMaxNodes &&
+           pasNodeDescriptor[nNextNonEmptyNode].nBinStart <= 0)
+        nNextNonEmptyNode++;
 
     int nExpectedBinId = 1;
 
-/* -------------------------------------------------------------------- */
-/*      Traverse bins to compute the offset of the first bin of each    */
-/*      node.                                                           */
-/*      Note: we could use the .sbx file to compute the offsets instead.*/
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Traverse bins to compute the offset of the first bin of each    */
+    /*      node.                                                           */
+    /*      Note: we could use the .sbx file to compute the offsets instead.*/
+    /* -------------------------------------------------------------------- */
     uchar abyBinHeader[8];
 
-    while( hSBN->sHooks.FRead(abyBinHeader, 8, 1,
-                                     hSBN->fpSBN) == 1 )
+    while (hSBN->sHooks.FRead(abyBinHeader, 8, 1, hSBN->fpSBN) == 1)
     {
         nExpectedBinId++;
 
@@ -380,24 +378,24 @@ SBNSearchHandle SBNOpenDiskTree( const char* pszSBNFilename,
         int nBinSize = READ_MSB_INT(abyBinHeader + 4);
         nBinSize *= 2; /* 16-bit words */
 
-        if( nBinId != nExpectedBinId )
+        if (nBinId != nExpectedBinId)
         {
-            hSBN->sHooks.Error( "Unexpected bin id" );
+            hSBN->sHooks.Error("Unexpected bin id");
             SBNCloseDiskTree(hSBN);
             return SHPLIB_NULLPTR;
         }
 
         /* Bins are always limited to 100 features */
         /* If there are more, then they are located in continuous bins */
-        if( (nBinSize % 8) != 0 || nBinSize <= 0 || nBinSize > 100 * 8)
+        if ((nBinSize % 8) != 0 || nBinSize <= 0 || nBinSize > 100 * 8)
         {
-            hSBN->sHooks.Error( "Unexpected bin size" );
+            hSBN->sHooks.Error("Unexpected bin size");
             SBNCloseDiskTree(hSBN);
             return SHPLIB_NULLPTR;
         }
 
-        if( nNextNonEmptyNode < nMaxNodes &&
-            nBinId == pasNodeDescriptor[nNextNonEmptyNode].nBinStart )
+        if (nNextNonEmptyNode < nMaxNodes &&
+            nBinId == pasNodeDescriptor[nNextNonEmptyNode].nBinStart)
         {
             nCurNode = nNextNonEmptyNode;
             pasNodeDescriptor[nCurNode].nBinOffset =
@@ -405,12 +403,12 @@ SBNSearchHandle SBNOpenDiskTree( const char* pszSBNFilename,
 
             /* Compute the index of the next non empty node. */
             nNextNonEmptyNode = nCurNode + 1;
-            while(nNextNonEmptyNode < nMaxNodes &&
-                  pasNodeDescriptor[nNextNonEmptyNode].nBinStart <= 0)
-                nNextNonEmptyNode ++;
+            while (nNextNonEmptyNode < nMaxNodes &&
+                   pasNodeDescriptor[nNextNonEmptyNode].nBinStart <= 0)
+                nNextNonEmptyNode++;
         }
 
-        pasNodeDescriptor[nCurNode].nBinCount ++;
+        pasNodeDescriptor[nCurNode].nBinCount++;
 
         /* Skip shape description */
         hSBN->sHooks.FSeek(hSBN->fpSBN, nBinSize, SEEK_CUR);
@@ -423,16 +421,17 @@ SBNSearchHandle SBNOpenDiskTree( const char* pszSBNFilename,
 /*                          SBNCloseDiskTree()                         */
 /************************************************************************/
 
-void SBNCloseDiskTree( SBNSearchHandle hSBN ) {
+void SBNCloseDiskTree(SBNSearchHandle hSBN)
+{
     if (hSBN == SHPLIB_NULLPTR)
         return;
 
-    if( hSBN->pasNodeDescriptor != SHPLIB_NULLPTR )
+    if (hSBN->pasNodeDescriptor != SHPLIB_NULLPTR)
     {
         const int nMaxNodes = (1 << hSBN->nMaxDepth) - 1;
-        for(int i = 0; i < nMaxNodes; i++)
+        for (int i = 0; i < nMaxNodes; i++)
         {
-            if( hSBN->pasNodeDescriptor[i].pabyShapeDesc != SHPLIB_NULLPTR )
+            if (hSBN->pasNodeDescriptor[i].pabyShapeDesc != SHPLIB_NULLPTR)
                 free(hSBN->pasNodeDescriptor[i].pabyShapeDesc);
         }
     }
@@ -444,30 +443,29 @@ void SBNCloseDiskTree( SBNSearchHandle hSBN ) {
     free(hSBN);
 }
 
-
 /************************************************************************/
 /*                         SBNAddShapeId()                              */
 /************************************************************************/
 
-static bool SBNAddShapeId( SearchStruct* psSearch,
-                          int nShapeId ) {
+static bool SBNAddShapeId(SearchStruct *psSearch, int nShapeId)
+{
     if (psSearch->nShapeCount == psSearch->nShapeAlloc)
     {
         psSearch->nShapeAlloc =
             STATIC_CAST(int, ((psSearch->nShapeCount + 100) * 5) / 4);
         int *pNewPtr =
-            STATIC_CAST(int *, realloc( psSearch->panShapeId,
-                               psSearch->nShapeAlloc * sizeof(int) ));
-        if( pNewPtr == SHPLIB_NULLPTR )
+            STATIC_CAST(int *, realloc(psSearch->panShapeId,
+                                       psSearch->nShapeAlloc * sizeof(int)));
+        if (pNewPtr == SHPLIB_NULLPTR)
         {
-            psSearch->hSBN->sHooks.Error( "Out of memory error" );
+            psSearch->hSBN->sHooks.Error("Out of memory error");
             return false;
         }
         psSearch->panShapeId = pNewPtr;
     }
 
     psSearch->panShapeId[psSearch->nShapeCount] = nShapeId;
-    psSearch->nShapeCount ++;
+    psSearch->nShapeCount++;
     return true;
 }
 
@@ -478,22 +476,17 @@ static bool SBNAddShapeId( SearchStruct* psSearch,
 /*      Due to the way integer coordinates are rounded,                 */
 /*      we can use a strict intersection test, except when the node     */
 /*      bounding box or the search bounding box is degenerated.         */
-#define SEARCH_BB_INTERSECTS(_bMinX, _bMinY, _bMaxX, _bMaxY) \
-   (((bSearchMinX < _bMaxX && bSearchMaxX > _bMinX) || \
-    ((_bMinX == _bMaxX || bSearchMinX == bSearchMaxX) && \
-     bSearchMinX <= _bMaxX && bSearchMaxX >= _bMinX)) && \
-    ((bSearchMinY < _bMaxY && bSearchMaxY > _bMinY) || \
-    ((_bMinY == _bMaxY || bSearchMinY == bSearchMaxY ) && \
-     bSearchMinY <= _bMaxY && bSearchMaxY >= _bMinY)))
+#define SEARCH_BB_INTERSECTS(_bMinX, _bMinY, _bMaxX, _bMaxY)                   \
+    (((bSearchMinX < _bMaxX && bSearchMaxX > _bMinX) ||                        \
+      ((_bMinX == _bMaxX || bSearchMinX == bSearchMaxX) &&                     \
+       bSearchMinX <= _bMaxX && bSearchMaxX >= _bMinX)) &&                     \
+     ((bSearchMinY < _bMaxY && bSearchMaxY > _bMinY) ||                        \
+      ((_bMinY == _bMaxY || bSearchMinY == bSearchMaxY) &&                     \
+       bSearchMinY <= _bMaxY && bSearchMaxY >= _bMinY)))
 
-
-static bool SBNSearchDiskInternal( SearchStruct* psSearch,
-                                  int nDepth,
-                                  int nNodeId,
-                                  coord bNodeMinX,
-                                  coord bNodeMinY,
-                                  coord bNodeMaxX,
-                                  coord bNodeMaxY )
+static bool SBNSearchDiskInternal(SearchStruct *psSearch, int nDepth,
+                                  int nNodeId, coord bNodeMinX, coord bNodeMinY,
+                                  coord bNodeMaxX, coord bNodeMaxY)
 {
     const coord bSearchMinX = psSearch->bMinX;
     const coord bSearchMinY = psSearch->bMinY;
@@ -502,48 +495,48 @@ static bool SBNSearchDiskInternal( SearchStruct* psSearch,
 
     SBNSearchHandle hSBN = psSearch->hSBN;
 
-    SBNNodeDescriptor* psNode = &(hSBN->pasNodeDescriptor[nNodeId]);
+    SBNNodeDescriptor *psNode = &(hSBN->pasNodeDescriptor[nNodeId]);
 
-/* -------------------------------------------------------------------- */
-/*      Check if this node contains shapes that intersect the search    */
-/*      bounding box.                                                   */
-/* -------------------------------------------------------------------- */
-    if ( psNode->bBBoxInit &&
-         !(SEARCH_BB_INTERSECTS(psNode->bMinX, psNode->bMinY,
-                                psNode->bMaxX, psNode->bMaxY)) )
+    /* -------------------------------------------------------------------- */
+    /*      Check if this node contains shapes that intersect the search    */
+    /*      bounding box.                                                   */
+    /* -------------------------------------------------------------------- */
+    if (psNode->bBBoxInit &&
+        !(SEARCH_BB_INTERSECTS(psNode->bMinX, psNode->bMinY, psNode->bMaxX,
+                               psNode->bMaxY)))
 
     {
         /* No intersection, then don't try to read the shapes attached */
         /* to this node */
     }
 
-/* -------------------------------------------------------------------- */
-/*      If this node contains shapes that are cached, then read them.   */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      If this node contains shapes that are cached, then read them.   */
+    /* -------------------------------------------------------------------- */
     else if (psNode->pabyShapeDesc != SHPLIB_NULLPTR)
     {
-        uchar* pabyShapeDesc = psNode->pabyShapeDesc;
+        uchar *pabyShapeDesc = psNode->pabyShapeDesc;
 
         /* printf("nNodeId = %d, nDepth = %d\n", nNodeId, nDepth); */
 
-        for(int j = 0; j < psNode->nShapeCount; j++)
+        for (int j = 0; j < psNode->nShapeCount; j++)
         {
             const coord bMinX = pabyShapeDesc[0];
             const coord bMinY = pabyShapeDesc[1];
             const coord bMaxX = pabyShapeDesc[2];
             const coord bMaxY = pabyShapeDesc[3];
 
-            if( SEARCH_BB_INTERSECTS(bMinX, bMinY, bMaxX, bMaxY) )
+            if (SEARCH_BB_INTERSECTS(bMinX, bMinY, bMaxX, bMaxY))
             {
                 int nShapeId = READ_MSB_INT(pabyShapeDesc + 4);
 
                 /* Caution : we count shape id starting from 0, and not 1 */
-                nShapeId --;
+                nShapeId--;
 
                 /*printf("shape=%d, minx=%d, miny=%d, maxx=%d, maxy=%d\n",
                        nShapeId, bMinX, bMinY, bMaxX, bMaxY);*/
 
-                if( !SBNAddShapeId( psSearch, nShapeId ) )
+                if (!SBNAddShapeId(psSearch, nShapeId))
                     return false;
             }
 
@@ -551,38 +544,38 @@ static bool SBNSearchDiskInternal( SearchStruct* psSearch,
         }
     }
 
-/* -------------------------------------------------------------------- */
-/*      If the node has attached shapes (that are not (yet) cached),    */
-/*      then retrieve them from disk.                                   */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      If the node has attached shapes (that are not (yet) cached),    */
+    /*      then retrieve them from disk.                                   */
+    /* -------------------------------------------------------------------- */
 
     else if (psNode->nBinCount > 0)
     {
         hSBN->sHooks.FSeek(hSBN->fpSBN, psNode->nBinOffset, SEEK_SET);
 
         if (nDepth < CACHED_DEPTH_LIMIT)
-            psNode->pabyShapeDesc = STATIC_CAST(uchar*, malloc(psNode->nShapeCount * 8));
+            psNode->pabyShapeDesc =
+                STATIC_CAST(uchar *, malloc(psNode->nShapeCount * 8));
 
         uchar abyBinHeader[8];
         int nShapeCountAcc = 0;
 
-        for(int i = 0; i < psNode->nBinCount; i++)
+        for (int i = 0; i < psNode->nBinCount; i++)
         {
 #ifdef DEBUG_IO
             psSearch->nBytesRead += 8;
 #endif
-            if( hSBN->sHooks.FRead(abyBinHeader, 8, 1,
-                                          hSBN->fpSBN) != 1)
+            if (hSBN->sHooks.FRead(abyBinHeader, 8, 1, hSBN->fpSBN) != 1)
             {
-                hSBN->sHooks.Error( "I/O error" );
+                hSBN->sHooks.Error("I/O error");
                 free(psNode->pabyShapeDesc);
                 psNode->pabyShapeDesc = SHPLIB_NULLPTR;
                 return false;
             }
 
-            if ( READ_MSB_INT(abyBinHeader + 0) != psNode->nBinStart + i )
+            if (READ_MSB_INT(abyBinHeader + 0) != psNode->nBinStart + i)
             {
-                hSBN->sHooks.Error( "Unexpected bin id" );
+                hSBN->sHooks.Error("Unexpected bin id");
                 free(psNode->pabyShapeDesc);
                 psNode->pabyShapeDesc = SHPLIB_NULLPTR;
                 return false;
@@ -594,24 +587,25 @@ static bool SBNSearchDiskInternal( SearchStruct* psSearch,
             int nShapes = nBinSize / 8;
 
             /* Bins are always limited to 100 features */
-            if( (nBinSize % 8) != 0 || nShapes <= 0 || nShapes > 100)
+            if ((nBinSize % 8) != 0 || nShapes <= 0 || nShapes > 100)
             {
-                hSBN->sHooks.Error( "Unexpected bin size" );
+                hSBN->sHooks.Error("Unexpected bin size");
                 free(psNode->pabyShapeDesc);
                 psNode->pabyShapeDesc = SHPLIB_NULLPTR;
                 return false;
             }
 
-            if( nShapeCountAcc + nShapes > psNode->nShapeCount)
+            if (nShapeCountAcc + nShapes > psNode->nShapeCount)
             {
                 free(psNode->pabyShapeDesc);
                 psNode->pabyShapeDesc = SHPLIB_NULLPTR;
-                hSBN->sHooks.Error( "Inconsistent shape count for bin" );
+                hSBN->sHooks.Error("Inconsistent shape count for bin");
                 return false;
             }
 
-            uchar* pabyBinShape;
-            if (nDepth < CACHED_DEPTH_LIMIT && psNode->pabyShapeDesc != SHPLIB_NULLPTR)
+            uchar *pabyBinShape;
+            if (nDepth < CACHED_DEPTH_LIMIT &&
+                psNode->pabyShapeDesc != SHPLIB_NULLPTR)
             {
                 pabyBinShape = psNode->pabyShapeDesc + nShapeCountAcc * 8;
             }
@@ -623,10 +617,9 @@ static bool SBNSearchDiskInternal( SearchStruct* psSearch,
 #ifdef DEBUG_IO
             psSearch->nBytesRead += nBinSize;
 #endif
-            if (hSBN->sHooks.FRead(pabyBinShape, nBinSize, 1,
-                                          hSBN->fpSBN) != 1)
+            if (hSBN->sHooks.FRead(pabyBinShape, nBinSize, 1, hSBN->fpSBN) != 1)
             {
-                hSBN->sHooks.Error( "I/O error" );
+                hSBN->sHooks.Error("I/O error");
                 free(psNode->pabyShapeDesc);
                 psNode->pabyShapeDesc = SHPLIB_NULLPTR;
                 return false;
@@ -642,58 +635,59 @@ static bool SBNSearchDiskInternal( SearchStruct* psSearch,
                 psNode->bMaxY = pabyBinShape[3];
             }
 
-            for(int j = 0; j < nShapes; j++)
+            for (int j = 0; j < nShapes; j++)
             {
                 const coord bMinX = pabyBinShape[0];
                 const coord bMinY = pabyBinShape[1];
                 const coord bMaxX = pabyBinShape[2];
                 const coord bMaxY = pabyBinShape[3];
 
-                if( !psNode->bBBoxInit )
+                if (!psNode->bBBoxInit)
                 {
 #ifdef sanity_checks
-/* -------------------------------------------------------------------- */
-/*      Those tests only check that the shape bounding box in the bin   */
-/*      are consistent (self-consistent and consistent with the node    */
-/*      they are attached to). They are optional however (as far as     */
-/*      the safety of runtime is concerned at least).                   */
-/* -------------------------------------------------------------------- */
+                    /* -------------------------------------------------------------------- */
+                    /*      Those tests only check that the shape bounding box in the bin   */
+                    /*      are consistent (self-consistent and consistent with the node    */
+                    /*      they are attached to). They are optional however (as far as     */
+                    /*      the safety of runtime is concerned at least).                   */
+                    /* -------------------------------------------------------------------- */
 
-                    if( !(((bMinX < bMaxX ||
-                           (bMinX == 0 && bMaxX == 0) ||
-                           (bMinX == 255 && bMaxX == 255))) &&
-                          ((bMinY < bMaxY ||
-                           (bMinY == 0 && bMaxY == 0) ||
-                           (bMinY == 255 && bMaxY == 255)))) ||
+                    if (!(((bMinX < bMaxX || (bMinX == 0 && bMaxX == 0) ||
+                            (bMinX == 255 && bMaxX == 255))) &&
+                          ((bMinY < bMaxY || (bMinY == 0 && bMaxY == 0) ||
+                            (bMinY == 255 && bMaxY == 255)))) ||
                         bMaxX < bNodeMinX || bMaxY < bNodeMinY ||
-                        bMinX > bNodeMaxX || bMinY > bNodeMaxY )
+                        bMinX > bNodeMaxX || bMinY > bNodeMaxY)
                     {
                         /* printf("shape %d %d %d %d\n", bMinX, bMinY, bMaxX, bMaxY);*/
                         /* printf("node  %d %d %d %d\n", bNodeMinX, bNodeMinY, bNodeMaxX, bNodeMaxY);*/
-                        hSBN->sHooks.Error(
-                            "Invalid shape bounding box in bin" );
+                        hSBN->sHooks.Error("Invalid shape bounding box in bin");
                         free(psNode->pabyShapeDesc);
                         psNode->pabyShapeDesc = SHPLIB_NULLPTR;
                         return false;
                     }
 #endif
-                    if (bMinX < psNode->bMinX) psNode->bMinX = bMinX;
-                    if (bMinY < psNode->bMinY) psNode->bMinY = bMinY;
-                    if (bMaxX > psNode->bMaxX) psNode->bMaxX = bMaxX;
-                    if (bMaxY > psNode->bMaxY) psNode->bMaxY = bMaxY;
+                    if (bMinX < psNode->bMinX)
+                        psNode->bMinX = bMinX;
+                    if (bMinY < psNode->bMinY)
+                        psNode->bMinY = bMinY;
+                    if (bMaxX > psNode->bMaxX)
+                        psNode->bMaxX = bMaxX;
+                    if (bMaxY > psNode->bMaxY)
+                        psNode->bMaxY = bMaxY;
                 }
 
-                if( SEARCH_BB_INTERSECTS(bMinX, bMinY, bMaxX, bMaxY) )
+                if (SEARCH_BB_INTERSECTS(bMinX, bMinY, bMaxX, bMaxY))
                 {
                     int nShapeId = READ_MSB_INT(pabyBinShape + 4);
 
                     /* Caution : we count shape id starting from 0, and not 1 */
-                    nShapeId --;
+                    nShapeId--;
 
                     /*printf("shape=%d, minx=%d, miny=%d, maxx=%d, maxy=%d\n",
                         nShapeId, bMinX, bMinY, bMaxX, bMaxY);*/
 
-                    if( !SBNAddShapeId( psSearch, nShapeId ) )
+                    if (!SBNAddShapeId(psSearch, nShapeId))
                         return false;
                 }
 
@@ -701,56 +695,56 @@ static bool SBNSearchDiskInternal( SearchStruct* psSearch,
             }
         }
 
-        if( nShapeCountAcc != psNode->nShapeCount)
+        if (nShapeCountAcc != psNode->nShapeCount)
         {
             free(psNode->pabyShapeDesc);
             psNode->pabyShapeDesc = SHPLIB_NULLPTR;
-            hSBN->sHooks.Error( "Inconsistent shape count for bin" );
+            hSBN->sHooks.Error("Inconsistent shape count for bin");
             return false;
         }
 
         psNode->bBBoxInit = true;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Look up in child nodes.                                         */
-/* -------------------------------------------------------------------- */
-    if( nDepth + 1 < hSBN->nMaxDepth )
+    /* -------------------------------------------------------------------- */
+    /*      Look up in child nodes.                                         */
+    /* -------------------------------------------------------------------- */
+    if (nDepth + 1 < hSBN->nMaxDepth)
     {
         nNodeId = nNodeId * 2 + 1;
 
-        if( (nDepth % 2) == 0 ) /* x split */
+        if ((nDepth % 2) == 0) /* x split */
         {
-            const coord bMid = STATIC_CAST(coord, 1 + (STATIC_CAST(int, bNodeMinX) + bNodeMaxX) / 2);
-            if( bSearchMinX <= bMid - 1 &&
-                !SBNSearchDiskInternal( psSearch, nDepth + 1, nNodeId + 1,
-                                        bNodeMinX, bNodeMinY,
-                                        bMid - 1, bNodeMaxY ) )
+            const coord bMid = STATIC_CAST(
+                coord, 1 + (STATIC_CAST(int, bNodeMinX) + bNodeMaxX) / 2);
+            if (bSearchMinX <= bMid - 1 &&
+                !SBNSearchDiskInternal(psSearch, nDepth + 1, nNodeId + 1,
+                                       bNodeMinX, bNodeMinY, bMid - 1,
+                                       bNodeMaxY))
             {
                 return false;
             }
-            if( bSearchMaxX >= bMid &&
-                !SBNSearchDiskInternal( psSearch, nDepth + 1, nNodeId,
-                                        bMid, bNodeMinY,
-                                        bNodeMaxX, bNodeMaxY ) )
+            if (bSearchMaxX >= bMid &&
+                !SBNSearchDiskInternal(psSearch, nDepth + 1, nNodeId, bMid,
+                                       bNodeMinY, bNodeMaxX, bNodeMaxY))
             {
                 return false;
             }
         }
         else /* y split */
         {
-            const coord bMid = STATIC_CAST(coord, 1 + (STATIC_CAST(int, bNodeMinY) + bNodeMaxY) / 2);
-            if( bSearchMinY <= bMid - 1 &&
-                !SBNSearchDiskInternal( psSearch, nDepth + 1, nNodeId + 1,
-                                        bNodeMinX, bNodeMinY,
-                                        bNodeMaxX, bMid - 1 ) )
+            const coord bMid = STATIC_CAST(
+                coord, 1 + (STATIC_CAST(int, bNodeMinY) + bNodeMaxY) / 2);
+            if (bSearchMinY <= bMid - 1 &&
+                !SBNSearchDiskInternal(psSearch, nDepth + 1, nNodeId + 1,
+                                       bNodeMinX, bNodeMinY, bNodeMaxX,
+                                       bMid - 1))
             {
                 return false;
             }
-            if( bSearchMaxY >= bMid &&
-                !SBNSearchDiskInternal( psSearch, nDepth + 1, nNodeId,
-                                        bNodeMinX, bMid,
-                                        bNodeMaxX, bNodeMaxY ) )
+            if (bSearchMaxY >= bMid &&
+                !SBNSearchDiskInternal(psSearch, nDepth + 1, nNodeId, bNodeMinX,
+                                       bMid, bNodeMaxX, bNodeMaxY))
             {
                 return false;
             }
@@ -765,19 +759,19 @@ static bool SBNSearchDiskInternal( SearchStruct* psSearch,
 /************************************************************************/
 
 /* helper for qsort */
-static int
-compare_ints( const void * a, const void * b)
+static int compare_ints(const void *a, const void *b)
 {
-    return *REINTERPRET_CAST(const int*, a) - *REINTERPRET_CAST(const int*, b);
+    return *REINTERPRET_CAST(const int *, a) -
+           *REINTERPRET_CAST(const int *, b);
 }
 
 /************************************************************************/
 /*                        SBNSearchDiskTree()                           */
 /************************************************************************/
 
-int* SBNSearchDiskTree( SBNSearchHandle hSBN,
-                        double *padfBoundsMin, double *padfBoundsMax,
-                        int *pnShapeCount ) {
+int *SBNSearchDiskTree(SBNSearchHandle hSBN, double *padfBoundsMin,
+                       double *padfBoundsMax, int *pnShapeCount)
+{
     *pnShapeCount = 0;
 
     const double dfMinX = padfBoundsMin[0];
@@ -785,16 +779,16 @@ int* SBNSearchDiskTree( SBNSearchHandle hSBN,
     const double dfMaxX = padfBoundsMax[0];
     const double dfMaxY = padfBoundsMax[1];
 
-    if( dfMinX > dfMaxX || dfMinY > dfMaxY )
+    if (dfMinX > dfMaxX || dfMinY > dfMaxY)
         return SHPLIB_NULLPTR;
 
-    if( dfMaxX < hSBN->dfMinX || dfMaxY < hSBN->dfMinY ||
-        dfMinX > hSBN->dfMaxX || dfMinY > hSBN->dfMaxY )
+    if (dfMaxX < hSBN->dfMinX || dfMaxY < hSBN->dfMinY ||
+        dfMinX > hSBN->dfMaxX || dfMinY > hSBN->dfMaxY)
         return SHPLIB_NULLPTR;
 
-/* -------------------------------------------------------------------- */
-/*      Compute the search coordinates in [0,255]x[0,255] coord. space  */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Compute the search coordinates in [0,255]x[0,255] coord. space  */
+    /* -------------------------------------------------------------------- */
     const double dfDiskXExtent = hSBN->dfMaxX - hSBN->dfMinX;
     const double dfDiskYExtent = hSBN->dfMaxY - hSBN->dfMinY;
 
@@ -802,68 +796,71 @@ int* SBNSearchDiskTree( SBNSearchHandle hSBN,
     int bMaxX;
     int bMinY;
     int bMaxY;
-    if ( dfDiskXExtent == 0.0 )
+    if (dfDiskXExtent == 0.0)
     {
         bMinX = 0;
         bMaxX = 255;
     }
     else
     {
-        if( dfMinX < hSBN->dfMinX )
+        if (dfMinX < hSBN->dfMinX)
             bMinX = 0;
         else
         {
-            const double dfMinX_255 = (dfMinX - hSBN->dfMinX)
-                                                    / dfDiskXExtent * 255.0;
+            const double dfMinX_255 =
+                (dfMinX - hSBN->dfMinX) / dfDiskXExtent * 255.0;
             bMinX = STATIC_CAST(int, floor(dfMinX_255 - 0.005));
-            if( bMinX < 0 ) bMinX = 0;
+            if (bMinX < 0)
+                bMinX = 0;
         }
 
-        if( dfMaxX > hSBN->dfMaxX )
+        if (dfMaxX > hSBN->dfMaxX)
             bMaxX = 255;
         else
         {
-            const double dfMaxX_255 = (dfMaxX - hSBN->dfMinX)
-                                                    / dfDiskXExtent * 255.0;
+            const double dfMaxX_255 =
+                (dfMaxX - hSBN->dfMinX) / dfDiskXExtent * 255.0;
             bMaxX = STATIC_CAST(int, ceil(dfMaxX_255 + 0.005));
-            if( bMaxX > 255 ) bMaxX = 255;
+            if (bMaxX > 255)
+                bMaxX = 255;
         }
     }
 
-    if ( dfDiskYExtent == 0.0 )
+    if (dfDiskYExtent == 0.0)
     {
         bMinY = 0;
         bMaxY = 255;
     }
     else
     {
-        if( dfMinY < hSBN->dfMinY )
+        if (dfMinY < hSBN->dfMinY)
             bMinY = 0;
         else
         {
-            const double dfMinY_255 = (dfMinY - hSBN->dfMinY)
-                                                    / dfDiskYExtent * 255.0;
+            const double dfMinY_255 =
+                (dfMinY - hSBN->dfMinY) / dfDiskYExtent * 255.0;
             bMinY = STATIC_CAST(int, floor(dfMinY_255 - 0.005));
-            if( bMinY < 0 ) bMinY = 0;
+            if (bMinY < 0)
+                bMinY = 0;
         }
 
-        if( dfMaxY > hSBN->dfMaxY )
+        if (dfMaxY > hSBN->dfMaxY)
             bMaxY = 255;
         else
         {
-            const double dfMaxY_255 = (dfMaxY - hSBN->dfMinY)
-                                                    / dfDiskYExtent * 255.0;
+            const double dfMaxY_255 =
+                (dfMaxY - hSBN->dfMinY) / dfDiskYExtent * 255.0;
             bMaxY = STATIC_CAST(int, ceil(dfMaxY_255 + 0.005));
-            if( bMaxY > 255 ) bMaxY = 255;
+            if (bMaxY > 255)
+                bMaxY = 255;
         }
     }
 
-/* -------------------------------------------------------------------- */
-/*      Run the search.                                                 */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Run the search.                                                 */
+    /* -------------------------------------------------------------------- */
 
-    return SBNSearchDiskTreeInteger(hSBN,
-                                    bMinX, bMinY, bMaxX, bMaxY,
+    return SBNSearchDiskTreeInteger(hSBN, bMinX, bMinY, bMaxX, bMaxY,
                                     pnShapeCount);
 }
 
@@ -871,24 +868,24 @@ int* SBNSearchDiskTree( SBNSearchHandle hSBN,
 /*                     SBNSearchDiskTreeInteger()                       */
 /************************************************************************/
 
-int* SBNSearchDiskTreeInteger( SBNSearchHandle hSBN,
-                               int bMinX, int bMinY, int bMaxX, int bMaxY,
-                               int *pnShapeCount ) {
+int *SBNSearchDiskTreeInteger(SBNSearchHandle hSBN, int bMinX, int bMinY,
+                              int bMaxX, int bMaxY, int *pnShapeCount)
+{
     *pnShapeCount = 0;
 
-    if( bMinX > bMaxX || bMinY > bMaxY )
+    if (bMinX > bMaxX || bMinY > bMaxY)
         return SHPLIB_NULLPTR;
 
-    if( bMaxX < 0 || bMaxY < 0 || bMinX > 255 || bMinY > 255 )
+    if (bMaxX < 0 || bMaxY < 0 || bMinX > 255 || bMinY > 255)
         return SHPLIB_NULLPTR;
 
-    if( hSBN->nShapeCount == 0 )
+    if (hSBN->nShapeCount == 0)
         return SHPLIB_NULLPTR;
-/* -------------------------------------------------------------------- */
-/*      Run the search.                                                 */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Run the search.                                                 */
+    /* -------------------------------------------------------------------- */
     SearchStruct sSearch;
-    memset( &sSearch, 0, sizeof(sSearch) );
+    memset(&sSearch, 0, sizeof(sSearch));
     sSearch.hSBN = hSBN;
     sSearch.bMinX = STATIC_CAST(coord, bMinX >= 0 ? bMinX : 0);
     sSearch.bMinY = STATIC_CAST(coord, bMinY >= 0 ? bMinY : 0);
@@ -896,7 +893,7 @@ int* SBNSearchDiskTreeInteger( SBNSearchHandle hSBN,
     sSearch.bMaxY = STATIC_CAST(coord, bMaxY <= 255 ? bMaxY : 255);
     sSearch.nShapeCount = 0;
     sSearch.nShapeAlloc = 0;
-    sSearch.panShapeId = STATIC_CAST(int*, calloc(1, sizeof(int)));
+    sSearch.panShapeId = STATIC_CAST(int *, calloc(1, sizeof(int)));
 #ifdef DEBUG_IO
     sSearch.nBytesRead = 0;
 #endif
@@ -908,18 +905,18 @@ int* SBNSearchDiskTreeInteger( SBNSearchHandle hSBN,
     /* printf("nBytesRead = %d\n", sSearch.nBytesRead); */
 #endif
 
-    if( !bRet )
+    if (!bRet)
     {
-        free( sSearch.panShapeId );
+        free(sSearch.panShapeId);
         *pnShapeCount = 0;
         return SHPLIB_NULLPTR;
     }
 
     *pnShapeCount = sSearch.nShapeCount;
 
-/* -------------------------------------------------------------------- */
-/*      Sort the id array                                               */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Sort the id array                                               */
+    /* -------------------------------------------------------------------- */
     qsort(sSearch.panShapeId, *pnShapeCount, sizeof(int), compare_ints);
 
     return sSearch.panShapeId;
@@ -929,6 +926,7 @@ int* SBNSearchDiskTreeInteger( SBNSearchHandle hSBN,
 /*                         SBNSearchFreeIds()                           */
 /************************************************************************/
 
-void SBNSearchFreeIds( int* panShapeId ) {
-    free( panShapeId );
+void SBNSearchFreeIds(int *panShapeId)
+{
+    free(panShapeId);
 }

--- a/shapefil.h
+++ b/shapefil.h
@@ -49,7 +49,8 @@
 #endif
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 /************************************************************************/
@@ -69,51 +70,51 @@ extern "C" {
 /* -------------------------------------------------------------------- */
 #define DISABLE_MULTIPATCH_MEASURE
 
-/* -------------------------------------------------------------------- */
-/*      SHPAPI_CALL                                                     */
-/*                                                                      */
-/*      The following two macros are present to allow forcing           */
-/*      various calling conventions on the Shapelib API.                */
-/*                                                                      */
-/*      To force __stdcall conventions (needed to call Shapelib         */
-/*      from Visual Basic and/or Dephi I believe) the makefile could    */
-/*      be modified to define:                                          */
-/*                                                                      */
-/*        /DSHPAPI_CALL=__stdcall                                       */
-/*                                                                      */
-/*      If it is desired to force export of the Shapelib API without    */
-/*      using the shapelib.def file, use the following definition.      */
-/*                                                                      */
-/*        /DSHAPELIB_DLLEXPORT                                          */
-/*                                                                      */
-/*      To get both at once it will be necessary to hack this           */
-/*      include file to define:                                         */
-/*                                                                      */
-/*        #define SHPAPI_CALL __declspec(dllexport) __stdcall           */
-/*        #define SHPAPI_CALL1 __declspec(dllexport) * __stdcall        */
-/*                                                                      */
-/*      The complexity of the situation is partly caused by the        */
-/*      peculiar requirement of Visual C++ that __stdcall appear        */
-/*      after any "*"'s in the return value of a function while the     */
-/*      __declspec(dllexport) must appear before them.                  */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      SHPAPI_CALL                                                     */
+    /*                                                                      */
+    /*      The following two macros are present to allow forcing           */
+    /*      various calling conventions on the Shapelib API.                */
+    /*                                                                      */
+    /*      To force __stdcall conventions (needed to call Shapelib         */
+    /*      from Visual Basic and/or Dephi I believe) the makefile could    */
+    /*      be modified to define:                                          */
+    /*                                                                      */
+    /*        /DSHPAPI_CALL=__stdcall                                       */
+    /*                                                                      */
+    /*      If it is desired to force export of the Shapelib API without    */
+    /*      using the shapelib.def file, use the following definition.      */
+    /*                                                                      */
+    /*        /DSHAPELIB_DLLEXPORT                                          */
+    /*                                                                      */
+    /*      To get both at once it will be necessary to hack this           */
+    /*      include file to define:                                         */
+    /*                                                                      */
+    /*        #define SHPAPI_CALL __declspec(dllexport) __stdcall           */
+    /*        #define SHPAPI_CALL1 __declspec(dllexport) * __stdcall        */
+    /*                                                                      */
+    /*      The complexity of the situation is partly caused by the        */
+    /*      peculiar requirement of Visual C++ that __stdcall appear        */
+    /*      after any "*"'s in the return value of a function while the     */
+    /*      __declspec(dllexport) must appear before them.                  */
+    /* -------------------------------------------------------------------- */
 
 #ifdef SHAPELIB_DLLEXPORT
-#  define SHPAPI_CALL __declspec(dllexport)
-#  define SHPAPI_CALL1(x)  __declspec(dllexport) x
+#define SHPAPI_CALL __declspec(dllexport)
+#define SHPAPI_CALL1(x) __declspec(dllexport) x
 #endif
 
 #ifndef SHPAPI_CALL
-#  if defined(USE_GCC_VISIBILITY_FLAG)
-#    define SHPAPI_CALL     __attribute__ ((visibility("default")))
-#    define SHPAPI_CALL1(x) __attribute__ ((visibility("default")))     x
-#  else
-#    define SHPAPI_CALL
-#  endif
+#if defined(USE_GCC_VISIBILITY_FLAG)
+#define SHPAPI_CALL __attribute__((visibility("default")))
+#define SHPAPI_CALL1(x) __attribute__((visibility("default"))) x
+#else
+#define SHPAPI_CALL
+#endif
 #endif
 
 #ifndef SHPAPI_CALL1
-#  define SHPAPI_CALL1(x)      x SHPAPI_CALL
+#define SHPAPI_CALL1(x) x SHPAPI_CALL
 #endif
 
 /* -------------------------------------------------------------------- */
@@ -121,14 +122,19 @@ extern "C" {
 /*      as unreferenced variables resulting in lots of warnings.        */
 /* -------------------------------------------------------------------- */
 #ifndef DISABLE_CVSID
-#  if defined(__GNUC__) && __GNUC__ >= 4
-#    define SHP_CVSID(string)     static const char cpl_cvsid[] __attribute__((used)) = string;
-#  else
-#    define SHP_CVSID(string)     static const char cpl_cvsid[] = string; \
-static const char *cvsid_aw() { return( cvsid_aw() ? NULL : cpl_cvsid ); }
-#  endif
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define SHP_CVSID(string)                                                      \
+    static const char cpl_cvsid[] __attribute__((used)) = string;
 #else
-#  define SHP_CVSID(string)
+#define SHP_CVSID(string)                                                      \
+    static const char cpl_cvsid[] = string;                                    \
+    static const char *cvsid_aw()                                              \
+    {                                                                          \
+        return (cvsid_aw() ? NULL : cpl_cvsid);                                \
+    }
+#endif
+#else
+#define SHP_CVSID(string)
 #endif
 
 /* -------------------------------------------------------------------- */
@@ -136,204 +142,192 @@ static const char *cvsid_aw() { return( cvsid_aw() ? NULL : cpl_cvsid ); }
 /*      UTF-8 encoded filenames Unicode filenames                       */
 /* -------------------------------------------------------------------- */
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
-#  define SHPAPI_WINDOWS
-#  define SHPAPI_UTF8_HOOKS
+#define SHPAPI_WINDOWS
+#define SHPAPI_UTF8_HOOKS
 #endif
 
-/* -------------------------------------------------------------------- */
-/*      IO/Error hook functions.                                        */
-/* -------------------------------------------------------------------- */
-typedef int *SAFile;
+    /* -------------------------------------------------------------------- */
+    /*      IO/Error hook functions.                                        */
+    /* -------------------------------------------------------------------- */
+    typedef int *SAFile;
 
 #ifndef SAOffset
-typedef unsigned long SAOffset;
+    typedef unsigned long SAOffset;
 #endif
 
-typedef struct {
-    SAFile     (*FOpen) ( const char *filename, const char *access);
-    SAOffset   (*FRead) ( void *p, SAOffset size, SAOffset nmemb, SAFile file);
-    SAOffset   (*FWrite)( void *p, SAOffset size, SAOffset nmemb, SAFile file);
-    SAOffset   (*FSeek) ( SAFile file, SAOffset offset, int whence );
-    SAOffset   (*FTell) ( SAFile file );
-    int        (*FFlush)( SAFile file );
-    int        (*FClose)( SAFile file );
-    int        (*Remove) ( const char *filename );
+    typedef struct
+    {
+        SAFile (*FOpen)(const char *filename, const char *access);
+        SAOffset (*FRead)(void *p, SAOffset size, SAOffset nmemb, SAFile file);
+        SAOffset (*FWrite)(void *p, SAOffset size, SAOffset nmemb, SAFile file);
+        SAOffset (*FSeek)(SAFile file, SAOffset offset, int whence);
+        SAOffset (*FTell)(SAFile file);
+        int (*FFlush)(SAFile file);
+        int (*FClose)(SAFile file);
+        int (*Remove)(const char *filename);
 
-    void       (*Error) ( const char *message );
-    double     (*Atof)  ( const char *str );
-} SAHooks;
+        void (*Error)(const char *message);
+        double (*Atof)(const char *str);
+    } SAHooks;
 
-void SHPAPI_CALL SASetupDefaultHooks( SAHooks *psHooks );
+    void SHPAPI_CALL SASetupDefaultHooks(SAHooks *psHooks);
 #ifdef SHPAPI_UTF8_HOOKS
-void SHPAPI_CALL SASetupUtf8Hooks( SAHooks *psHooks );
+    void SHPAPI_CALL SASetupUtf8Hooks(SAHooks *psHooks);
 #endif
 
-/************************************************************************/
-/*                             SHP Support.                             */
-/************************************************************************/
-typedef struct tagSHPObject SHPObject;
+    /************************************************************************/
+    /*                             SHP Support.                             */
+    /************************************************************************/
+    typedef struct tagSHPObject SHPObject;
 
-typedef struct
-{
-    SAHooks sHooks;
+    typedef struct
+    {
+        SAHooks sHooks;
 
-    SAFile      fpSHP;
-    SAFile      fpSHX;
+        SAFile fpSHP;
+        SAFile fpSHX;
 
-    int         nShapeType;  /* SHPT_* */
+        int nShapeType; /* SHPT_* */
 
-    unsigned int nFileSize;  /* SHP file */
+        unsigned int nFileSize; /* SHP file */
 
-    int         nRecords;
-    int         nMaxRecords;
-    unsigned int*panRecOffset;
-    unsigned int *panRecSize;
+        int nRecords;
+        int nMaxRecords;
+        unsigned int *panRecOffset;
+        unsigned int *panRecSize;
 
-    double      adBoundsMin[4];
-    double      adBoundsMax[4];
+        double adBoundsMin[4];
+        double adBoundsMax[4];
 
-    int         bUpdated;
+        int bUpdated;
 
-    unsigned char *pabyRec;
-    int         nBufSize;
+        unsigned char *pabyRec;
+        int nBufSize;
 
-    int            bFastModeReadObject;
-    unsigned char *pabyObjectBuf;
-    int            nObjectBufSize;
-    SHPObject*     psCachedObject;
-} SHPInfo;
+        int bFastModeReadObject;
+        unsigned char *pabyObjectBuf;
+        int nObjectBufSize;
+        SHPObject *psCachedObject;
+    } SHPInfo;
 
-typedef SHPInfo * SHPHandle;
+    typedef SHPInfo *SHPHandle;
 
 /* -------------------------------------------------------------------- */
 /*      Shape types (nSHPType)                                          */
 /* -------------------------------------------------------------------- */
-#define SHPT_NULL       0
-#define SHPT_POINT      1
-#define SHPT_ARC        3
-#define SHPT_POLYGON    5
+#define SHPT_NULL 0
+#define SHPT_POINT 1
+#define SHPT_ARC 3
+#define SHPT_POLYGON 5
 #define SHPT_MULTIPOINT 8
-#define SHPT_POINTZ     11
-#define SHPT_ARCZ       13
-#define SHPT_POLYGONZ   15
+#define SHPT_POINTZ 11
+#define SHPT_ARCZ 13
+#define SHPT_POLYGONZ 15
 #define SHPT_MULTIPOINTZ 18
-#define SHPT_POINTM     21
-#define SHPT_ARCM       23
-#define SHPT_POLYGONM   25
+#define SHPT_POINTM 21
+#define SHPT_ARCM 23
+#define SHPT_POLYGONM 25
 #define SHPT_MULTIPOINTM 28
 #define SHPT_MULTIPATCH 31
 
-/* -------------------------------------------------------------------- */
-/*      Part types - everything but SHPT_MULTIPATCH just uses           */
-/*      SHPP_RING.                                                      */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Part types - everything but SHPT_MULTIPATCH just uses           */
+    /*      SHPP_RING.                                                      */
+    /* -------------------------------------------------------------------- */
 
-#define SHPP_TRISTRIP   0
-#define SHPP_TRIFAN     1
-#define SHPP_OUTERRING  2
-#define SHPP_INNERRING  3
-#define SHPP_FIRSTRING  4
-#define SHPP_RING       5
+#define SHPP_TRISTRIP 0
+#define SHPP_TRIFAN 1
+#define SHPP_OUTERRING 2
+#define SHPP_INNERRING 3
+#define SHPP_FIRSTRING 4
+#define SHPP_RING 5
 
-/* -------------------------------------------------------------------- */
-/*      SHPObject - represents on shape (without attributes) read       */
-/*      from the .shp file.                                             */
-/* -------------------------------------------------------------------- */
-struct tagSHPObject
-{
-    int    nSHPType;
+    /* -------------------------------------------------------------------- */
+    /*      SHPObject - represents on shape (without attributes) read       */
+    /*      from the .shp file.                                             */
+    /* -------------------------------------------------------------------- */
+    struct tagSHPObject
+    {
+        int nSHPType;
 
-    int    nShapeId;  /* -1 is unknown/unassigned */
+        int nShapeId; /* -1 is unknown/unassigned */
 
-    int    nParts;
-    int    *panPartStart;
-    int    *panPartType;
+        int nParts;
+        int *panPartStart;
+        int *panPartType;
 
-    int    nVertices;
-    double *padfX;
-    double *padfY;
-    double *padfZ;
-    double *padfM;
+        int nVertices;
+        double *padfX;
+        double *padfY;
+        double *padfZ;
+        double *padfM;
 
-    double dfXMin;
-    double dfYMin;
-    double dfZMin;
-    double dfMMin;
+        double dfXMin;
+        double dfYMin;
+        double dfZMin;
+        double dfMMin;
 
-    double dfXMax;
-    double dfYMax;
-    double dfZMax;
-    double dfMMax;
+        double dfXMax;
+        double dfYMax;
+        double dfZMax;
+        double dfMMax;
 
-    int    bMeasureIsUsed;
-    int    bFastModeReadObject;
-};
+        int bMeasureIsUsed;
+        int bFastModeReadObject;
+    };
 
-/* -------------------------------------------------------------------- */
-/*      SHP API Prototypes                                              */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      SHP API Prototypes                                              */
+    /* -------------------------------------------------------------------- */
 
-/* If pszAccess is read-only, the fpSHX field of the returned structure */
-/* will be NULL as it is not necessary to keep the SHX file open */
-SHPHandle SHPAPI_CALL
-      SHPOpen( const char * pszShapeFile, const char * pszAccess );
-SHPHandle SHPAPI_CALL
-      SHPOpenLL( const char *pszShapeFile, const char *pszAccess,
-                 SAHooks *psHooks );
-SHPHandle SHPAPI_CALL
-      SHPOpenLLEx( const char *pszShapeFile, const char *pszAccess,
-                  SAHooks *psHooks, int bRestoreSHX );
+    /* If pszAccess is read-only, the fpSHX field of the returned structure */
+    /* will be NULL as it is not necessary to keep the SHX file open */
+    SHPHandle SHPAPI_CALL SHPOpen(const char *pszShapeFile,
+                                  const char *pszAccess);
+    SHPHandle SHPAPI_CALL SHPOpenLL(const char *pszShapeFile,
+                                    const char *pszAccess, SAHooks *psHooks);
+    SHPHandle SHPAPI_CALL SHPOpenLLEx(const char *pszShapeFile,
+                                      const char *pszAccess, SAHooks *psHooks,
+                                      int bRestoreSHX);
 
-int SHPAPI_CALL
-      SHPRestoreSHX( const char *pszShapeFile, const char *pszAccess,
-                  SAHooks *psHooks );
+    int SHPAPI_CALL SHPRestoreSHX(const char *pszShapeFile,
+                                  const char *pszAccess, SAHooks *psHooks);
 
-/* If setting bFastMode = TRUE, the content of SHPReadObject() is owned by the SHPHandle. */
-/* So you cannot have 2 valid instances of SHPReadObject() simultaneously. */
-/* The SHPObject padfZ and padfM members may be NULL depending on the geometry */
-/* type. It is illegal to free at hand any of the pointer members of the SHPObject structure */
-void SHPAPI_CALL SHPSetFastModeReadObject( SHPHandle hSHP, int bFastMode );
+    /* If setting bFastMode = TRUE, the content of SHPReadObject() is owned by the SHPHandle. */
+    /* So you cannot have 2 valid instances of SHPReadObject() simultaneously. */
+    /* The SHPObject padfZ and padfM members may be NULL depending on the geometry */
+    /* type. It is illegal to free at hand any of the pointer members of the SHPObject structure */
+    void SHPAPI_CALL SHPSetFastModeReadObject(SHPHandle hSHP, int bFastMode);
 
-SHPHandle SHPAPI_CALL
-      SHPCreate( const char * pszShapeFile, int nShapeType );
-SHPHandle SHPAPI_CALL
-      SHPCreateLL( const char * pszShapeFile, int nShapeType,
-                   SAHooks *psHooks );
-void SHPAPI_CALL
-      SHPGetInfo( SHPHandle hSHP, int * pnEntities, int * pnShapeType,
-                  double * padfMinBound, double * padfMaxBound );
+    SHPHandle SHPAPI_CALL SHPCreate(const char *pszShapeFile, int nShapeType);
+    SHPHandle SHPAPI_CALL SHPCreateLL(const char *pszShapeFile, int nShapeType,
+                                      SAHooks *psHooks);
+    void SHPAPI_CALL SHPGetInfo(SHPHandle hSHP, int *pnEntities,
+                                int *pnShapeType, double *padfMinBound,
+                                double *padfMaxBound);
 
-SHPObject SHPAPI_CALL1(*)
-      SHPReadObject( SHPHandle hSHP, int iShape );
-int SHPAPI_CALL
-      SHPWriteObject( SHPHandle hSHP, int iShape, SHPObject * psObject );
+    SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle hSHP, int iShape);
+    int SHPAPI_CALL SHPWriteObject(SHPHandle hSHP, int iShape,
+                                   SHPObject *psObject);
 
-void SHPAPI_CALL
-      SHPDestroyObject( SHPObject * psObject );
-void SHPAPI_CALL
-      SHPComputeExtents( SHPObject * psObject );
-SHPObject SHPAPI_CALL1(*)
-      SHPCreateObject( int nSHPType, int nShapeId, int nParts,
-                       const int * panPartStart, const int * panPartType,
-                       int nVertices,
-                       const double * padfX, const double * padfY,
-                       const double * padfZ, const double * padfM );
-SHPObject SHPAPI_CALL1(*)
-      SHPCreateSimpleObject( int nSHPType, int nVertices,
-                             const double * padfX,
-                             const double * padfY,
-                             const double * padfZ );
+    void SHPAPI_CALL SHPDestroyObject(SHPObject *psObject);
+    void SHPAPI_CALL SHPComputeExtents(SHPObject *psObject);
+    SHPObject SHPAPI_CALL1(*)
+        SHPCreateObject(int nSHPType, int nShapeId, int nParts,
+                        const int *panPartStart, const int *panPartType,
+                        int nVertices, const double *padfX, const double *padfY,
+                        const double *padfZ, const double *padfM);
+    SHPObject SHPAPI_CALL1(*)
+        SHPCreateSimpleObject(int nSHPType, int nVertices, const double *padfX,
+                              const double *padfY, const double *padfZ);
 
-int SHPAPI_CALL
-      SHPRewindObject( SHPHandle hSHP, SHPObject * psObject );
+    int SHPAPI_CALL SHPRewindObject(SHPHandle hSHP, SHPObject *psObject);
 
-void SHPAPI_CALL SHPClose( SHPHandle hSHP );
-void SHPAPI_CALL SHPWriteHeader( SHPHandle hSHP );
+    void SHPAPI_CALL SHPClose(SHPHandle hSHP);
+    void SHPAPI_CALL SHPWriteHeader(SHPHandle hSHP);
 
-const char SHPAPI_CALL1(*)
-      SHPTypeName( int nSHPType );
-const char SHPAPI_CALL1(*)
-      SHPPartTypeName( int nPartType );
+    const char SHPAPI_CALL1(*) SHPTypeName(int nSHPType);
+    const char SHPAPI_CALL1(*) SHPPartTypeName(int nPartType);
 
 /* -------------------------------------------------------------------- */
 /*      Shape quadtree indexing API.                                    */
@@ -345,273 +339,243 @@ const char SHPAPI_CALL1(*)
 /* upper limit of tree levels for automatic estimation */
 #define MAX_DEFAULT_TREE_DEPTH 12
 
-typedef struct shape_tree_node
-{
-    /* region covered by this node */
-    double      adfBoundsMin[4];
-    double      adfBoundsMax[4];
+    typedef struct shape_tree_node
+    {
+        /* region covered by this node */
+        double adfBoundsMin[4];
+        double adfBoundsMax[4];
 
-    /* list of shapes stored at this node.  The papsShapeObj pointers
+        /* list of shapes stored at this node.  The papsShapeObj pointers
        or the whole list can be NULL */
-    int         nShapeCount;
-    int         *panShapeIds;
-    SHPObject   **papsShapeObj;
+        int nShapeCount;
+        int *panShapeIds;
+        SHPObject **papsShapeObj;
 
-    int         nSubNodes;
-    struct shape_tree_node *apsSubNode[MAX_SUBNODE];
+        int nSubNodes;
+        struct shape_tree_node *apsSubNode[MAX_SUBNODE];
 
-} SHPTreeNode;
+    } SHPTreeNode;
 
-typedef struct
-{
-    SHPHandle   hSHP;
+    typedef struct
+    {
+        SHPHandle hSHP;
 
-    int         nMaxDepth;
-    int         nDimension;
-    int         nTotalCount;
+        int nMaxDepth;
+        int nDimension;
+        int nTotalCount;
 
-    SHPTreeNode *psRoot;
-} SHPTree;
+        SHPTreeNode *psRoot;
+    } SHPTree;
 
-SHPTree SHPAPI_CALL1(*)
-      SHPCreateTree( SHPHandle hSHP, int nDimension, int nMaxDepth,
-                     double *padfBoundsMin, double *padfBoundsMax );
-void SHPAPI_CALL
-      SHPDestroyTree( SHPTree * hTree );
+    SHPTree SHPAPI_CALL1(*)
+        SHPCreateTree(SHPHandle hSHP, int nDimension, int nMaxDepth,
+                      double *padfBoundsMin, double *padfBoundsMax);
+    void SHPAPI_CALL SHPDestroyTree(SHPTree *hTree);
 
-int SHPAPI_CALL
-      SHPWriteTree( SHPTree *hTree, const char * pszFilename );
+    int SHPAPI_CALL SHPWriteTree(SHPTree *hTree, const char *pszFilename);
 
-int SHPAPI_CALL
-      SHPTreeAddShapeId( SHPTree * hTree, SHPObject * psObject );
-int SHPAPI_CALL
-      SHPTreeRemoveShapeId( SHPTree * hTree, int nShapeId );
+    int SHPAPI_CALL SHPTreeAddShapeId(SHPTree *hTree, SHPObject *psObject);
+    int SHPAPI_CALL SHPTreeRemoveShapeId(SHPTree *hTree, int nShapeId);
 
-void SHPAPI_CALL
-      SHPTreeTrimExtraNodes( SHPTree * hTree );
+    void SHPAPI_CALL SHPTreeTrimExtraNodes(SHPTree *hTree);
 
-int SHPAPI_CALL1(*)
-      SHPTreeFindLikelyShapes( SHPTree * hTree,
-                               double * padfBoundsMin,
-                               double * padfBoundsMax,
-                               int * );
-int SHPAPI_CALL
-      SHPCheckBoundsOverlap( double *, double *, double *, double *, int );
+    int SHPAPI_CALL1(*)
+        SHPTreeFindLikelyShapes(SHPTree *hTree, double *padfBoundsMin,
+                                double *padfBoundsMax, int *);
+    int SHPAPI_CALL SHPCheckBoundsOverlap(double *, double *, double *,
+                                          double *, int);
 
-int SHPAPI_CALL1(*)
-SHPSearchDiskTree( FILE *fp,
-                   double *padfBoundsMin, double *padfBoundsMax,
-                   int *pnShapeCount );
+    int SHPAPI_CALL1(*)
+        SHPSearchDiskTree(FILE *fp, double *padfBoundsMin,
+                          double *padfBoundsMax, int *pnShapeCount);
 
-typedef struct SHPDiskTreeInfo* SHPTreeDiskHandle;
+    typedef struct SHPDiskTreeInfo *SHPTreeDiskHandle;
 
-SHPTreeDiskHandle SHPAPI_CALL
-    SHPOpenDiskTree( const char* pszQIXFilename,
-                     SAHooks *psHooks );
+    SHPTreeDiskHandle SHPAPI_CALL SHPOpenDiskTree(const char *pszQIXFilename,
+                                                  SAHooks *psHooks);
 
-void SHPAPI_CALL
-    SHPCloseDiskTree( SHPTreeDiskHandle hDiskTree );
+    void SHPAPI_CALL SHPCloseDiskTree(SHPTreeDiskHandle hDiskTree);
 
-int SHPAPI_CALL1(*)
-SHPSearchDiskTreeEx( SHPTreeDiskHandle hDiskTree,
-                     double *padfBoundsMin, double *padfBoundsMax,
-                     int *pnShapeCount );
+    int SHPAPI_CALL1(*)
+        SHPSearchDiskTreeEx(SHPTreeDiskHandle hDiskTree, double *padfBoundsMin,
+                            double *padfBoundsMax, int *pnShapeCount);
 
-int SHPAPI_CALL
-    SHPWriteTreeLL(SHPTree *hTree, const char *pszFilename, SAHooks *psHooks );
+    int SHPAPI_CALL SHPWriteTreeLL(SHPTree *hTree, const char *pszFilename,
+                                   SAHooks *psHooks);
 
-/* -------------------------------------------------------------------- */
-/*      SBN Search API                                                  */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      SBN Search API                                                  */
+    /* -------------------------------------------------------------------- */
 
-typedef struct SBNSearchInfo* SBNSearchHandle;
+    typedef struct SBNSearchInfo *SBNSearchHandle;
 
-SBNSearchHandle SHPAPI_CALL
-    SBNOpenDiskTree( const char* pszSBNFilename,
-                 SAHooks *psHooks );
+    SBNSearchHandle SHPAPI_CALL SBNOpenDiskTree(const char *pszSBNFilename,
+                                                SAHooks *psHooks);
 
-void SHPAPI_CALL
-    SBNCloseDiskTree( SBNSearchHandle hSBN );
+    void SHPAPI_CALL SBNCloseDiskTree(SBNSearchHandle hSBN);
 
-int SHPAPI_CALL1(*)
-SBNSearchDiskTree( SBNSearchHandle hSBN,
-                   double *padfBoundsMin, double *padfBoundsMax,
-                   int *pnShapeCount );
+    int SHPAPI_CALL1(*)
+        SBNSearchDiskTree(SBNSearchHandle hSBN, double *padfBoundsMin,
+                          double *padfBoundsMax, int *pnShapeCount);
 
-int SHPAPI_CALL1(*)
-SBNSearchDiskTreeInteger( SBNSearchHandle hSBN,
-                          int bMinX, int bMinY, int bMaxX, int bMaxY,
-                          int *pnShapeCount );
+    int SHPAPI_CALL1(*)
+        SBNSearchDiskTreeInteger(SBNSearchHandle hSBN, int bMinX, int bMinY,
+                                 int bMaxX, int bMaxY, int *pnShapeCount);
 
-void SHPAPI_CALL SBNSearchFreeIds( int* panShapeId );
+    void SHPAPI_CALL SBNSearchFreeIds(int *panShapeId);
 
-/************************************************************************/
-/*                             DBF Support.                             */
-/************************************************************************/
-typedef struct
-{
-    SAHooks sHooks;
+    /************************************************************************/
+    /*                             DBF Support.                             */
+    /************************************************************************/
+    typedef struct
+    {
+        SAHooks sHooks;
 
-    SAFile      fp;
+        SAFile fp;
 
-    int         nRecords;
+        int nRecords;
 
-    int         nRecordLength; /* Must fit on uint16 */
-    int         nHeaderLength; /* File header length (32) + field
+        int nRecordLength; /* Must fit on uint16 */
+        int nHeaderLength; /* File header length (32) + field
                                   descriptor length + spare space.
                                   Must fit on uint16 */
-    int         nFields;
-    int         *panFieldOffset;
-    int         *panFieldSize;
-    int         *panFieldDecimals;
-    char        *pachFieldType;
+        int nFields;
+        int *panFieldOffset;
+        int *panFieldSize;
+        int *panFieldDecimals;
+        char *pachFieldType;
 
-    char        *pszHeader; /* Field descriptors */
+        char *pszHeader; /* Field descriptors */
 
-    int         nCurrentRecord;
-    int         bCurrentRecordModified;
-    char        *pszCurrentRecord;
+        int nCurrentRecord;
+        int bCurrentRecordModified;
+        char *pszCurrentRecord;
 
-    int         nWorkFieldLength;
-    char        *pszWorkField;
+        int nWorkFieldLength;
+        char *pszWorkField;
 
-    int         bNoHeader;
-    int         bUpdated;
+        int bNoHeader;
+        int bUpdated;
 
-    union
+        union
+        {
+            double dfDoubleField;
+            int nIntField;
+        } fieldValue;
+
+        int iLanguageDriver;
+        char *pszCodePage;
+
+        int nUpdateYearSince1900; /* 0-255 */
+        int nUpdateMonth;         /* 1-12 */
+        int nUpdateDay;           /* 1-31 */
+
+        int bWriteEndOfFileChar; /* defaults to TRUE */
+
+        int bRequireNextWriteSeek;
+    } DBFInfo;
+
+    typedef DBFInfo *DBFHandle;
+
+    typedef enum
     {
-        double      dfDoubleField;
-        int         nIntField;
-    } fieldValue;
-
-    int         iLanguageDriver;
-    char        *pszCodePage;
-
-    int         nUpdateYearSince1900; /* 0-255 */
-    int         nUpdateMonth; /* 1-12 */
-    int         nUpdateDay; /* 1-31 */
-
-    int         bWriteEndOfFileChar; /* defaults to TRUE */
-
-    int         bRequireNextWriteSeek;
-} DBFInfo;
-
-typedef DBFInfo * DBFHandle;
-
-typedef enum {
-  FTString,
-  FTInteger,
-  FTDouble,
-  FTLogical,
-  FTDate,
-  FTInvalid
-} DBFFieldType;
+        FTString,
+        FTInteger,
+        FTDouble,
+        FTLogical,
+        FTDate,
+        FTInvalid
+    } DBFFieldType;
 
 /* Field descriptor/header size */
-#define XBASE_FLDHDR_SZ         32
+#define XBASE_FLDHDR_SZ 32
 /* Shapelib read up to 11 characters, even if only 10 should normally be used */
-#define XBASE_FLDNAME_LEN_READ  11
+#define XBASE_FLDNAME_LEN_READ 11
 /* On writing, we limit to 10 characters */
 #define XBASE_FLDNAME_LEN_WRITE 10
 /* Normally only 254 characters should be used. We tolerate 255 historically */
-#define XBASE_FLD_MAX_WIDTH     255
+#define XBASE_FLD_MAX_WIDTH 255
 
-DBFHandle SHPAPI_CALL
-      DBFOpen( const char * pszDBFFile, const char * pszAccess );
-DBFHandle SHPAPI_CALL
-      DBFOpenLL( const char * pszDBFFile, const char * pszAccess,
-                 SAHooks *psHooks );
-DBFHandle SHPAPI_CALL
-      DBFCreate( const char * pszDBFFile );
-DBFHandle SHPAPI_CALL
-      DBFCreateEx( const char * pszDBFFile, const char * pszCodePage );
-DBFHandle SHPAPI_CALL
-      DBFCreateLL( const char * pszDBFFile, const char * pszCodePage, SAHooks *psHooks );
+    DBFHandle SHPAPI_CALL DBFOpen(const char *pszDBFFile,
+                                  const char *pszAccess);
+    DBFHandle SHPAPI_CALL DBFOpenLL(const char *pszDBFFile,
+                                    const char *pszAccess, SAHooks *psHooks);
+    DBFHandle SHPAPI_CALL DBFCreate(const char *pszDBFFile);
+    DBFHandle SHPAPI_CALL DBFCreateEx(const char *pszDBFFile,
+                                      const char *pszCodePage);
+    DBFHandle SHPAPI_CALL DBFCreateLL(const char *pszDBFFile,
+                                      const char *pszCodePage,
+                                      SAHooks *psHooks);
 
-int SHPAPI_CALL
-      DBFGetFieldCount( DBFHandle psDBF );
-int SHPAPI_CALL
-      DBFGetRecordCount( DBFHandle psDBF );
-int SHPAPI_CALL
-      DBFAddField( DBFHandle hDBF, const char * pszFieldName,
-                   DBFFieldType eType, int nWidth, int nDecimals );
+    int SHPAPI_CALL DBFGetFieldCount(DBFHandle psDBF);
+    int SHPAPI_CALL DBFGetRecordCount(DBFHandle psDBF);
+    int SHPAPI_CALL DBFAddField(DBFHandle hDBF, const char *pszFieldName,
+                                DBFFieldType eType, int nWidth, int nDecimals);
 
-int SHPAPI_CALL
-      DBFAddNativeFieldType( DBFHandle hDBF, const char * pszFieldName,
-                             char chType, int nWidth, int nDecimals );
+    int SHPAPI_CALL DBFAddNativeFieldType(DBFHandle hDBF,
+                                          const char *pszFieldName, char chType,
+                                          int nWidth, int nDecimals);
 
-int SHPAPI_CALL
-      DBFDeleteField( DBFHandle hDBF, int iField );
+    int SHPAPI_CALL DBFDeleteField(DBFHandle hDBF, int iField);
 
-int SHPAPI_CALL
-      DBFReorderFields( DBFHandle psDBF, int* panMap );
+    int SHPAPI_CALL DBFReorderFields(DBFHandle psDBF, int *panMap);
 
-int SHPAPI_CALL
-      DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
-                         char chType, int nWidth, int nDecimals );
+    int SHPAPI_CALL DBFAlterFieldDefn(DBFHandle psDBF, int iField,
+                                      const char *pszFieldName, char chType,
+                                      int nWidth, int nDecimals);
 
-DBFFieldType SHPAPI_CALL
-      DBFGetFieldInfo( DBFHandle psDBF, int iField,
-                       char * pszFieldName, int * pnWidth, int * pnDecimals );
+    DBFFieldType SHPAPI_CALL DBFGetFieldInfo(DBFHandle psDBF, int iField,
+                                             char *pszFieldName, int *pnWidth,
+                                             int *pnDecimals);
 
-int SHPAPI_CALL
-      DBFGetFieldIndex(DBFHandle psDBF, const char *pszFieldName);
+    int SHPAPI_CALL DBFGetFieldIndex(DBFHandle psDBF, const char *pszFieldName);
 
-int SHPAPI_CALL
-      DBFReadIntegerAttribute( DBFHandle hDBF, int iShape, int iField );
-double SHPAPI_CALL
-      DBFReadDoubleAttribute( DBFHandle hDBF, int iShape, int iField );
-const char SHPAPI_CALL1(*)
-      DBFReadStringAttribute( DBFHandle hDBF, int iShape, int iField );
-const char SHPAPI_CALL1(*)
-      DBFReadLogicalAttribute( DBFHandle hDBF, int iShape, int iField );
-int SHPAPI_CALL
-      DBFIsAttributeNULL( DBFHandle hDBF, int iShape, int iField );
+    int SHPAPI_CALL DBFReadIntegerAttribute(DBFHandle hDBF, int iShape,
+                                            int iField);
+    double SHPAPI_CALL DBFReadDoubleAttribute(DBFHandle hDBF, int iShape,
+                                              int iField);
+    const char SHPAPI_CALL1(*)
+        DBFReadStringAttribute(DBFHandle hDBF, int iShape, int iField);
+    const char SHPAPI_CALL1(*)
+        DBFReadLogicalAttribute(DBFHandle hDBF, int iShape, int iField);
+    int SHPAPI_CALL DBFIsAttributeNULL(DBFHandle hDBF, int iShape, int iField);
 
-int SHPAPI_CALL
-      DBFWriteIntegerAttribute( DBFHandle hDBF, int iShape, int iField,
-                                int nFieldValue );
-int SHPAPI_CALL
-      DBFWriteDoubleAttribute( DBFHandle hDBF, int iShape, int iField,
-                               double dFieldValue );
-int SHPAPI_CALL
-      DBFWriteStringAttribute( DBFHandle hDBF, int iShape, int iField,
-                               const char * pszFieldValue );
-int SHPAPI_CALL
-     DBFWriteNULLAttribute( DBFHandle hDBF, int iShape, int iField );
+    int SHPAPI_CALL DBFWriteIntegerAttribute(DBFHandle hDBF, int iShape,
+                                             int iField, int nFieldValue);
+    int SHPAPI_CALL DBFWriteDoubleAttribute(DBFHandle hDBF, int iShape,
+                                            int iField, double dFieldValue);
+    int SHPAPI_CALL DBFWriteStringAttribute(DBFHandle hDBF, int iShape,
+                                            int iField,
+                                            const char *pszFieldValue);
+    int SHPAPI_CALL DBFWriteNULLAttribute(DBFHandle hDBF, int iShape,
+                                          int iField);
 
-int SHPAPI_CALL
-     DBFWriteLogicalAttribute( DBFHandle hDBF, int iShape, int iField,
-                               const char lFieldValue);
-int SHPAPI_CALL
-     DBFWriteAttributeDirectly(DBFHandle psDBF, int hEntity, int iField,
-                               void * pValue );
-const char SHPAPI_CALL1(*)
-      DBFReadTuple(DBFHandle psDBF, int hEntity );
-int SHPAPI_CALL
-      DBFWriteTuple(DBFHandle psDBF, int hEntity, void * pRawTuple );
+    int SHPAPI_CALL DBFWriteLogicalAttribute(DBFHandle hDBF, int iShape,
+                                             int iField,
+                                             const char lFieldValue);
+    int SHPAPI_CALL DBFWriteAttributeDirectly(DBFHandle psDBF, int hEntity,
+                                              int iField, void *pValue);
+    const char SHPAPI_CALL1(*) DBFReadTuple(DBFHandle psDBF, int hEntity);
+    int SHPAPI_CALL DBFWriteTuple(DBFHandle psDBF, int hEntity,
+                                  void *pRawTuple);
 
-int SHPAPI_CALL DBFIsRecordDeleted( DBFHandle psDBF, int iShape );
-int SHPAPI_CALL DBFMarkRecordDeleted( DBFHandle psDBF, int iShape,
-                                      int bIsDeleted );
+    int SHPAPI_CALL DBFIsRecordDeleted(DBFHandle psDBF, int iShape);
+    int SHPAPI_CALL DBFMarkRecordDeleted(DBFHandle psDBF, int iShape,
+                                         int bIsDeleted);
 
-DBFHandle SHPAPI_CALL
-      DBFCloneEmpty(DBFHandle psDBF, const char * pszFilename );
+    DBFHandle SHPAPI_CALL DBFCloneEmpty(DBFHandle psDBF,
+                                        const char *pszFilename);
 
-void SHPAPI_CALL
-      DBFClose( DBFHandle hDBF );
-void    SHPAPI_CALL
-      DBFUpdateHeader( DBFHandle hDBF );
-char SHPAPI_CALL
-      DBFGetNativeFieldType( DBFHandle hDBF, int iField );
+    void SHPAPI_CALL DBFClose(DBFHandle hDBF);
+    void SHPAPI_CALL DBFUpdateHeader(DBFHandle hDBF);
+    char SHPAPI_CALL DBFGetNativeFieldType(DBFHandle hDBF, int iField);
 
-const char SHPAPI_CALL1(*)
-      DBFGetCodePage(DBFHandle psDBF );
+    const char SHPAPI_CALL1(*) DBFGetCodePage(DBFHandle psDBF);
 
-void SHPAPI_CALL
-    DBFSetLastModifiedDate( DBFHandle psDBF, int nYYSince1900, int nMM, int nDD );
+    void SHPAPI_CALL DBFSetLastModifiedDate(DBFHandle psDBF, int nYYSince1900,
+                                            int nMM, int nDD);
 
-void SHPAPI_CALL DBFSetWriteEndOfFileChar( DBFHandle psDBF, int bWriteFlag );
+    void SHPAPI_CALL DBFSetWriteEndOfFileChar(DBFHandle psDBF, int bWriteFlag);
 
 #ifdef __cplusplus
 }

--- a/shpadd.c
+++ b/shpadd.c
@@ -42,130 +42,129 @@
 
 SHP_CVSID("$Id$")
 
-int main( int argc, char ** argv ) {
-/* -------------------------------------------------------------------- */
-/*      Display a usage message.                                        */
-/* -------------------------------------------------------------------- */
-    if( argc < 2 )
+int main(int argc, char **argv)
+{
+    /* -------------------------------------------------------------------- */
+    /*      Display a usage message.                                        */
+    /* -------------------------------------------------------------------- */
+    if (argc < 2)
     {
-        printf( "shpadd shp_file [[x y] [+]]*\n" );
-        printf( "  or\n" );
-        printf( "shpadd shp_file -m [[x y m] [+]]*\n" );
-        printf( "  or\n" );
-        printf( "shpadd shp_file -z [[x y z] [+]]*\n" );
-        printf( "  or\n" );
-        printf( "shpadd shp_file -zm [[x y z m] [+]]*\n" );
-        exit( 1 );
+        printf("shpadd shp_file [[x y] [+]]*\n");
+        printf("  or\n");
+        printf("shpadd shp_file -m [[x y m] [+]]*\n");
+        printf("  or\n");
+        printf("shpadd shp_file -z [[x y z] [+]]*\n");
+        printf("  or\n");
+        printf("shpadd shp_file -zm [[x y z m] [+]]*\n");
+        exit(1);
     }
 
     const char *filename = argv[1];
     argv++;
     argc--;
 
-/* -------------------------------------------------------------------- */
-/*      Check for tuple description options.                            */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Check for tuple description options.                            */
+    /* -------------------------------------------------------------------- */
     const char *tuple = "";
 
-    if( argc > 1
-        && (strcmp(argv[1],"-z") == 0
-            || strcmp(argv[1],"-m") == 0
-            || strcmp(argv[1],"-zm") == 0) )
+    if (argc > 1 && (strcmp(argv[1], "-z") == 0 || strcmp(argv[1], "-m") == 0 ||
+                     strcmp(argv[1], "-zm") == 0))
     {
         tuple = argv[1] + 1;
         argv++;
         argc--;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Open the passed shapefile.                                      */
-/* -------------------------------------------------------------------- */
-    SHPHandle hSHP = SHPOpen( filename, "r+b" );
+    /* -------------------------------------------------------------------- */
+    /*      Open the passed shapefile.                                      */
+    /* -------------------------------------------------------------------- */
+    SHPHandle hSHP = SHPOpen(filename, "r+b");
 
-    if( hSHP == NULL )
+    if (hSHP == NULL)
     {
-        printf( "Unable to open:%s\n", filename );
-        exit( 1 );
+        printf("Unable to open:%s\n", filename);
+        exit(1);
     }
 
     int nShapeType;
-    SHPGetInfo( hSHP, NULL, &nShapeType, NULL, NULL );
+    SHPGetInfo(hSHP, NULL, &nShapeType, NULL, NULL);
 
-    if( argc == 1 )
+    if (argc == 1)
         nShapeType = SHPT_NULL;
 
-/* -------------------------------------------------------------------- */
-/*	Build a vertex/part list from the command line arguments.	*/
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*	Build a vertex/part list from the command line arguments.	*/
+    /* -------------------------------------------------------------------- */
     int nVMax = 1000;
-    double *padfX = (double *) malloc(sizeof(double) * nVMax);
-    double *padfY = (double *) malloc(sizeof(double) * nVMax);
+    double *padfX = (double *)malloc(sizeof(double) * nVMax);
+    double *padfY = (double *)malloc(sizeof(double) * nVMax);
 
     double *padfZ = NULL;
-    if( strchr(tuple,'z') )
-        padfZ = (double *) malloc(sizeof(double) * nVMax);
+    if (strchr(tuple, 'z'))
+        padfZ = (double *)malloc(sizeof(double) * nVMax);
     double *padfM = NULL;
-    if( strchr(tuple,'m') )
-        padfM = (double *) malloc(sizeof(double) * nVMax);
+    if (strchr(tuple, 'm'))
+        padfM = (double *)malloc(sizeof(double) * nVMax);
 
     int *panParts;
-    if( (panParts = (int *) malloc(sizeof(int) * 1000 )) == NULL )
+    if ((panParts = (int *)malloc(sizeof(int) * 1000)) == NULL)
     {
-        printf( "Out of memory\n" );
-        exit( 1 );
+        printf("Out of memory\n");
+        exit(1);
     }
 
     int nParts = 1;
     panParts[0] = 0;
     int nVertices = 0;
 
-    for( int i = 1; i < argc;  )
+    for (int i = 1; i < argc;)
     {
-        if( argv[i][0] == '+' )
+        if (argv[i][0] == '+')
         {
             panParts[nParts++] = nVertices;
             i++;
         }
-        else if( i < argc-1-(int)strlen(tuple) )
+        else if (i < argc - 1 - (int)strlen(tuple))
         {
-            if( nVertices == nVMax )
+            if (nVertices == nVMax)
             {
                 nVMax = nVMax * 2;
-                padfX = (double *) realloc(padfX,sizeof(double)*nVMax);
-                padfY = (double *) realloc(padfY,sizeof(double)*nVMax);
-                if( padfZ )
-                    padfZ = (double *) realloc(padfZ,sizeof(double)*nVMax);
-                if( padfM )
-                    padfM = (double *) realloc(padfM,sizeof(double)*nVMax);
+                padfX = (double *)realloc(padfX, sizeof(double) * nVMax);
+                padfY = (double *)realloc(padfY, sizeof(double) * nVMax);
+                if (padfZ)
+                    padfZ = (double *)realloc(padfZ, sizeof(double) * nVMax);
+                if (padfM)
+                    padfM = (double *)realloc(padfM, sizeof(double) * nVMax);
             }
 
-            sscanf( argv[i++], "%lg", padfX+nVertices );
-            sscanf( argv[i++], "%lg", padfY+nVertices );
-            if( padfZ )
-                sscanf( argv[i++], "%lg", padfZ+nVertices );
-            if( padfM )
-                sscanf( argv[i++], "%lg", padfM+nVertices );
+            sscanf(argv[i++], "%lg", padfX + nVertices);
+            sscanf(argv[i++], "%lg", padfY + nVertices);
+            if (padfZ)
+                sscanf(argv[i++], "%lg", padfZ + nVertices);
+            if (padfM)
+                sscanf(argv[i++], "%lg", padfM + nVertices);
 
             nVertices += 1;
         }
     }
 
-/* -------------------------------------------------------------------- */
-/*      Write the new entity to the shape file.                         */
-/* -------------------------------------------------------------------- */
-    SHPObject *psObject = SHPCreateObject(
-        nShapeType, -1, nParts, panParts, NULL,
-        nVertices, padfX, padfY, padfZ, padfM );
-    SHPWriteObject( hSHP, -1, psObject );
-    SHPDestroyObject( psObject );
+    /* -------------------------------------------------------------------- */
+    /*      Write the new entity to the shape file.                         */
+    /* -------------------------------------------------------------------- */
+    SHPObject *psObject =
+        SHPCreateObject(nShapeType, -1, nParts, panParts, NULL, nVertices,
+                        padfX, padfY, padfZ, padfM);
+    SHPWriteObject(hSHP, -1, psObject);
+    SHPDestroyObject(psObject);
 
-    SHPClose( hSHP );
+    SHPClose(hSHP);
 
-    free( panParts );
-    free( padfX );
-    free( padfY );
-    free( padfZ );
-    free( padfM );
+    free(panParts);
+    free(padfX);
+    free(padfY);
+    free(padfZ);
+    free(padfM);
 
     return 0;
 }

--- a/shpcreate.c
+++ b/shpcreate.c
@@ -41,64 +41,68 @@
 
 SHP_CVSID("$Id$")
 
-int main( int argc, char ** argv ) {
-/* -------------------------------------------------------------------- */
-/*      Display a usage message.                                        */
-/* -------------------------------------------------------------------- */
-    if( argc != 3 )
+int main(int argc, char **argv)
+{
+    /* -------------------------------------------------------------------- */
+    /*      Display a usage message.                                        */
+    /* -------------------------------------------------------------------- */
+    if (argc != 3)
     {
-	printf( "shpcreate shp_file [point/arc/polygon/multipoint][/m/z]\n" );
-	exit( 1 );
+        printf("shpcreate shp_file [point/arc/polygon/multipoint][/m/z]\n");
+        exit(1);
     }
 
-/* -------------------------------------------------------------------- */
-/*	Figure out the shape type.					*/
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*	Figure out the shape type.					*/
+    /* -------------------------------------------------------------------- */
     int nShapeType;
-    if( strcmp(argv[2],"POINT") == 0 || strcmp(argv[2],"point") == 0 )
+    if (strcmp(argv[2], "POINT") == 0 || strcmp(argv[2], "point") == 0)
         nShapeType = SHPT_POINT;
-    else if( strcmp(argv[2],"ARC") == 0 || strcmp(argv[2],"arc") == 0 )
+    else if (strcmp(argv[2], "ARC") == 0 || strcmp(argv[2], "arc") == 0)
         nShapeType = SHPT_ARC;
-    else if( strcmp(argv[2],"POLYGON") == 0 || strcmp(argv[2],"polygon") == 0 )
+    else if (strcmp(argv[2], "POLYGON") == 0 || strcmp(argv[2], "polygon") == 0)
         nShapeType = SHPT_POLYGON;
-    else if( strcmp(argv[2],"MULTIPOINT")==0 ||strcmp(argv[2],"multipoint")==0)
+    else if (strcmp(argv[2], "MULTIPOINT") == 0 ||
+             strcmp(argv[2], "multipoint") == 0)
         nShapeType = SHPT_MULTIPOINT;
-    else if( strcmp(argv[2],"POINTZ") == 0 || strcmp(argv[2],"pointz") == 0 )
+    else if (strcmp(argv[2], "POINTZ") == 0 || strcmp(argv[2], "pointz") == 0)
         nShapeType = SHPT_POINTZ;
-    else if( strcmp(argv[2],"ARCZ") == 0 || strcmp(argv[2],"arcz") == 0 )
+    else if (strcmp(argv[2], "ARCZ") == 0 || strcmp(argv[2], "arcz") == 0)
         nShapeType = SHPT_ARCZ;
-    else if( strcmp(argv[2],"POLYGONZ") == 0 || strcmp(argv[2],"polygonz") == 0)
+    else if (strcmp(argv[2], "POLYGONZ") == 0 ||
+             strcmp(argv[2], "polygonz") == 0)
         nShapeType = SHPT_POLYGONZ;
-    else if( strcmp(argv[2],"MULTIPOINTZ") == 0
-             || strcmp(argv[2],"multipointz") == 0)
+    else if (strcmp(argv[2], "MULTIPOINTZ") == 0 ||
+             strcmp(argv[2], "multipointz") == 0)
         nShapeType = SHPT_MULTIPOINTZ;
-    else if( strcmp(argv[2],"POINTM") == 0 || strcmp(argv[2],"pointm") == 0 )
+    else if (strcmp(argv[2], "POINTM") == 0 || strcmp(argv[2], "pointm") == 0)
         nShapeType = SHPT_POINTM;
-    else if( strcmp(argv[2],"ARCM") == 0 || strcmp(argv[2],"arcm") == 0 )
+    else if (strcmp(argv[2], "ARCM") == 0 || strcmp(argv[2], "arcm") == 0)
         nShapeType = SHPT_ARCM;
-    else if( strcmp(argv[2],"POLYGONM") == 0 || strcmp(argv[2],"polygonm") == 0)
+    else if (strcmp(argv[2], "POLYGONM") == 0 ||
+             strcmp(argv[2], "polygonm") == 0)
         nShapeType = SHPT_POLYGONM;
-    else if( strcmp(argv[2],"MULTIPOINTM") == 0
-             || strcmp(argv[2],"multipointm") == 0 )
+    else if (strcmp(argv[2], "MULTIPOINTM") == 0 ||
+             strcmp(argv[2], "multipointm") == 0)
         nShapeType = SHPT_MULTIPOINTM;
     else
     {
-	printf( "Shape Type `%s' not recognised.\n", argv[2] );
-	exit( 2 );
+        printf("Shape Type `%s' not recognised.\n", argv[2]);
+        exit(2);
     }
 
-/* -------------------------------------------------------------------- */
-/*	Create the requested layer.					*/
-/* -------------------------------------------------------------------- */
-    SHPHandle hSHP = SHPCreate( argv[1], nShapeType );
+    /* -------------------------------------------------------------------- */
+    /*	Create the requested layer.					*/
+    /* -------------------------------------------------------------------- */
+    SHPHandle hSHP = SHPCreate(argv[1], nShapeType);
 
-    if( hSHP == NULL )
+    if (hSHP == NULL)
     {
-	printf( "Unable to create:%s\n", argv[1] );
-	exit( 3 );
+        printf("Unable to create:%s\n", argv[1]);
+        exit(3);
     }
 
-    SHPClose( hSHP );
+    SHPClose(hSHP);
 
     return 0;
 }

--- a/shpdump.c
+++ b/shpdump.c
@@ -43,9 +43,10 @@
 
 SHP_CVSID("$Id$")
 
-int main( int argc, char ** argv ) {
+int main(int argc, char **argv)
+{
     bool bValidate = false;
-    if( argc > 1 && strcmp(argv[1],"-validate") == 0 )
+    if (argc > 1 && strcmp(argv[1], "-validate") == 0)
     {
         bValidate = true;
         argv++;
@@ -53,7 +54,7 @@ int main( int argc, char ** argv ) {
     }
 
     bool bHeaderOnly = false;
-    if( argc > 1 && strcmp(argv[1],"-ho") == 0 )
+    if (argc > 1 && strcmp(argv[1], "-ho") == 0)
     {
         bHeaderOnly = true;
         argv++;
@@ -61,165 +62,146 @@ int main( int argc, char ** argv ) {
     }
 
     int nPrecision = 15;
-    if( argc > 2 && strcmp(argv[1],"-precision") == 0 )
+    if (argc > 2 && strcmp(argv[1], "-precision") == 0)
     {
         nPrecision = atoi(argv[2]);
-        argv+=2;
-        argc-=2;
+        argv += 2;
+        argc -= 2;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Display a usage message.                                        */
-/* -------------------------------------------------------------------- */
-    if( argc != 2 )
+    /* -------------------------------------------------------------------- */
+    /*      Display a usage message.                                        */
+    /* -------------------------------------------------------------------- */
+    if (argc != 2)
     {
-        printf( "shpdump [-validate] [-ho] [-precision number] shp_file\n" );
-        exit( 1 );
+        printf("shpdump [-validate] [-ho] [-precision number] shp_file\n");
+        exit(1);
     }
 
-/* -------------------------------------------------------------------- */
-/*      Open the passed shapefile.                                      */
-/* -------------------------------------------------------------------- */
-    SHPHandle hSHP = SHPOpen( argv[1], "rb" );
-    if( hSHP == NULL )
+    /* -------------------------------------------------------------------- */
+    /*      Open the passed shapefile.                                      */
+    /* -------------------------------------------------------------------- */
+    SHPHandle hSHP = SHPOpen(argv[1], "rb");
+    if (hSHP == NULL)
     {
-        printf( "Unable to open:%s\n", argv[1] );
-        exit( 1 );
+        printf("Unable to open:%s\n", argv[1]);
+        exit(1);
     }
 
-/* -------------------------------------------------------------------- */
-/*      Print out the file bounds.                                      */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Print out the file bounds.                                      */
+    /* -------------------------------------------------------------------- */
     int nEntities;
     int nShapeType;
     double adfMinBound[4];
     double adfMaxBound[4];
-    SHPGetInfo( hSHP, &nEntities, &nShapeType, adfMinBound, adfMaxBound );
+    SHPGetInfo(hSHP, &nEntities, &nShapeType, adfMinBound, adfMaxBound);
 
-    printf( "Shapefile Type: %s   # of Shapes: %d\n\n",
-            SHPTypeName( nShapeType ), nEntities );
+    printf("Shapefile Type: %s   # of Shapes: %d\n\n", SHPTypeName(nShapeType),
+           nEntities);
 
-    printf( "File Bounds: (%.*g,%.*g,%.*g,%.*g)\n"
-            "         to  (%.*g,%.*g,%.*g,%.*g)\n",
-            nPrecision, adfMinBound[0],
-            nPrecision, adfMinBound[1],
-            nPrecision, adfMinBound[2],
-            nPrecision, adfMinBound[3],
-            nPrecision, adfMaxBound[0],
-            nPrecision, adfMaxBound[1],
-            nPrecision, adfMaxBound[2],
-            nPrecision, adfMaxBound[3] );
+    printf("File Bounds: (%.*g,%.*g,%.*g,%.*g)\n"
+           "         to  (%.*g,%.*g,%.*g,%.*g)\n",
+           nPrecision, adfMinBound[0], nPrecision, adfMinBound[1], nPrecision,
+           adfMinBound[2], nPrecision, adfMinBound[3], nPrecision,
+           adfMaxBound[0], nPrecision, adfMaxBound[1], nPrecision,
+           adfMaxBound[2], nPrecision, adfMaxBound[3]);
 
-/* -------------------------------------------------------------------- */
-/*	Skim over the list of shapes, printing all the vertices.	*/
-/* -------------------------------------------------------------------- */
-    int	nInvalidCount = 0;
+    /* -------------------------------------------------------------------- */
+    /*	Skim over the list of shapes, printing all the vertices.	*/
+    /* -------------------------------------------------------------------- */
+    int nInvalidCount = 0;
 
-    for( int i = 0; i < nEntities && !bHeaderOnly; i++ )
+    for (int i = 0; i < nEntities && !bHeaderOnly; i++)
     {
-        SHPObject *psShape = SHPReadObject( hSHP, i );
+        SHPObject *psShape = SHPReadObject(hSHP, i);
 
-        if( psShape == NULL )
+        if (psShape == NULL)
         {
-            fprintf( stderr,
-                     "Unable to read shape %d, terminating object reading.\n",
-                    i );
+            fprintf(stderr,
+                    "Unable to read shape %d, terminating object reading.\n",
+                    i);
             break;
         }
 
-        if( psShape->bMeasureIsUsed )
-            printf( "\nShape:%d (%s)  nVertices=%d, nParts=%d\n"
-                    "  Bounds:(%.*g,%.*g, %.*g, %.*g)\n"
-                    "      to (%.*g,%.*g, %.*g, %.*g)\n",
-                    i, SHPTypeName(psShape->nSHPType),
-                    psShape->nVertices, psShape->nParts,
-                    nPrecision, psShape->dfXMin,
-                    nPrecision, psShape->dfYMin,
-                    nPrecision, psShape->dfZMin,
-                    nPrecision, psShape->dfMMin,
-                    nPrecision, psShape->dfXMax,
-                    nPrecision, psShape->dfYMax,
-                    nPrecision, psShape->dfZMax,
-                    nPrecision, psShape->dfMMax );
+        if (psShape->bMeasureIsUsed)
+            printf("\nShape:%d (%s)  nVertices=%d, nParts=%d\n"
+                   "  Bounds:(%.*g,%.*g, %.*g, %.*g)\n"
+                   "      to (%.*g,%.*g, %.*g, %.*g)\n",
+                   i, SHPTypeName(psShape->nSHPType), psShape->nVertices,
+                   psShape->nParts, nPrecision, psShape->dfXMin, nPrecision,
+                   psShape->dfYMin, nPrecision, psShape->dfZMin, nPrecision,
+                   psShape->dfMMin, nPrecision, psShape->dfXMax, nPrecision,
+                   psShape->dfYMax, nPrecision, psShape->dfZMax, nPrecision,
+                   psShape->dfMMax);
         else
-            printf( "\nShape:%d (%s)  nVertices=%d, nParts=%d\n"
-                    "  Bounds:(%.*g,%.*g, %.*g)\n"
-                    "      to (%.*g,%.*g, %.*g)\n",
-                    i, SHPTypeName(psShape->nSHPType),
-                    psShape->nVertices, psShape->nParts,
-                    nPrecision, psShape->dfXMin,
-                    nPrecision, psShape->dfYMin,
-                    nPrecision, psShape->dfZMin,
-                    nPrecision, psShape->dfXMax,
-                    nPrecision, psShape->dfYMax,
-                    nPrecision, psShape->dfZMax );
+            printf("\nShape:%d (%s)  nVertices=%d, nParts=%d\n"
+                   "  Bounds:(%.*g,%.*g, %.*g)\n"
+                   "      to (%.*g,%.*g, %.*g)\n",
+                   i, SHPTypeName(psShape->nSHPType), psShape->nVertices,
+                   psShape->nParts, nPrecision, psShape->dfXMin, nPrecision,
+                   psShape->dfYMin, nPrecision, psShape->dfZMin, nPrecision,
+                   psShape->dfXMax, nPrecision, psShape->dfYMax, nPrecision,
+                   psShape->dfZMax);
 
-        if( psShape->nParts > 0 && psShape->panPartStart[0] != 0 )
+        if (psShape->nParts > 0 && psShape->panPartStart[0] != 0)
         {
-            fprintf( stderr, "panPartStart[0] = %d, not zero as expected.\n",
-                     psShape->panPartStart[0] );
+            fprintf(stderr, "panPartStart[0] = %d, not zero as expected.\n",
+                    psShape->panPartStart[0]);
         }
 
-        for( int j = 0, iPart = 1; j < psShape->nVertices; j++ )
+        for (int j = 0, iPart = 1; j < psShape->nVertices; j++)
         {
-            const char	*pszPartType = "";
+            const char *pszPartType = "";
 
-            if( j == 0 && psShape->nParts > 0 )
-                pszPartType = SHPPartTypeName( psShape->panPartType[0] );
+            if (j == 0 && psShape->nParts > 0)
+                pszPartType = SHPPartTypeName(psShape->panPartType[0]);
 
             const char *pszPlus;
-            if( iPart < psShape->nParts
-                && psShape->panPartStart[iPart] == j )
+            if (iPart < psShape->nParts && psShape->panPartStart[iPart] == j)
             {
-                pszPartType = SHPPartTypeName( psShape->panPartType[iPart] );
+                pszPartType = SHPPartTypeName(psShape->panPartType[iPart]);
                 iPart++;
                 pszPlus = "+";
             }
             else
                 pszPlus = " ";
 
-            if( psShape->bMeasureIsUsed )
-                printf("   %s (%.*g,%.*g, %.*g, %.*g) %s \n",
-                       pszPlus,
-                       nPrecision, psShape->padfX[j],
-                       nPrecision, psShape->padfY[j],
-                       nPrecision, psShape->padfZ[j],
-                       nPrecision, psShape->padfM[j],
-                       pszPartType );
+            if (psShape->bMeasureIsUsed)
+                printf("   %s (%.*g,%.*g, %.*g, %.*g) %s \n", pszPlus,
+                       nPrecision, psShape->padfX[j], nPrecision,
+                       psShape->padfY[j], nPrecision, psShape->padfZ[j],
+                       nPrecision, psShape->padfM[j], pszPartType);
             else
-                printf("   %s (%.*g,%.*g, %.*g) %s \n",
-                       pszPlus,
-                       nPrecision, psShape->padfX[j],
-                       nPrecision, psShape->padfY[j],
-                       nPrecision, psShape->padfZ[j],
-                       pszPartType );
+                printf("   %s (%.*g,%.*g, %.*g) %s \n", pszPlus, nPrecision,
+                       psShape->padfX[j], nPrecision, psShape->padfY[j],
+                       nPrecision, psShape->padfZ[j], pszPartType);
         }
 
-        if( bValidate )
+        if (bValidate)
         {
-            int nAltered = SHPRewindObject( hSHP, psShape );
+            int nAltered = SHPRewindObject(hSHP, psShape);
 
-            if( nAltered > 0 )
+            if (nAltered > 0)
             {
-                printf( "  %d rings wound in the wrong direction.\n",
-                        nAltered );
+                printf("  %d rings wound in the wrong direction.\n", nAltered);
                 nInvalidCount++;
             }
         }
 
-        SHPDestroyObject( psShape );
+        SHPDestroyObject(psShape);
     }
 
-    SHPClose( hSHP );
+    SHPClose(hSHP);
 
-    if( bValidate )
+    if (bValidate)
     {
-        printf( "%d object has invalid ring orderings.\n", nInvalidCount );
+        printf("%d object has invalid ring orderings.\n", nInvalidCount);
     }
 
 #ifdef USE_DBMALLOC
     malloc_dump(2);
 #endif
 
-    exit( 0 );
+    exit(0);
 }

--- a/shpopen.c
+++ b/shpopen.c
@@ -49,39 +49,39 @@ SHP_CVSID("$Id$")
 typedef unsigned char uchar;
 
 #if UINT_MAX == 65535
-typedef unsigned long	      int32;
+typedef unsigned long int32;
 #else
-typedef unsigned int	      int32;
+typedef unsigned int int32;
 #endif
 
 #ifndef FALSE
-#  define FALSE		0
-#  define TRUE		1
+#define FALSE 0
+#define TRUE 1
 #endif
 
-#define ByteCopy( a, b, c )	memcpy( b, a, c )
+#define ByteCopy(a, b, c) memcpy(b, a, c)
 #ifndef MAX
-#  define MIN(a,b)      ((a<b) ? a : b)
-#  define MAX(a,b)      ((a>b) ? a : b)
+#define MIN(a, b) ((a < b) ? a : b)
+#define MAX(a, b) ((a > b) ? a : b)
 #endif
 
 #ifndef USE_CPL
 #if defined(_MSC_VER)
-# if _MSC_VER < 1900
-#     define snprintf _snprintf
-# endif
+#if _MSC_VER < 1900
+#define snprintf _snprintf
+#endif
 #elif defined(WIN32) || defined(_WIN32)
-#  ifndef snprintf
-#     define snprintf _snprintf
-#  endif
+#ifndef snprintf
+#define snprintf _snprintf
+#endif
 #endif
 #endif
 
 #ifndef CPL_UNUSED
 #if defined(__GNUC__) && __GNUC__ >= 4
-#  define CPL_UNUSED __attribute((__unused__))
+#define CPL_UNUSED __attribute((__unused__))
 #else
-#  define CPL_UNUSED
+#define CPL_UNUSED
 #endif
 #endif
 
@@ -94,10 +94,10 @@ static bool bBigEndian;
 #endif
 
 #ifdef __cplusplus
-#define STATIC_CAST(type,x) static_cast<type>(x)
+#define STATIC_CAST(type, x) static_cast<type>(x)
 #define SHPLIB_NULLPTR nullptr
 #else
-#define STATIC_CAST(type,x) ((type)(x))
+#define STATIC_CAST(type, x) ((type)(x))
 #define SHPLIB_NULLPTR NULL
 #endif
 
@@ -107,12 +107,14 @@ static bool bBigEndian;
 /*      Swap a 2, 4 or 8 byte word.                                     */
 /************************************************************************/
 
-static void SwapWord( int length, void * wordP ) {
-    for( int i = 0; i < length/2; i++ )
+static void SwapWord(int length, void *wordP)
+{
+    for (int i = 0; i < length / 2; i++)
     {
-	const uchar temp = STATIC_CAST(uchar*, wordP)[i];
-	STATIC_CAST(uchar*, wordP)[i] = STATIC_CAST(uchar*, wordP)[length-i-1];
-	STATIC_CAST(uchar*, wordP)[length-i-1] = temp;
+        const uchar temp = STATIC_CAST(uchar *, wordP)[i];
+        STATIC_CAST(uchar *, wordP)
+        [i] = STATIC_CAST(uchar *, wordP)[length - i - 1];
+        STATIC_CAST(uchar *, wordP)[length - i - 1] = temp;
     }
 }
 
@@ -123,163 +125,179 @@ static void SwapWord( int length, void * wordP ) {
 /*	contents of the index (.shx) file.				*/
 /************************************************************************/
 
-void SHPAPI_CALL SHPWriteHeader( SHPHandle psSHP ) {
+void SHPAPI_CALL SHPWriteHeader(SHPHandle psSHP)
+{
     if (psSHP->fpSHX == SHPLIB_NULLPTR)
     {
-        psSHP->sHooks.Error( "SHPWriteHeader failed : SHX file is closed");
+        psSHP->sHooks.Error("SHPWriteHeader failed : SHX file is closed");
         return;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Prepare header block for .shp file.                             */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Prepare header block for .shp file.                             */
+    /* -------------------------------------------------------------------- */
 
-    uchar abyHeader[100] = { 0 };
-    abyHeader[2] = 0x27;				/* magic cookie */
+    uchar abyHeader[100] = {0};
+    abyHeader[2] = 0x27; /* magic cookie */
     abyHeader[3] = 0x0a;
 
-    int32 i32 = psSHP->nFileSize/2;				/* file size */
-    ByteCopy( &i32, abyHeader+24, 4 );
-    if( !bBigEndian ) SwapWord( 4, abyHeader+24 );
+    int32 i32 = psSHP->nFileSize / 2; /* file size */
+    ByteCopy(&i32, abyHeader + 24, 4);
+    if (!bBigEndian)
+        SwapWord(4, abyHeader + 24);
 
-    i32 = 1000;						/* version */
-    ByteCopy( &i32, abyHeader+28, 4 );
-    if( bBigEndian ) SwapWord( 4, abyHeader+28 );
+    i32 = 1000; /* version */
+    ByteCopy(&i32, abyHeader + 28, 4);
+    if (bBigEndian)
+        SwapWord(4, abyHeader + 28);
 
-    i32 = psSHP->nShapeType;				/* shape type */
-    ByteCopy( &i32, abyHeader+32, 4 );
-    if( bBigEndian ) SwapWord( 4, abyHeader+32 );
+    i32 = psSHP->nShapeType; /* shape type */
+    ByteCopy(&i32, abyHeader + 32, 4);
+    if (bBigEndian)
+        SwapWord(4, abyHeader + 32);
 
-    double dValue = psSHP->adBoundsMin[0];			/* set bounds */
-    ByteCopy( &dValue, abyHeader+36, 8 );
-    if( bBigEndian ) SwapWord( 8, abyHeader+36 );
+    double dValue = psSHP->adBoundsMin[0]; /* set bounds */
+    ByteCopy(&dValue, abyHeader + 36, 8);
+    if (bBigEndian)
+        SwapWord(8, abyHeader + 36);
 
     dValue = psSHP->adBoundsMin[1];
-    ByteCopy( &dValue, abyHeader+44, 8 );
-    if( bBigEndian ) SwapWord( 8, abyHeader+44 );
+    ByteCopy(&dValue, abyHeader + 44, 8);
+    if (bBigEndian)
+        SwapWord(8, abyHeader + 44);
 
     dValue = psSHP->adBoundsMax[0];
-    ByteCopy( &dValue, abyHeader+52, 8 );
-    if( bBigEndian ) SwapWord( 8, abyHeader+52 );
+    ByteCopy(&dValue, abyHeader + 52, 8);
+    if (bBigEndian)
+        SwapWord(8, abyHeader + 52);
 
     dValue = psSHP->adBoundsMax[1];
-    ByteCopy( &dValue, abyHeader+60, 8 );
-    if( bBigEndian ) SwapWord( 8, abyHeader+60 );
+    ByteCopy(&dValue, abyHeader + 60, 8);
+    if (bBigEndian)
+        SwapWord(8, abyHeader + 60);
 
-    dValue = psSHP->adBoundsMin[2];			/* z */
-    ByteCopy( &dValue, abyHeader+68, 8 );
-    if( bBigEndian ) SwapWord( 8, abyHeader+68 );
+    dValue = psSHP->adBoundsMin[2]; /* z */
+    ByteCopy(&dValue, abyHeader + 68, 8);
+    if (bBigEndian)
+        SwapWord(8, abyHeader + 68);
 
     dValue = psSHP->adBoundsMax[2];
-    ByteCopy( &dValue, abyHeader+76, 8 );
-    if( bBigEndian ) SwapWord( 8, abyHeader+76 );
+    ByteCopy(&dValue, abyHeader + 76, 8);
+    if (bBigEndian)
+        SwapWord(8, abyHeader + 76);
 
-    dValue = psSHP->adBoundsMin[3];			/* m */
-    ByteCopy( &dValue, abyHeader+84, 8 );
-    if( bBigEndian ) SwapWord( 8, abyHeader+84 );
+    dValue = psSHP->adBoundsMin[3]; /* m */
+    ByteCopy(&dValue, abyHeader + 84, 8);
+    if (bBigEndian)
+        SwapWord(8, abyHeader + 84);
 
     dValue = psSHP->adBoundsMax[3];
-    ByteCopy( &dValue, abyHeader+92, 8 );
-    if( bBigEndian ) SwapWord( 8, abyHeader+92 );
+    ByteCopy(&dValue, abyHeader + 92, 8);
+    if (bBigEndian)
+        SwapWord(8, abyHeader + 92);
 
-/* -------------------------------------------------------------------- */
-/*      Write .shp file header.                                         */
-/* -------------------------------------------------------------------- */
-    if( psSHP->sHooks.FSeek( psSHP->fpSHP, 0, 0 ) != 0
-        || psSHP->sHooks.FWrite( abyHeader, 100, 1, psSHP->fpSHP ) != 1 )
+    /* -------------------------------------------------------------------- */
+    /*      Write .shp file header.                                         */
+    /* -------------------------------------------------------------------- */
+    if (psSHP->sHooks.FSeek(psSHP->fpSHP, 0, 0) != 0 ||
+        psSHP->sHooks.FWrite(abyHeader, 100, 1, psSHP->fpSHP) != 1)
     {
         char szErrorMsg[200];
 
-        snprintf( szErrorMsg, sizeof(szErrorMsg),
-                 "Failure writing .shp header: %s", strerror(errno) );
-        szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-        psSHP->sHooks.Error( szErrorMsg );
+        snprintf(szErrorMsg, sizeof(szErrorMsg),
+                 "Failure writing .shp header: %s", strerror(errno));
+        szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+        psSHP->sHooks.Error(szErrorMsg);
         return;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Prepare, and write .shx file header.                            */
-/* -------------------------------------------------------------------- */
-    i32 = (psSHP->nRecords * 2 * sizeof(int32) + 100)/2;   /* file size */
-    ByteCopy( &i32, abyHeader+24, 4 );
-    if( !bBigEndian ) SwapWord( 4, abyHeader+24 );
+    /* -------------------------------------------------------------------- */
+    /*      Prepare, and write .shx file header.                            */
+    /* -------------------------------------------------------------------- */
+    i32 = (psSHP->nRecords * 2 * sizeof(int32) + 100) / 2; /* file size */
+    ByteCopy(&i32, abyHeader + 24, 4);
+    if (!bBigEndian)
+        SwapWord(4, abyHeader + 24);
 
-    if( psSHP->sHooks.FSeek( psSHP->fpSHX, 0, 0 ) != 0
-        || psSHP->sHooks.FWrite( abyHeader, 100, 1, psSHP->fpSHX ) != 1 )
+    if (psSHP->sHooks.FSeek(psSHP->fpSHX, 0, 0) != 0 ||
+        psSHP->sHooks.FWrite(abyHeader, 100, 1, psSHP->fpSHX) != 1)
     {
         char szErrorMsg[200];
 
-        snprintf( szErrorMsg, sizeof(szErrorMsg),
-                 "Failure writing .shx header: %s", strerror(errno) );
-        szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-        psSHP->sHooks.Error( szErrorMsg );
+        snprintf(szErrorMsg, sizeof(szErrorMsg),
+                 "Failure writing .shx header: %s", strerror(errno));
+        szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+        psSHP->sHooks.Error(szErrorMsg);
 
         return;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Write out the .shx contents.                                    */
-/* -------------------------------------------------------------------- */
-    int32 *panSHX = STATIC_CAST(int32 *, malloc(sizeof(int32) * 2 * psSHP->nRecords));
-    if( panSHX == SHPLIB_NULLPTR )
+    /* -------------------------------------------------------------------- */
+    /*      Write out the .shx contents.                                    */
+    /* -------------------------------------------------------------------- */
+    int32 *panSHX =
+        STATIC_CAST(int32 *, malloc(sizeof(int32) * 2 * psSHP->nRecords));
+    if (panSHX == SHPLIB_NULLPTR)
     {
-        psSHP->sHooks.Error( "Failure allocatin panSHX" );
+        psSHP->sHooks.Error("Failure allocatin panSHX");
         return;
     }
 
-    for( int i = 0; i < psSHP->nRecords; i++ )
+    for (int i = 0; i < psSHP->nRecords; i++)
     {
-        panSHX[i*2  ] = psSHP->panRecOffset[i]/2;
-        panSHX[i*2+1] = psSHP->panRecSize[i]/2;
-        if( !bBigEndian ) SwapWord( 4, panSHX+i*2 );
-        if( !bBigEndian ) SwapWord( 4, panSHX+i*2+1 );
+        panSHX[i * 2] = psSHP->panRecOffset[i] / 2;
+        panSHX[i * 2 + 1] = psSHP->panRecSize[i] / 2;
+        if (!bBigEndian)
+            SwapWord(4, panSHX + i * 2);
+        if (!bBigEndian)
+            SwapWord(4, panSHX + i * 2 + 1);
     }
 
-    if( STATIC_CAST(int, psSHP->sHooks.FWrite( panSHX, sizeof(int32)*2, psSHP->nRecords, psSHP->fpSHX ))
-        != psSHP->nRecords )
+    if (STATIC_CAST(int, psSHP->sHooks.FWrite(panSHX, sizeof(int32) * 2,
+                                              psSHP->nRecords, psSHP->fpSHX)) !=
+        psSHP->nRecords)
     {
         char szErrorMsg[200];
 
-        snprintf( szErrorMsg, sizeof(szErrorMsg),
-                 "Failure writing .shx contents: %s", strerror(errno) );
-        szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-        psSHP->sHooks.Error( szErrorMsg );
+        snprintf(szErrorMsg, sizeof(szErrorMsg),
+                 "Failure writing .shx contents: %s", strerror(errno));
+        szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+        psSHP->sHooks.Error(szErrorMsg);
     }
 
-    free( panSHX );
+    free(panSHX);
 
-/* -------------------------------------------------------------------- */
-/*      Flush to disk.                                                  */
-/* -------------------------------------------------------------------- */
-    psSHP->sHooks.FFlush( psSHP->fpSHP );
-    psSHP->sHooks.FFlush( psSHP->fpSHX );
+    /* -------------------------------------------------------------------- */
+    /*      Flush to disk.                                                  */
+    /* -------------------------------------------------------------------- */
+    psSHP->sHooks.FFlush(psSHP->fpSHP);
+    psSHP->sHooks.FFlush(psSHP->fpSHX);
 }
 
 /************************************************************************/
 /*                              SHPOpen()                               */
 /************************************************************************/
 
-SHPHandle SHPAPI_CALL
-SHPOpen( const char * pszLayer, const char * pszAccess ){
+SHPHandle SHPAPI_CALL SHPOpen(const char *pszLayer, const char *pszAccess)
+{
     SAHooks sHooks;
 
-    SASetupDefaultHooks( &sHooks );
+    SASetupDefaultHooks(&sHooks);
 
-    return SHPOpenLL( pszLayer, pszAccess, &sHooks );
+    return SHPOpenLL(pszLayer, pszAccess, &sHooks);
 }
 
 /************************************************************************/
 /*                      SHPGetLenWithoutExtension()                     */
 /************************************************************************/
 
-static int SHPGetLenWithoutExtension(const char* pszBasename)
+static int SHPGetLenWithoutExtension(const char *pszBasename)
 {
     const int nLen = STATIC_CAST(int, strlen(pszBasename));
-    for( int i = nLen-1;
-         i > 0 && pszBasename[i] != '/' && pszBasename[i] != '\\';
-         i-- )
+    for (int i = nLen - 1;
+         i > 0 && pszBasename[i] != '/' && pszBasename[i] != '\\'; i--)
     {
-        if( pszBasename[i] == '.' )
+        if (pszBasename[i] == '.')
         {
             return i;
         }
@@ -294,18 +312,22 @@ static int SHPGetLenWithoutExtension(const char* pszBasename)
 /*      files or either file name.                                      */
 /************************************************************************/
 
-SHPHandle SHPAPI_CALL
-SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks ) {
-/* -------------------------------------------------------------------- */
-/*      Ensure the access string is one of the legal ones.  We          */
-/*      ensure the result string indicates binary to avoid common       */
-/*      problems on Windows.                                            */
-/* -------------------------------------------------------------------- */
+SHPHandle SHPAPI_CALL SHPOpenLL(const char *pszLayer, const char *pszAccess,
+                                SAHooks *psHooks)
+{
+    /* -------------------------------------------------------------------- */
+    /*      Ensure the access string is one of the legal ones.  We          */
+    /*      ensure the result string indicates binary to avoid common       */
+    /*      problems on Windows.                                            */
+    /* -------------------------------------------------------------------- */
     bool bLazySHXLoading = false;
-    if( strcmp(pszAccess,"rb+") == 0 || strcmp(pszAccess,"r+b") == 0
-        || strcmp(pszAccess,"r+") == 0 ) {
+    if (strcmp(pszAccess, "rb+") == 0 || strcmp(pszAccess, "r+b") == 0 ||
+        strcmp(pszAccess, "r+") == 0)
+    {
         pszAccess = "r+b";
-    } else {
+    }
+    else
+    {
         bLazySHXLoading = strchr(pszAccess, 'l') != SHPLIB_NULLPTR;
         pszAccess = "rb";
     }
@@ -315,139 +337,139 @@ SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks ) {
 /* -------------------------------------------------------------------- */
 #if !defined(bBigEndian)
     {
-    int i = 1;
-    if( *((uchar *) &i) == 1 )
-        bBigEndian = false;
-    else
-        bBigEndian = true;
+        int i = 1;
+        if (*((uchar *)&i) == 1)
+            bBigEndian = false;
+        else
+            bBigEndian = true;
     }
 #endif
 
-/* -------------------------------------------------------------------- */
-/*  Initialize the info structure.                  */
-/* -------------------------------------------------------------------- */
-    SHPHandle psSHP = STATIC_CAST(SHPHandle, calloc(sizeof(SHPInfo),1));
+    /* -------------------------------------------------------------------- */
+    /*  Initialize the info structure.                  */
+    /* -------------------------------------------------------------------- */
+    SHPHandle psSHP = STATIC_CAST(SHPHandle, calloc(sizeof(SHPInfo), 1));
 
     psSHP->bUpdated = FALSE;
-    memcpy( &(psSHP->sHooks), psHooks, sizeof(SAHooks) );
+    memcpy(&(psSHP->sHooks), psHooks, sizeof(SAHooks));
 
-/* -------------------------------------------------------------------- */
-/*  Open the .shp and .shx files.  Note that files pulled from  */
-/*  a PC to Unix with upper case filenames won't work!      */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*  Open the .shp and .shx files.  Note that files pulled from  */
+    /*  a PC to Unix with upper case filenames won't work!      */
+    /* -------------------------------------------------------------------- */
     const int nLenWithoutExtension = SHPGetLenWithoutExtension(pszLayer);
     char *pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
     memcpy(pszFullname, pszLayer, nLenWithoutExtension);
     memcpy(pszFullname + nLenWithoutExtension, ".shp", 5);
-    psSHP->fpSHP = psSHP->sHooks.FOpen(pszFullname, pszAccess );
-    if( psSHP->fpSHP == SHPLIB_NULLPTR )
+    psSHP->fpSHP = psSHP->sHooks.FOpen(pszFullname, pszAccess);
+    if (psSHP->fpSHP == SHPLIB_NULLPTR)
     {
         memcpy(pszFullname + nLenWithoutExtension, ".SHP", 5);
-        psSHP->fpSHP = psSHP->sHooks.FOpen(pszFullname, pszAccess );
+        psSHP->fpSHP = psSHP->sHooks.FOpen(pszFullname, pszAccess);
     }
 
-    if( psSHP->fpSHP == SHPLIB_NULLPTR )
+    if (psSHP->fpSHP == SHPLIB_NULLPTR)
     {
-        const size_t nMessageLen = strlen(pszFullname)*2+256;
+        const size_t nMessageLen = strlen(pszFullname) * 2 + 256;
         char *pszMessage = STATIC_CAST(char *, malloc(nMessageLen));
         pszFullname[nLenWithoutExtension] = 0;
-        snprintf( pszMessage, nMessageLen, "Unable to open %s.shp or %s.SHP.",
-                  pszFullname, pszFullname );
-        psHooks->Error( pszMessage );
-        free( pszMessage );
+        snprintf(pszMessage, nMessageLen, "Unable to open %s.shp or %s.SHP.",
+                 pszFullname, pszFullname);
+        psHooks->Error(pszMessage);
+        free(pszMessage);
 
-        free( psSHP );
-        free( pszFullname );
+        free(psSHP);
+        free(pszFullname);
 
         return SHPLIB_NULLPTR;
     }
 
     memcpy(pszFullname + nLenWithoutExtension, ".shx", 5);
-    psSHP->fpSHX =  psSHP->sHooks.FOpen(pszFullname, pszAccess );
-    if( psSHP->fpSHX == SHPLIB_NULLPTR )
+    psSHP->fpSHX = psSHP->sHooks.FOpen(pszFullname, pszAccess);
+    if (psSHP->fpSHX == SHPLIB_NULLPTR)
     {
         memcpy(pszFullname + nLenWithoutExtension, ".SHX", 5);
-        psSHP->fpSHX = psSHP->sHooks.FOpen(pszFullname, pszAccess );
+        psSHP->fpSHX = psSHP->sHooks.FOpen(pszFullname, pszAccess);
     }
 
-    if( psSHP->fpSHX == SHPLIB_NULLPTR )
+    if (psSHP->fpSHX == SHPLIB_NULLPTR)
     {
-        const size_t nMessageLen = strlen(pszFullname)*2+256;
+        const size_t nMessageLen = strlen(pszFullname) * 2 + 256;
         char *pszMessage = STATIC_CAST(char *, malloc(nMessageLen));
         pszFullname[nLenWithoutExtension] = 0;
-        snprintf( pszMessage, nMessageLen, "Unable to open %s.shx or %s.SHX. "
-                  "Set SHAPE_RESTORE_SHX config option to YES to restore or "
-                  "create it.", pszFullname, pszFullname );
-        psHooks->Error( pszMessage );
-        free( pszMessage );
+        snprintf(pszMessage, nMessageLen,
+                 "Unable to open %s.shx or %s.SHX. "
+                 "Set SHAPE_RESTORE_SHX config option to YES to restore or "
+                 "create it.",
+                 pszFullname, pszFullname);
+        psHooks->Error(pszMessage);
+        free(pszMessage);
 
-        psSHP->sHooks.FClose( psSHP->fpSHP );
-        free( psSHP );
-        free( pszFullname );
-        return SHPLIB_NULLPTR ;
+        psSHP->sHooks.FClose(psSHP->fpSHP);
+        free(psSHP);
+        free(pszFullname);
+        return SHPLIB_NULLPTR;
     }
 
-    free( pszFullname );
+    free(pszFullname);
 
-/* -------------------------------------------------------------------- */
-/*  Read the file size from the SHP file.               */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*  Read the file size from the SHP file.               */
+    /* -------------------------------------------------------------------- */
     uchar *pabyBuf = STATIC_CAST(uchar *, malloc(100));
-    if( psSHP->sHooks.FRead( pabyBuf, 100, 1, psSHP->fpSHP ) != 1 )
+    if (psSHP->sHooks.FRead(pabyBuf, 100, 1, psSHP->fpSHP) != 1)
     {
-        psSHP->sHooks.Error( ".shp file is unreadable, or corrupt." );
-        psSHP->sHooks.FClose( psSHP->fpSHP );
-        psSHP->sHooks.FClose( psSHP->fpSHX );
-        free( pabyBuf );
-        free( psSHP );
-
-        return SHPLIB_NULLPTR ;
-    }
-
-    psSHP->nFileSize = (STATIC_CAST(unsigned int, pabyBuf[24])<<24)|(pabyBuf[25]<<16)|
-                        (pabyBuf[26]<<8)|pabyBuf[27];
-    if( psSHP->nFileSize < UINT_MAX / 2 )
-        psSHP->nFileSize *= 2;
-    else
-        psSHP->nFileSize = (UINT_MAX / 2) * 2;
-
-/* -------------------------------------------------------------------- */
-/*  Read SHX file Header info                                           */
-/* -------------------------------------------------------------------- */
-    if( psSHP->sHooks.FRead( pabyBuf, 100, 1, psSHP->fpSHX ) != 1
-        || pabyBuf[0] != 0
-        || pabyBuf[1] != 0
-        || pabyBuf[2] != 0x27
-        || (pabyBuf[3] != 0x0a && pabyBuf[3] != 0x0d) )
-    {
-        psSHP->sHooks.Error( ".shx file is unreadable, or corrupt." );
-        psSHP->sHooks.FClose( psSHP->fpSHP );
-        psSHP->sHooks.FClose( psSHP->fpSHX );
-        free( pabyBuf );
-        free( psSHP );
+        psSHP->sHooks.Error(".shp file is unreadable, or corrupt.");
+        psSHP->sHooks.FClose(psSHP->fpSHP);
+        psSHP->sHooks.FClose(psSHP->fpSHX);
+        free(pabyBuf);
+        free(psSHP);
 
         return SHPLIB_NULLPTR;
     }
 
-    psSHP->nRecords = pabyBuf[27]|(pabyBuf[26]<<8)|(pabyBuf[25]<<16)|
-                      ((pabyBuf[24] & 0x7F)<<24);
+    psSHP->nFileSize = (STATIC_CAST(unsigned int, pabyBuf[24]) << 24) |
+                       (pabyBuf[25] << 16) | (pabyBuf[26] << 8) | pabyBuf[27];
+    if (psSHP->nFileSize < UINT_MAX / 2)
+        psSHP->nFileSize *= 2;
+    else
+        psSHP->nFileSize = (UINT_MAX / 2) * 2;
+
+    /* -------------------------------------------------------------------- */
+    /*  Read SHX file Header info                                           */
+    /* -------------------------------------------------------------------- */
+    if (psSHP->sHooks.FRead(pabyBuf, 100, 1, psSHP->fpSHX) != 1 ||
+        pabyBuf[0] != 0 || pabyBuf[1] != 0 || pabyBuf[2] != 0x27 ||
+        (pabyBuf[3] != 0x0a && pabyBuf[3] != 0x0d))
+    {
+        psSHP->sHooks.Error(".shx file is unreadable, or corrupt.");
+        psSHP->sHooks.FClose(psSHP->fpSHP);
+        psSHP->sHooks.FClose(psSHP->fpSHX);
+        free(pabyBuf);
+        free(psSHP);
+
+        return SHPLIB_NULLPTR;
+    }
+
+    psSHP->nRecords = pabyBuf[27] | (pabyBuf[26] << 8) | (pabyBuf[25] << 16) |
+                      ((pabyBuf[24] & 0x7F) << 24);
     psSHP->nRecords = (psSHP->nRecords - 50) / 4;
 
     psSHP->nShapeType = pabyBuf[32];
 
-    if( psSHP->nRecords < 0 || psSHP->nRecords > 256000000 )
+    if (psSHP->nRecords < 0 || psSHP->nRecords > 256000000)
     {
         char szErrorMsg[200];
 
-        snprintf( szErrorMsg, sizeof(szErrorMsg),
+        snprintf(szErrorMsg, sizeof(szErrorMsg),
                  "Record count in .shx header is %d, which seems\n"
                  "unreasonable.  Assuming header is corrupt.",
-                 psSHP->nRecords );
-        szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-        psSHP->sHooks.Error( szErrorMsg );
-        psSHP->sHooks.FClose( psSHP->fpSHP );
-        psSHP->sHooks.FClose( psSHP->fpSHX );
-        free( psSHP );
+                 psSHP->nRecords);
+        szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+        psSHP->sHooks.Error(szErrorMsg);
+        psSHP->sHooks.FClose(psSHP->fpSHP);
+        psSHP->sHooks.FClose(psSHP->fpSHX);
+        free(psSHP);
         free(pabyBuf);
 
         return SHPLIB_NULLPTR;
@@ -455,71 +477,81 @@ SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks ) {
 
     /* If a lot of records are advertized, check that the file is big enough */
     /* to hold them */
-    if( psSHP->nRecords >= 1024 * 1024 )
+    if (psSHP->nRecords >= 1024 * 1024)
     {
-        psSHP->sHooks.FSeek( psSHP->fpSHX, 0, 2 );
-        const SAOffset nFileSize = psSHP->sHooks.FTell( psSHP->fpSHX );
-        if( nFileSize > 100 &&
-            nFileSize/2 < STATIC_CAST(SAOffset, psSHP->nRecords * 4 + 50) )
+        psSHP->sHooks.FSeek(psSHP->fpSHX, 0, 2);
+        const SAOffset nFileSize = psSHP->sHooks.FTell(psSHP->fpSHX);
+        if (nFileSize > 100 &&
+            nFileSize / 2 < STATIC_CAST(SAOffset, psSHP->nRecords * 4 + 50))
         {
             psSHP->nRecords = STATIC_CAST(int, (nFileSize - 100) / 8);
         }
-        psSHP->sHooks.FSeek( psSHP->fpSHX, 100, 0 );
+        psSHP->sHooks.FSeek(psSHP->fpSHX, 100, 0);
     }
 
-/* -------------------------------------------------------------------- */
-/*      Read the bounds.                                                */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Read the bounds.                                                */
+    /* -------------------------------------------------------------------- */
     double dValue;
 
-    if( bBigEndian ) SwapWord( 8, pabyBuf+36 );
-    memcpy( &dValue, pabyBuf+36, 8 );
+    if (bBigEndian)
+        SwapWord(8, pabyBuf + 36);
+    memcpy(&dValue, pabyBuf + 36, 8);
     psSHP->adBoundsMin[0] = dValue;
 
-    if( bBigEndian ) SwapWord( 8, pabyBuf+44 );
-    memcpy( &dValue, pabyBuf+44, 8 );
+    if (bBigEndian)
+        SwapWord(8, pabyBuf + 44);
+    memcpy(&dValue, pabyBuf + 44, 8);
     psSHP->adBoundsMin[1] = dValue;
 
-    if( bBigEndian ) SwapWord( 8, pabyBuf+52 );
-    memcpy( &dValue, pabyBuf+52, 8 );
+    if (bBigEndian)
+        SwapWord(8, pabyBuf + 52);
+    memcpy(&dValue, pabyBuf + 52, 8);
     psSHP->adBoundsMax[0] = dValue;
 
-    if( bBigEndian ) SwapWord( 8, pabyBuf+60 );
-    memcpy( &dValue, pabyBuf+60, 8 );
+    if (bBigEndian)
+        SwapWord(8, pabyBuf + 60);
+    memcpy(&dValue, pabyBuf + 60, 8);
     psSHP->adBoundsMax[1] = dValue;
 
-    if( bBigEndian ) SwapWord( 8, pabyBuf+68 );     /* z */
-    memcpy( &dValue, pabyBuf+68, 8 );
+    if (bBigEndian)
+        SwapWord(8, pabyBuf + 68); /* z */
+    memcpy(&dValue, pabyBuf + 68, 8);
     psSHP->adBoundsMin[2] = dValue;
 
-    if( bBigEndian ) SwapWord( 8, pabyBuf+76 );
-    memcpy( &dValue, pabyBuf+76, 8 );
+    if (bBigEndian)
+        SwapWord(8, pabyBuf + 76);
+    memcpy(&dValue, pabyBuf + 76, 8);
     psSHP->adBoundsMax[2] = dValue;
 
-    if( bBigEndian ) SwapWord( 8, pabyBuf+84 );     /* z */
-    memcpy( &dValue, pabyBuf+84, 8 );
+    if (bBigEndian)
+        SwapWord(8, pabyBuf + 84); /* z */
+    memcpy(&dValue, pabyBuf + 84, 8);
     psSHP->adBoundsMin[3] = dValue;
 
-    if( bBigEndian ) SwapWord( 8, pabyBuf+92 );
-    memcpy( &dValue, pabyBuf+92, 8 );
+    if (bBigEndian)
+        SwapWord(8, pabyBuf + 92);
+    memcpy(&dValue, pabyBuf + 92, 8);
     psSHP->adBoundsMax[3] = dValue;
 
-    free( pabyBuf );
+    free(pabyBuf);
 
-/* -------------------------------------------------------------------- */
-/*  Read the .shx file to get the offsets to each record in     */
-/*  the .shp file.                          */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*  Read the .shx file to get the offsets to each record in     */
+    /*  the .shp file.                          */
+    /* -------------------------------------------------------------------- */
     psSHP->nMaxRecords = psSHP->nRecords;
 
-    psSHP->panRecOffset = STATIC_CAST(unsigned int *,
-        malloc(sizeof(unsigned int) * MAX(1,psSHP->nMaxRecords) ));
-    psSHP->panRecSize = STATIC_CAST(unsigned int *,
-        malloc(sizeof(unsigned int) * MAX(1,psSHP->nMaxRecords) ));
-    if( bLazySHXLoading )
+    psSHP->panRecOffset =
+        STATIC_CAST(unsigned int *,
+                    malloc(sizeof(unsigned int) * MAX(1, psSHP->nMaxRecords)));
+    psSHP->panRecSize =
+        STATIC_CAST(unsigned int *,
+                    malloc(sizeof(unsigned int) * MAX(1, psSHP->nMaxRecords)));
+    if (bLazySHXLoading)
         pabyBuf = SHPLIB_NULLPTR;
     else
-        pabyBuf = STATIC_CAST(uchar *, malloc(8 * MAX(1,psSHP->nRecords) ));
+        pabyBuf = STATIC_CAST(uchar *, malloc(8 * MAX(1, psSHP->nRecords)));
 
     if (psSHP->panRecOffset == SHPLIB_NULLPTR ||
         psSHP->panRecSize == SHPLIB_NULLPTR ||
@@ -527,47 +559,53 @@ SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks ) {
     {
         char szErrorMsg[200];
 
-        snprintf( szErrorMsg, sizeof(szErrorMsg),
-                "Not enough memory to allocate requested memory (nRecords=%d).\n"
-                "Probably broken SHP file",
-                psSHP->nRecords );
-        szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-        psSHP->sHooks.Error( szErrorMsg );
-        psSHP->sHooks.FClose( psSHP->fpSHP );
-        psSHP->sHooks.FClose( psSHP->fpSHX );
-        if (psSHP->panRecOffset) free( psSHP->panRecOffset );
-        if (psSHP->panRecSize) free( psSHP->panRecSize );
-        if (pabyBuf) free( pabyBuf );
-        free( psSHP );
+        snprintf(
+            szErrorMsg, sizeof(szErrorMsg),
+            "Not enough memory to allocate requested memory (nRecords=%d).\n"
+            "Probably broken SHP file",
+            psSHP->nRecords);
+        szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+        psSHP->sHooks.Error(szErrorMsg);
+        psSHP->sHooks.FClose(psSHP->fpSHP);
+        psSHP->sHooks.FClose(psSHP->fpSHX);
+        if (psSHP->panRecOffset)
+            free(psSHP->panRecOffset);
+        if (psSHP->panRecSize)
+            free(psSHP->panRecSize);
+        if (pabyBuf)
+            free(pabyBuf);
+        free(psSHP);
         return SHPLIB_NULLPTR;
     }
 
-    if( bLazySHXLoading )
+    if (bLazySHXLoading)
     {
-        memset(psSHP->panRecOffset, 0, sizeof(unsigned int) * MAX(1,psSHP->nMaxRecords) );
-        memset(psSHP->panRecSize, 0, sizeof(unsigned int) * MAX(1,psSHP->nMaxRecords) );
-        free( pabyBuf ); // sometimes make cppcheck happy, but
-        return( psSHP );
+        memset(psSHP->panRecOffset, 0,
+               sizeof(unsigned int) * MAX(1, psSHP->nMaxRecords));
+        memset(psSHP->panRecSize, 0,
+               sizeof(unsigned int) * MAX(1, psSHP->nMaxRecords));
+        free(pabyBuf);  // sometimes make cppcheck happy, but
+        return (psSHP);
     }
 
-    if( STATIC_CAST(int, psSHP->sHooks.FRead( pabyBuf, 8, psSHP->nRecords, psSHP->fpSHX ))
-        != psSHP->nRecords )
+    if (STATIC_CAST(int, psSHP->sHooks.FRead(pabyBuf, 8, psSHP->nRecords,
+                                             psSHP->fpSHX)) != psSHP->nRecords)
     {
         char szErrorMsg[200];
 
-        snprintf( szErrorMsg, sizeof(szErrorMsg),
+        snprintf(szErrorMsg, sizeof(szErrorMsg),
                  "Failed to read all values for %d records in .shx file: %s.",
-                 psSHP->nRecords, strerror(errno) );
-        szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-        psSHP->sHooks.Error( szErrorMsg );
+                 psSHP->nRecords, strerror(errno));
+        szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+        psSHP->sHooks.Error(szErrorMsg);
 
         /* SHX is short or unreadable for some reason. */
-        psSHP->sHooks.FClose( psSHP->fpSHP );
-        psSHP->sHooks.FClose( psSHP->fpSHX );
-        free( psSHP->panRecOffset );
-        free( psSHP->panRecSize );
-        free( pabyBuf );
-        free( psSHP );
+        psSHP->sHooks.FClose(psSHP->fpSHP);
+        psSHP->sHooks.FClose(psSHP->fpSHX);
+        free(psSHP->panRecOffset);
+        free(psSHP->panRecSize);
+        free(pabyBuf);
+        free(psSHP);
 
         return SHPLIB_NULLPTR;
     }
@@ -575,50 +613,50 @@ SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks ) {
     /* In read-only mode, we can close the SHX now */
     if (strcmp(pszAccess, "rb") == 0)
     {
-        psSHP->sHooks.FClose( psSHP->fpSHX );
+        psSHP->sHooks.FClose(psSHP->fpSHX);
         psSHP->fpSHX = SHPLIB_NULLPTR;
     }
 
-    for( int i = 0; i < psSHP->nRecords; i++ )
+    for (int i = 0; i < psSHP->nRecords; i++)
     {
         unsigned int nOffset;
-        memcpy( &nOffset, pabyBuf + i * 8, 4 );
-        if( !bBigEndian ) SwapWord( 4, &nOffset );
+        memcpy(&nOffset, pabyBuf + i * 8, 4);
+        if (!bBigEndian)
+            SwapWord(4, &nOffset);
 
         unsigned int nLength;
-        memcpy( &nLength, pabyBuf + i * 8 + 4, 4 );
-        if( !bBigEndian ) SwapWord( 4, &nLength );
+        memcpy(&nLength, pabyBuf + i * 8 + 4, 4);
+        if (!bBigEndian)
+            SwapWord(4, &nLength);
 
-        if( nOffset > STATIC_CAST(unsigned int, INT_MAX) )
+        if (nOffset > STATIC_CAST(unsigned int, INT_MAX))
         {
             char str[128];
-            snprintf( str, sizeof(str),
-                    "Invalid offset for entity %d", i);
-            str[sizeof(str)-1] = '\0';
+            snprintf(str, sizeof(str), "Invalid offset for entity %d", i);
+            str[sizeof(str) - 1] = '\0';
 
-            psSHP->sHooks.Error( str );
+            psSHP->sHooks.Error(str);
             SHPClose(psSHP);
-            free( pabyBuf );
+            free(pabyBuf);
             return SHPLIB_NULLPTR;
         }
-        if( nLength > STATIC_CAST(unsigned int, INT_MAX / 2 - 4) )
+        if (nLength > STATIC_CAST(unsigned int, INT_MAX / 2 - 4))
         {
             char str[128];
-            snprintf( str, sizeof(str),
-                    "Invalid length for entity %d", i);
-            str[sizeof(str)-1] = '\0';
+            snprintf(str, sizeof(str), "Invalid length for entity %d", i);
+            str[sizeof(str) - 1] = '\0';
 
-            psSHP->sHooks.Error( str );
+            psSHP->sHooks.Error(str);
             SHPClose(psSHP);
-            free( pabyBuf );
+            free(pabyBuf);
             return SHPLIB_NULLPTR;
         }
-        psSHP->panRecOffset[i] = nOffset*2;
-        psSHP->panRecSize[i] = nLength*2;
+        psSHP->panRecOffset[i] = nOffset * 2;
+        psSHP->panRecSize[i] = nLength * 2;
     }
-    free( pabyBuf );
+    free(pabyBuf);
 
-    return( psSHP );
+    return (psSHP);
 }
 
 /************************************************************************/
@@ -629,15 +667,16 @@ SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks ) {
 /*      in case when bRestoreSHX equals true.                           */
 /************************************************************************/
 
-SHPHandle SHPAPI_CALL
-SHPOpenLLEx( const char * pszLayer, const char * pszAccess, SAHooks *psHooks,
-            int bRestoreSHX ) {
-    if ( !bRestoreSHX ) return SHPOpenLL ( pszLayer, pszAccess, psHooks );
+SHPHandle SHPAPI_CALL SHPOpenLLEx(const char *pszLayer, const char *pszAccess,
+                                  SAHooks *psHooks, int bRestoreSHX)
+{
+    if (!bRestoreSHX)
+        return SHPOpenLL(pszLayer, pszAccess, psHooks);
     else
     {
-        if ( SHPRestoreSHX ( pszLayer, pszAccess, psHooks ) )
+        if (SHPRestoreSHX(pszLayer, pszAccess, psHooks))
         {
-            return SHPOpenLL ( pszLayer, pszAccess, psHooks );
+            return SHPOpenLL(pszLayer, pszAccess, psHooks);
         }
     }
 
@@ -651,17 +690,21 @@ SHPOpenLLEx( const char * pszLayer, const char * pszAccess, SAHooks *psHooks,
 /*                                                                      */
 /************************************************************************/
 
-int SHPAPI_CALL
-SHPRestoreSHX ( const char * pszLayer, const char * pszAccess, SAHooks *psHooks ) {
-/* -------------------------------------------------------------------- */
-/*      Ensure the access string is one of the legal ones.  We          */
-/*      ensure the result string indicates binary to avoid common       */
-/*      problems on Windows.                                            */
-/* -------------------------------------------------------------------- */
-    if( strcmp(pszAccess,"rb+") == 0 || strcmp(pszAccess,"r+b") == 0
-        || strcmp(pszAccess,"r+") == 0 ) {
+int SHPAPI_CALL SHPRestoreSHX(const char *pszLayer, const char *pszAccess,
+                              SAHooks *psHooks)
+{
+    /* -------------------------------------------------------------------- */
+    /*      Ensure the access string is one of the legal ones.  We          */
+    /*      ensure the result string indicates binary to avoid common       */
+    /*      problems on Windows.                                            */
+    /* -------------------------------------------------------------------- */
+    if (strcmp(pszAccess, "rb+") == 0 || strcmp(pszAccess, "r+b") == 0 ||
+        strcmp(pszAccess, "r+") == 0)
+    {
         pszAccess = "r+b";
-    } else {
+    }
+    else
+    {
         pszAccess = "rb";
     }
 
@@ -671,95 +714,96 @@ SHPRestoreSHX ( const char * pszLayer, const char * pszAccess, SAHooks *psHooks 
 #if !defined(bBigEndian)
     {
         int i = 1;
-        if( *((uchar *) &i) == 1 )
+        if (*((uchar *)&i) == 1)
             bBigEndian = false;
         else
             bBigEndian = true;
     }
 #endif
 
-/* -------------------------------------------------------------------- */
-/*  Open the .shp file.  Note that files pulled from                    */
-/*  a PC to Unix with upper case filenames won't work!                  */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*  Open the .shp file.  Note that files pulled from                    */
+    /*  a PC to Unix with upper case filenames won't work!                  */
+    /* -------------------------------------------------------------------- */
     const int nLenWithoutExtension = SHPGetLenWithoutExtension(pszLayer);
     char *pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
     memcpy(pszFullname, pszLayer, nLenWithoutExtension);
     memcpy(pszFullname + nLenWithoutExtension, ".shp", 5);
-    SAFile fpSHP = psHooks->FOpen(pszFullname, pszAccess );
-    if( fpSHP == SHPLIB_NULLPTR )
+    SAFile fpSHP = psHooks->FOpen(pszFullname, pszAccess);
+    if (fpSHP == SHPLIB_NULLPTR)
     {
         memcpy(pszFullname + nLenWithoutExtension, ".SHP", 5);
-        fpSHP = psHooks->FOpen(pszFullname, pszAccess );
+        fpSHP = psHooks->FOpen(pszFullname, pszAccess);
     }
 
-    if( fpSHP == SHPLIB_NULLPTR )
+    if (fpSHP == SHPLIB_NULLPTR)
     {
-        const size_t nMessageLen = strlen( pszFullname ) * 2 + 256;
-        char* pszMessage = STATIC_CAST(char *, malloc( nMessageLen ));
+        const size_t nMessageLen = strlen(pszFullname) * 2 + 256;
+        char *pszMessage = STATIC_CAST(char *, malloc(nMessageLen));
 
         pszFullname[nLenWithoutExtension] = 0;
-        snprintf( pszMessage, nMessageLen, "Unable to open %s.shp or %s.SHP.",
-                  pszFullname, pszFullname );
-        psHooks->Error( pszMessage );
-        free( pszMessage );
+        snprintf(pszMessage, nMessageLen, "Unable to open %s.shp or %s.SHP.",
+                 pszFullname, pszFullname);
+        psHooks->Error(pszMessage);
+        free(pszMessage);
 
-        free( pszFullname );
+        free(pszFullname);
 
-        return( 0 );
+        return (0);
     }
 
-/* -------------------------------------------------------------------- */
-/*  Read the file size from the SHP file.                               */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*  Read the file size from the SHP file.                               */
+    /* -------------------------------------------------------------------- */
     uchar *pabyBuf = STATIC_CAST(uchar *, malloc(100));
-    if( psHooks->FRead( pabyBuf, 100, 1, fpSHP ) != 1 )
+    if (psHooks->FRead(pabyBuf, 100, 1, fpSHP) != 1)
     {
-        psHooks->Error( ".shp file is unreadable, or corrupt." );
-        psHooks->FClose( fpSHP );
+        psHooks->Error(".shp file is unreadable, or corrupt.");
+        psHooks->FClose(fpSHP);
 
-        free( pabyBuf );
-        free( pszFullname );
+        free(pabyBuf);
+        free(pszFullname);
 
-        return( 0 );
+        return (0);
     }
 
-    unsigned int nSHPFilesize = (STATIC_CAST(unsigned int, pabyBuf[24])<<24)|(pabyBuf[25]<<16)|
-                   (pabyBuf[26]<<8)|pabyBuf[27];
-    if( nSHPFilesize < UINT_MAX / 2 )
+    unsigned int nSHPFilesize = (STATIC_CAST(unsigned int, pabyBuf[24]) << 24) |
+                                (pabyBuf[25] << 16) | (pabyBuf[26] << 8) |
+                                pabyBuf[27];
+    if (nSHPFilesize < UINT_MAX / 2)
         nSHPFilesize *= 2;
     else
         nSHPFilesize = (UINT_MAX / 2) * 2;
 
     memcpy(pszFullname + nLenWithoutExtension, ".shx", 5);
     const char pszSHXAccess[] = "w+b";
-    SAFile fpSHX = psHooks->FOpen( pszFullname, pszSHXAccess );
-    if( fpSHX == SHPLIB_NULLPTR )
+    SAFile fpSHX = psHooks->FOpen(pszFullname, pszSHXAccess);
+    if (fpSHX == SHPLIB_NULLPTR)
     {
-        size_t nMessageLen = strlen( pszFullname ) * 2 + 256;
-        char* pszMessage = STATIC_CAST(char *, malloc( nMessageLen ));
+        size_t nMessageLen = strlen(pszFullname) * 2 + 256;
+        char *pszMessage = STATIC_CAST(char *, malloc(nMessageLen));
         pszFullname[nLenWithoutExtension] = 0;
-        snprintf( pszMessage, nMessageLen,
-                  "Error opening file %s.shx for writing", pszFullname );
-        psHooks->Error( pszMessage );
-        free( pszMessage );
+        snprintf(pszMessage, nMessageLen,
+                 "Error opening file %s.shx for writing", pszFullname);
+        psHooks->Error(pszMessage);
+        free(pszMessage);
 
-        psHooks->FClose( fpSHP );
+        psHooks->FClose(fpSHP);
 
-        free( pabyBuf );
-        free( pszFullname );
+        free(pabyBuf);
+        free(pszFullname);
 
-        return( 0 );
+        return (0);
     }
 
-/* -------------------------------------------------------------------- */
-/*  Open SHX and create it using SHP file content.                      */
-/* -------------------------------------------------------------------- */
-    psHooks->FSeek( fpSHP, 100, 0 );
-    char *pabySHXHeader = STATIC_CAST(char *, malloc ( 100 ));
-    memcpy( pabySHXHeader, pabyBuf, 100 );
-    psHooks->FWrite( pabySHXHeader, 100, 1, fpSHX );
-    free ( pabyBuf );
+    /* -------------------------------------------------------------------- */
+    /*  Open SHX and create it using SHP file content.                      */
+    /* -------------------------------------------------------------------- */
+    psHooks->FSeek(fpSHP, 100, 0);
+    char *pabySHXHeader = STATIC_CAST(char *, malloc(100));
+    memcpy(pabySHXHeader, pabyBuf, 100);
+    psHooks->FWrite(pabySHXHeader, 100, 1, fpSHX);
+    free(pabyBuf);
 
     // unsigned int nCurrentRecordOffset = 0;
     unsigned int nCurrentSHPOffset = 100;
@@ -769,52 +813,56 @@ SHPRestoreSHX ( const char * pszLayer, const char * pszAccess, SAHooks *psHooks 
     unsigned int nRecordOffset = 50;
     char abyReadedRecord[8];
 
-    while( nCurrentSHPOffset < nSHPFilesize )
+    while (nCurrentSHPOffset < nSHPFilesize)
     {
-        if( psHooks->FRead( &niRecord, 4, 1, fpSHP ) == 1 &&
-            psHooks->FRead( &nRecordLength, 4, 1, fpSHP ) == 1)
+        if (psHooks->FRead(&niRecord, 4, 1, fpSHP) == 1 &&
+            psHooks->FRead(&nRecordLength, 4, 1, fpSHP) == 1)
         {
-            if( !bBigEndian ) SwapWord( 4, &nRecordOffset );
-            memcpy( abyReadedRecord, &nRecordOffset, 4 );
-            memcpy( abyReadedRecord + 4, &nRecordLength, 4 );
+            if (!bBigEndian)
+                SwapWord(4, &nRecordOffset);
+            memcpy(abyReadedRecord, &nRecordOffset, 4);
+            memcpy(abyReadedRecord + 4, &nRecordLength, 4);
 
-            psHooks->FWrite( abyReadedRecord, 8, 1, fpSHX );
+            psHooks->FWrite(abyReadedRecord, 8, 1, fpSHX);
 
-            if ( !bBigEndian ) SwapWord( 4, &nRecordOffset );
-            if ( !bBigEndian ) SwapWord( 4, &nRecordLength );
+            if (!bBigEndian)
+                SwapWord(4, &nRecordOffset);
+            if (!bBigEndian)
+                SwapWord(4, &nRecordLength);
             nRecordOffset += nRecordLength + 4;
             // nCurrentRecordOffset += 8;
             nCurrentSHPOffset += 8 + nRecordLength * 2;
 
-            psHooks->FSeek( fpSHP, nCurrentSHPOffset, 0 );
+            psHooks->FSeek(fpSHP, nCurrentSHPOffset, 0);
             nRealSHXContentSize += 8;
         }
         else
         {
-            psHooks->Error( "Error parsing .shp to restore .shx"  );
+            psHooks->Error("Error parsing .shp to restore .shx");
 
-            psHooks->FClose( fpSHX );
-            psHooks->FClose( fpSHP );
+            psHooks->FClose(fpSHX);
+            psHooks->FClose(fpSHP);
 
-            free( pabySHXHeader );
-            free( pszFullname );
+            free(pabySHXHeader);
+            free(pszFullname);
 
-            return( 0 );
+            return (0);
         }
     }
 
-    nRealSHXContentSize /= 2; // Bytes counted -> WORDs
-    if( !bBigEndian ) SwapWord( 4, &nRealSHXContentSize );
-    psHooks->FSeek( fpSHX, 24, 0 );
-    psHooks->FWrite( &nRealSHXContentSize, 4, 1, fpSHX );
+    nRealSHXContentSize /= 2;  // Bytes counted -> WORDs
+    if (!bBigEndian)
+        SwapWord(4, &nRealSHXContentSize);
+    psHooks->FSeek(fpSHX, 24, 0);
+    psHooks->FWrite(&nRealSHXContentSize, 4, 1, fpSHX);
 
-    psHooks->FClose( fpSHP );
-    psHooks->FClose( fpSHX );
+    psHooks->FClose(fpSHP);
+    psHooks->FClose(fpSHX);
 
-    free ( pszFullname );
-    free ( pabySHXHeader );
+    free(pszFullname);
+    free(pabySHXHeader);
 
-    return( 1 );
+    return (1);
 }
 
 /************************************************************************/
@@ -823,42 +871,42 @@ SHPRestoreSHX ( const char * pszLayer, const char * pszAccess, SAHooks *psHooks 
 /*	Close the .shp and .shx files.					*/
 /************************************************************************/
 
-void SHPAPI_CALL
-SHPClose(SHPHandle psSHP ) {
-    if( psSHP == SHPLIB_NULLPTR )
+void SHPAPI_CALL SHPClose(SHPHandle psSHP)
+{
+    if (psSHP == SHPLIB_NULLPTR)
         return;
 
-/* -------------------------------------------------------------------- */
-/*	Update the header if we have modified anything.			*/
-/* -------------------------------------------------------------------- */
-    if( psSHP->bUpdated )
-	SHPWriteHeader( psSHP );
+    /* -------------------------------------------------------------------- */
+    /*	Update the header if we have modified anything.			*/
+    /* -------------------------------------------------------------------- */
+    if (psSHP->bUpdated)
+        SHPWriteHeader(psSHP);
 
-/* -------------------------------------------------------------------- */
-/*      Free all resources, and close files.                            */
-/* -------------------------------------------------------------------- */
-    free( psSHP->panRecOffset );
-    free( psSHP->panRecSize );
+    /* -------------------------------------------------------------------- */
+    /*      Free all resources, and close files.                            */
+    /* -------------------------------------------------------------------- */
+    free(psSHP->panRecOffset);
+    free(psSHP->panRecSize);
 
-    if ( psSHP->fpSHX != SHPLIB_NULLPTR)
-        psSHP->sHooks.FClose( psSHP->fpSHX );
-    psSHP->sHooks.FClose( psSHP->fpSHP );
+    if (psSHP->fpSHX != SHPLIB_NULLPTR)
+        psSHP->sHooks.FClose(psSHP->fpSHX);
+    psSHP->sHooks.FClose(psSHP->fpSHP);
 
-    if( psSHP->pabyRec != SHPLIB_NULLPTR )
+    if (psSHP->pabyRec != SHPLIB_NULLPTR)
     {
-        free( psSHP->pabyRec );
+        free(psSHP->pabyRec);
     }
 
-    if( psSHP->pabyObjectBuf != SHPLIB_NULLPTR )
+    if (psSHP->pabyObjectBuf != SHPLIB_NULLPTR)
     {
-        free( psSHP->pabyObjectBuf );
+        free(psSHP->pabyObjectBuf);
     }
-    if( psSHP->psCachedObject != SHPLIB_NULLPTR )
+    if (psSHP->psCachedObject != SHPLIB_NULLPTR)
     {
-        free( psSHP->psCachedObject );
+        free(psSHP->psCachedObject);
     }
 
-    free( psSHP );
+    free(psSHP);
 }
 
 /************************************************************************/
@@ -869,14 +917,15 @@ SHPClose(SHPHandle psSHP ) {
 /* So you cannot have 2 valid instances of SHPReadObject() simultaneously. */
 /* The SHPObject padfZ and padfM members may be NULL depending on the geometry */
 /* type. It is illegal to free at hand any of the pointer members of the SHPObject structure */
-void SHPAPI_CALL SHPSetFastModeReadObject( SHPHandle hSHP, int bFastMode )
+void SHPAPI_CALL SHPSetFastModeReadObject(SHPHandle hSHP, int bFastMode)
 {
-    if( bFastMode )
+    if (bFastMode)
     {
-        if( hSHP->psCachedObject == SHPLIB_NULLPTR )
+        if (hSHP->psCachedObject == SHPLIB_NULLPTR)
         {
-            hSHP->psCachedObject = STATIC_CAST(SHPObject*, calloc(1, sizeof(SHPObject)));
-            assert( hSHP->psCachedObject != SHPLIB_NULLPTR );
+            hSHP->psCachedObject =
+                STATIC_CAST(SHPObject *, calloc(1, sizeof(SHPObject)));
+            assert(hSHP->psCachedObject != SHPLIB_NULLPTR);
         }
     }
 
@@ -889,23 +938,23 @@ void SHPAPI_CALL SHPSetFastModeReadObject( SHPHandle hSHP, int bFastMode )
 /*      Fetch general information about the shape file.                 */
 /************************************************************************/
 
-void SHPAPI_CALL
-SHPGetInfo(SHPHandle psSHP, int * pnEntities, int * pnShapeType,
-           double * padfMinBound, double * padfMaxBound ) {
-    if( psSHP == SHPLIB_NULLPTR )
+void SHPAPI_CALL SHPGetInfo(SHPHandle psSHP, int *pnEntities, int *pnShapeType,
+                            double *padfMinBound, double *padfMaxBound)
+{
+    if (psSHP == SHPLIB_NULLPTR)
         return;
 
-    if( pnEntities != SHPLIB_NULLPTR )
+    if (pnEntities != SHPLIB_NULLPTR)
         *pnEntities = psSHP->nRecords;
 
-    if( pnShapeType != SHPLIB_NULLPTR )
+    if (pnShapeType != SHPLIB_NULLPTR)
         *pnShapeType = psSHP->nShapeType;
 
-    for( int i = 0; i < 4; i++ )
+    for (int i = 0; i < 4; i++)
     {
-        if( padfMinBound != SHPLIB_NULLPTR )
+        if (padfMinBound != SHPLIB_NULLPTR)
             padfMinBound[i] = psSHP->adBoundsMin[i];
-        if( padfMaxBound != SHPLIB_NULLPTR )
+        if (padfMaxBound != SHPLIB_NULLPTR)
             padfMaxBound[i] = psSHP->adBoundsMax[i];
     }
 }
@@ -917,13 +966,13 @@ SHPGetInfo(SHPHandle psSHP, int * pnEntities, int * pnShapeType,
 /*      shape file with read/write access.                              */
 /************************************************************************/
 
-SHPHandle SHPAPI_CALL
-SHPCreate( const char * pszLayer, int nShapeType ) {
+SHPHandle SHPAPI_CALL SHPCreate(const char *pszLayer, int nShapeType)
+{
     SAHooks sHooks;
 
-    SASetupDefaultHooks( &sHooks );
+    SASetupDefaultHooks(&sHooks);
 
-    return SHPCreateLL( pszLayer, nShapeType, &sHooks );
+    return SHPCreateLL(pszLayer, nShapeType, &sHooks);
 }
 
 /************************************************************************/
@@ -933,97 +982,99 @@ SHPCreate( const char * pszLayer, int nShapeType ) {
 /*      shape file with read/write access.                              */
 /************************************************************************/
 
-SHPHandle SHPAPI_CALL
-SHPCreateLL( const char * pszLayer, int nShapeType, SAHooks *psHooks ) {
+SHPHandle SHPAPI_CALL SHPCreateLL(const char *pszLayer, int nShapeType,
+                                  SAHooks *psHooks)
+{
 /* -------------------------------------------------------------------- */
 /*      Establish the byte order on this system.                        */
 /* -------------------------------------------------------------------- */
 #if !defined(bBigEndian)
     {
         int i = 1;
-        if( *((uchar *) &i) == 1 )
+        if (*((uchar *)&i) == 1)
             bBigEndian = false;
         else
             bBigEndian = true;
     }
 #endif
 
-/* -------------------------------------------------------------------- */
-/*      Open the two files so we can write their headers.               */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Open the two files so we can write their headers.               */
+    /* -------------------------------------------------------------------- */
     const int nLenWithoutExtension = SHPGetLenWithoutExtension(pszLayer);
     char *pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
     memcpy(pszFullname, pszLayer, nLenWithoutExtension);
     memcpy(pszFullname + nLenWithoutExtension, ".shp", 5);
-    SAFile fpSHP = psHooks->FOpen(pszFullname, "wb" );
-    if( fpSHP == SHPLIB_NULLPTR )
+    SAFile fpSHP = psHooks->FOpen(pszFullname, "wb");
+    if (fpSHP == SHPLIB_NULLPTR)
     {
         char szErrorMsg[200];
-        snprintf( szErrorMsg, sizeof(szErrorMsg),
-                 "Failed to create file %s: %s",
-                  pszFullname, strerror(errno) );
-        psHooks->Error( szErrorMsg );
+        snprintf(szErrorMsg, sizeof(szErrorMsg), "Failed to create file %s: %s",
+                 pszFullname, strerror(errno));
+        psHooks->Error(szErrorMsg);
 
         free(pszFullname);
         return NULL;
     }
 
     memcpy(pszFullname + nLenWithoutExtension, ".shx", 5);
-    SAFile fpSHX = psHooks->FOpen(pszFullname, "wb" );
-    if( fpSHX == SHPLIB_NULLPTR )
+    SAFile fpSHX = psHooks->FOpen(pszFullname, "wb");
+    if (fpSHX == SHPLIB_NULLPTR)
     {
         char szErrorMsg[200];
-        snprintf( szErrorMsg, sizeof(szErrorMsg),
-                 "Failed to create file %s: %s",
-                  pszFullname, strerror(errno) );
-        psHooks->Error( szErrorMsg );
+        snprintf(szErrorMsg, sizeof(szErrorMsg), "Failed to create file %s: %s",
+                 pszFullname, strerror(errno));
+        psHooks->Error(szErrorMsg);
 
         free(pszFullname);
         psHooks->FClose(fpSHP);
         return NULL;
     }
 
-    free( pszFullname );
+    free(pszFullname);
     pszFullname = SHPLIB_NULLPTR;
 
-/* -------------------------------------------------------------------- */
-/*      Prepare header block for .shp file.                             */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Prepare header block for .shp file.                             */
+    /* -------------------------------------------------------------------- */
     uchar abyHeader[100];
-    memset( abyHeader, 0, sizeof(abyHeader) );
+    memset(abyHeader, 0, sizeof(abyHeader));
 
-    abyHeader[2] = 0x27;				/* magic cookie */
+    abyHeader[2] = 0x27; /* magic cookie */
     abyHeader[3] = 0x0a;
 
-    int32 i32 = 50;						/* file size */
-    ByteCopy( &i32, abyHeader+24, 4 );
-    if( !bBigEndian ) SwapWord( 4, abyHeader+24 );
+    int32 i32 = 50; /* file size */
+    ByteCopy(&i32, abyHeader + 24, 4);
+    if (!bBigEndian)
+        SwapWord(4, abyHeader + 24);
 
-    i32 = 1000;						/* version */
-    ByteCopy( &i32, abyHeader+28, 4 );
-    if( bBigEndian ) SwapWord( 4, abyHeader+28 );
+    i32 = 1000; /* version */
+    ByteCopy(&i32, abyHeader + 28, 4);
+    if (bBigEndian)
+        SwapWord(4, abyHeader + 28);
 
-    i32 = nShapeType;					/* shape type */
-    ByteCopy( &i32, abyHeader+32, 4 );
-    if( bBigEndian ) SwapWord( 4, abyHeader+32 );
+    i32 = nShapeType; /* shape type */
+    ByteCopy(&i32, abyHeader + 32, 4);
+    if (bBigEndian)
+        SwapWord(4, abyHeader + 32);
 
-    double dValue = 0.0;				/* set bounds */
-    ByteCopy( &dValue, abyHeader+36, 8 );
-    ByteCopy( &dValue, abyHeader+44, 8 );
-    ByteCopy( &dValue, abyHeader+52, 8 );
-    ByteCopy( &dValue, abyHeader+60, 8 );
+    double dValue = 0.0; /* set bounds */
+    ByteCopy(&dValue, abyHeader + 36, 8);
+    ByteCopy(&dValue, abyHeader + 44, 8);
+    ByteCopy(&dValue, abyHeader + 52, 8);
+    ByteCopy(&dValue, abyHeader + 60, 8);
 
-/* -------------------------------------------------------------------- */
-/*      Write .shp file header.                                         */
-/* -------------------------------------------------------------------- */
-    if( psHooks->FWrite( abyHeader, 100, 1, fpSHP ) != 1 )
+    /* -------------------------------------------------------------------- */
+    /*      Write .shp file header.                                         */
+    /* -------------------------------------------------------------------- */
+    if (psHooks->FWrite(abyHeader, 100, 1, fpSHP) != 1)
     {
         char szErrorMsg[200];
 
-        snprintf( szErrorMsg, sizeof(szErrorMsg),
-                 "Failed to write .shp header: %s", strerror(errno) );
-        szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-        psHooks->Error( szErrorMsg );
+        snprintf(szErrorMsg, sizeof(szErrorMsg),
+                 "Failed to write .shp header: %s", strerror(errno));
+        szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+        psHooks->Error(szErrorMsg);
 
         free(pszFullname);
         psHooks->FClose(fpSHP);
@@ -1031,21 +1082,22 @@ SHPCreateLL( const char * pszLayer, int nShapeType, SAHooks *psHooks ) {
         return NULL;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Prepare, and write .shx file header.                            */
-/* -------------------------------------------------------------------- */
-    i32 = 50;						/* file size */
-    ByteCopy( &i32, abyHeader+24, 4 );
-    if( !bBigEndian ) SwapWord( 4, abyHeader+24 );
+    /* -------------------------------------------------------------------- */
+    /*      Prepare, and write .shx file header.                            */
+    /* -------------------------------------------------------------------- */
+    i32 = 50; /* file size */
+    ByteCopy(&i32, abyHeader + 24, 4);
+    if (!bBigEndian)
+        SwapWord(4, abyHeader + 24);
 
-    if( psHooks->FWrite( abyHeader, 100, 1, fpSHX ) != 1 )
+    if (psHooks->FWrite(abyHeader, 100, 1, fpSHX) != 1)
     {
         char szErrorMsg[200];
 
-        snprintf( szErrorMsg, sizeof(szErrorMsg),
-                 "Failure writing .shx header: %s", strerror(errno) );
-        szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-        psHooks->Error( szErrorMsg );
+        snprintf(szErrorMsg, sizeof(szErrorMsg),
+                 "Failure writing .shx header: %s", strerror(errno));
+        szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+        psHooks->Error(szErrorMsg);
 
         free(pszFullname);
         psHooks->FClose(fpSHP);
@@ -1053,13 +1105,13 @@ SHPCreateLL( const char * pszLayer, int nShapeType, SAHooks *psHooks ) {
         return NULL;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Close the files, and then open them as regular existing files.  */
-/* -------------------------------------------------------------------- */
-    psHooks->FClose( fpSHP );
-    psHooks->FClose( fpSHX );
+    /* -------------------------------------------------------------------- */
+    /*      Close the files, and then open them as regular existing files.  */
+    /* -------------------------------------------------------------------- */
+    psHooks->FClose(fpSHP);
+    psHooks->FClose(fpSHX);
 
-    return( SHPOpenLL( pszLayer, "r+b", psHooks ) );
+    return (SHPOpenLL(pszLayer, "r+b", psHooks));
 }
 
 /************************************************************************/
@@ -1069,18 +1121,19 @@ SHPCreateLL( const char * pszLayer, int nShapeType, SAHooks *psHooks ) {
 /*      indicated location in the record.                               */
 /************************************************************************/
 
-static void _SHPSetBounds( uchar * pabyRec, SHPObject * psShape ) {
-    ByteCopy( &(psShape->dfXMin), pabyRec +  0, 8 );
-    ByteCopy( &(psShape->dfYMin), pabyRec +  8, 8 );
-    ByteCopy( &(psShape->dfXMax), pabyRec + 16, 8 );
-    ByteCopy( &(psShape->dfYMax), pabyRec + 24, 8 );
+static void _SHPSetBounds(uchar *pabyRec, SHPObject *psShape)
+{
+    ByteCopy(&(psShape->dfXMin), pabyRec + 0, 8);
+    ByteCopy(&(psShape->dfYMin), pabyRec + 8, 8);
+    ByteCopy(&(psShape->dfXMax), pabyRec + 16, 8);
+    ByteCopy(&(psShape->dfYMax), pabyRec + 24, 8);
 
-    if( bBigEndian )
+    if (bBigEndian)
     {
-        SwapWord( 8, pabyRec + 0 );
-        SwapWord( 8, pabyRec + 8 );
-        SwapWord( 8, pabyRec + 16 );
-        SwapWord( 8, pabyRec + 24 );
+        SwapWord(8, pabyRec + 0);
+        SwapWord(8, pabyRec + 8);
+        SwapWord(8, pabyRec + 16);
+        SwapWord(8, pabyRec + 24);
     }
 }
 
@@ -1091,12 +1144,12 @@ static void _SHPSetBounds( uchar * pabyRec, SHPObject * psShape ) {
 /*      SHPCreateObject().                                              */
 /************************************************************************/
 
-void SHPAPI_CALL
-SHPComputeExtents( SHPObject * psObject ) {
-/* -------------------------------------------------------------------- */
-/*      Build extents for this object.                                  */
-/* -------------------------------------------------------------------- */
-    if( psObject->nVertices > 0 )
+void SHPAPI_CALL SHPComputeExtents(SHPObject *psObject)
+{
+    /* -------------------------------------------------------------------- */
+    /*      Build extents for this object.                                  */
+    /* -------------------------------------------------------------------- */
+    if (psObject->nVertices > 0)
     {
         psObject->dfXMin = psObject->dfXMax = psObject->padfX[0];
         psObject->dfYMin = psObject->dfYMax = psObject->padfY[0];
@@ -1104,7 +1157,7 @@ SHPComputeExtents( SHPObject * psObject ) {
         psObject->dfMMin = psObject->dfMMax = psObject->padfM[0];
     }
 
-    for( int i = 0; i < psObject->nVertices; i++ )
+    for (int i = 0; i < psObject->nVertices; i++)
     {
         psObject->dfXMin = MIN(psObject->dfXMin, psObject->padfX[i]);
         psObject->dfYMin = MIN(psObject->dfYMin, psObject->padfY[i]);
@@ -1126,34 +1179,32 @@ SHPComputeExtents( SHPObject * psObject ) {
 /************************************************************************/
 
 SHPObject SHPAPI_CALL1(*)
-SHPCreateObject( int nSHPType, int nShapeId, int nParts,
-                 const int * panPartStart, const int * panPartType,
-                 int nVertices, const double *padfX, const double *padfY,
-                 const double * padfZ, const double * padfM ) {
-    SHPObject *psObject = STATIC_CAST(SHPObject *, calloc(1,sizeof(SHPObject)));
+    SHPCreateObject(int nSHPType, int nShapeId, int nParts,
+                    const int *panPartStart, const int *panPartType,
+                    int nVertices, const double *padfX, const double *padfY,
+                    const double *padfZ, const double *padfM)
+{
+    SHPObject *psObject =
+        STATIC_CAST(SHPObject *, calloc(1, sizeof(SHPObject)));
     psObject->nSHPType = nSHPType;
     psObject->nShapeId = nShapeId;
     psObject->bMeasureIsUsed = FALSE;
 
-/* -------------------------------------------------------------------- */
-/*	Establish whether this shape type has M, and Z values.		*/
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*	Establish whether this shape type has M, and Z values.		*/
+    /* -------------------------------------------------------------------- */
     bool bHasM;
     bool bHasZ;
 
-    if( nSHPType == SHPT_ARCM
-        || nSHPType == SHPT_POINTM
-        || nSHPType == SHPT_POLYGONM
-        || nSHPType == SHPT_MULTIPOINTM )
+    if (nSHPType == SHPT_ARCM || nSHPType == SHPT_POINTM ||
+        nSHPType == SHPT_POLYGONM || nSHPType == SHPT_MULTIPOINTM)
     {
         bHasM = true;
         bHasZ = false;
     }
-    else if( nSHPType == SHPT_ARCZ
-             || nSHPType == SHPT_POINTZ
-             || nSHPType == SHPT_POLYGONZ
-             || nSHPType == SHPT_MULTIPOINTZ
-             || nSHPType == SHPT_MULTIPATCH )
+    else if (nSHPType == SHPT_ARCZ || nSHPType == SHPT_POINTZ ||
+             nSHPType == SHPT_POLYGONZ || nSHPType == SHPT_MULTIPOINTZ ||
+             nSHPType == SHPT_MULTIPATCH)
     {
         bHasM = true;
         bHasZ = true;
@@ -1164,74 +1215,78 @@ SHPCreateObject( int nSHPType, int nShapeId, int nParts,
         bHasZ = false;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Capture parts.  Note that part type is optional, and            */
-/*      defaults to ring.                                               */
-/* -------------------------------------------------------------------- */
-    if( nSHPType == SHPT_ARC || nSHPType == SHPT_POLYGON
-        || nSHPType == SHPT_ARCM || nSHPType == SHPT_POLYGONM
-        || nSHPType == SHPT_ARCZ || nSHPType == SHPT_POLYGONZ
-        || nSHPType == SHPT_MULTIPATCH )
+    /* -------------------------------------------------------------------- */
+    /*      Capture parts.  Note that part type is optional, and            */
+    /*      defaults to ring.                                               */
+    /* -------------------------------------------------------------------- */
+    if (nSHPType == SHPT_ARC || nSHPType == SHPT_POLYGON ||
+        nSHPType == SHPT_ARCM || nSHPType == SHPT_POLYGONM ||
+        nSHPType == SHPT_ARCZ || nSHPType == SHPT_POLYGONZ ||
+        nSHPType == SHPT_MULTIPATCH)
     {
-        psObject->nParts = MAX(1,nParts);
+        psObject->nParts = MAX(1, nParts);
 
-        psObject->panPartStart = STATIC_CAST(int *,
-            calloc(sizeof(int), psObject->nParts));
-        psObject->panPartType = STATIC_CAST(int *,
-            malloc(sizeof(int) * psObject->nParts));
+        psObject->panPartStart =
+            STATIC_CAST(int *, calloc(sizeof(int), psObject->nParts));
+        psObject->panPartType =
+            STATIC_CAST(int *, malloc(sizeof(int) * psObject->nParts));
 
         psObject->panPartStart[0] = 0;
         psObject->panPartType[0] = SHPP_RING;
 
-        for( int i = 0; i < nParts; i++ )
+        for (int i = 0; i < nParts; i++)
         {
-            if( panPartStart != SHPLIB_NULLPTR )
+            if (panPartStart != SHPLIB_NULLPTR)
                 psObject->panPartStart[i] = panPartStart[i];
 
-            if( panPartType != SHPLIB_NULLPTR )
+            if (panPartType != SHPLIB_NULLPTR)
                 psObject->panPartType[i] = panPartType[i];
             else
                 psObject->panPartType[i] = SHPP_RING;
         }
 
-        if( psObject->panPartStart[0] != 0 )
+        if (psObject->panPartStart[0] != 0)
             psObject->panPartStart[0] = 0;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Capture vertices.  Note that X, Y, Z and M are optional.        */
-/* -------------------------------------------------------------------- */
-    if( nVertices > 0 )
+    /* -------------------------------------------------------------------- */
+    /*      Capture vertices.  Note that X, Y, Z and M are optional.        */
+    /* -------------------------------------------------------------------- */
+    if (nVertices > 0)
     {
         const size_t nSize = sizeof(double) * nVertices;
-        psObject->padfX = STATIC_CAST(double *, padfX ? malloc(nSize) :
-                                             calloc(sizeof(double),nVertices));
-        psObject->padfY = STATIC_CAST(double *, padfY ? malloc(nSize) :
-                                             calloc(sizeof(double),nVertices));
-        psObject->padfZ = STATIC_CAST(double *, padfZ && bHasZ ? malloc(nSize) :
-                                             calloc(sizeof(double),nVertices));
-        psObject->padfM = STATIC_CAST(double *, padfM && bHasM ? malloc(nSize) :
-                                             calloc(sizeof(double),nVertices));
-        if( padfX != SHPLIB_NULLPTR )
+        psObject->padfX =
+            STATIC_CAST(double *, padfX ? malloc(nSize)
+                                        : calloc(sizeof(double), nVertices));
+        psObject->padfY =
+            STATIC_CAST(double *, padfY ? malloc(nSize)
+                                        : calloc(sizeof(double), nVertices));
+        psObject->padfZ = STATIC_CAST(
+            double *,
+            padfZ &&bHasZ ? malloc(nSize) : calloc(sizeof(double), nVertices));
+        psObject->padfM = STATIC_CAST(
+            double *,
+            padfM &&bHasM ? malloc(nSize) : calloc(sizeof(double), nVertices));
+        if (padfX != SHPLIB_NULLPTR)
             memcpy(psObject->padfX, padfX, nSize);
-        if( padfY != SHPLIB_NULLPTR )
+        if (padfY != SHPLIB_NULLPTR)
             memcpy(psObject->padfY, padfY, nSize);
-        if( padfZ != SHPLIB_NULLPTR && bHasZ )
+        if (padfZ != SHPLIB_NULLPTR && bHasZ)
             memcpy(psObject->padfZ, padfZ, nSize);
-        if( padfM != SHPLIB_NULLPTR && bHasM )
+        if (padfM != SHPLIB_NULLPTR && bHasM)
         {
             memcpy(psObject->padfM, padfM, nSize);
             psObject->bMeasureIsUsed = TRUE;
         }
     }
 
-/* -------------------------------------------------------------------- */
-/*      Compute the extents.                                            */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Compute the extents.                                            */
+    /* -------------------------------------------------------------------- */
     psObject->nVertices = nVertices;
-    SHPComputeExtents( psObject );
+    SHPComputeExtents(psObject);
 
-    return( psObject );
+    return (psObject);
 }
 
 /************************************************************************/
@@ -1242,11 +1297,11 @@ SHPCreateObject( int nSHPType, int nShapeId, int nParts,
 /************************************************************************/
 
 SHPObject SHPAPI_CALL1(*)
-SHPCreateSimpleObject( int nSHPType, int nVertices,
-                       const double * padfX, const double * padfY,
-                       const double * padfZ ) {
-    return( SHPCreateObject( nSHPType, -1, 0, SHPLIB_NULLPTR, SHPLIB_NULLPTR,
-                             nVertices, padfX, padfY, padfZ, SHPLIB_NULLPTR ) );
+    SHPCreateSimpleObject(int nSHPType, int nVertices, const double *padfX,
+                          const double *padfY, const double *padfZ)
+{
+    return (SHPCreateObject(nSHPType, -1, 0, SHPLIB_NULLPTR, SHPLIB_NULLPTR,
+                            nVertices, padfX, padfY, padfZ, SHPLIB_NULLPTR));
 }
 
 /************************************************************************/
@@ -1256,108 +1311,113 @@ SHPCreateSimpleObject( int nSHPType, int nVertices,
 /*      only possible to write vertices at the end of the file.         */
 /************************************************************************/
 
-int SHPAPI_CALL
-SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject ) {
+int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
+                               SHPObject *psObject)
+{
     psSHP->bUpdated = TRUE;
 
-/* -------------------------------------------------------------------- */
-/*      Ensure that shape object matches the type of the file it is     */
-/*      being written to.                                               */
-/* -------------------------------------------------------------------- */
-    assert( psObject->nSHPType == psSHP->nShapeType
-            || psObject->nSHPType == SHPT_NULL );
+    /* -------------------------------------------------------------------- */
+    /*      Ensure that shape object matches the type of the file it is     */
+    /*      being written to.                                               */
+    /* -------------------------------------------------------------------- */
+    assert(psObject->nSHPType == psSHP->nShapeType ||
+           psObject->nSHPType == SHPT_NULL);
 
-/* -------------------------------------------------------------------- */
-/*      Ensure that -1 is used for appends.  Either blow an             */
-/*      assertion, or if they are disabled, set the shapeid to -1       */
-/*      for appends.                                                    */
-/* -------------------------------------------------------------------- */
-    assert( nShapeId == -1
-            || (nShapeId >= 0 && nShapeId < psSHP->nRecords) );
+    /* -------------------------------------------------------------------- */
+    /*      Ensure that -1 is used for appends.  Either blow an             */
+    /*      assertion, or if they are disabled, set the shapeid to -1       */
+    /*      for appends.                                                    */
+    /* -------------------------------------------------------------------- */
+    assert(nShapeId == -1 || (nShapeId >= 0 && nShapeId < psSHP->nRecords));
 
-    if( nShapeId != -1 && nShapeId >= psSHP->nRecords )
+    if (nShapeId != -1 && nShapeId >= psSHP->nRecords)
         nShapeId = -1;
 
-/* -------------------------------------------------------------------- */
-/*      Add the new entity to the in memory index.                      */
-/* -------------------------------------------------------------------- */
-    if( nShapeId == -1 && psSHP->nRecords+1 > psSHP->nMaxRecords )
+    /* -------------------------------------------------------------------- */
+    /*      Add the new entity to the in memory index.                      */
+    /* -------------------------------------------------------------------- */
+    if (nShapeId == -1 && psSHP->nRecords + 1 > psSHP->nMaxRecords)
     {
         int nNewMaxRecords = psSHP->nMaxRecords + psSHP->nMaxRecords / 3 + 100;
-        unsigned int* panRecOffsetNew;
-        unsigned int* panRecSizeNew;
+        unsigned int *panRecOffsetNew;
+        unsigned int *panRecSizeNew;
 
-        panRecOffsetNew = STATIC_CAST(unsigned int *,
-            realloc(psSHP->panRecOffset, sizeof(unsigned int) * nNewMaxRecords));
-        if( panRecOffsetNew == SHPLIB_NULLPTR )
+        panRecOffsetNew = STATIC_CAST(
+            unsigned int *, realloc(psSHP->panRecOffset,
+                                    sizeof(unsigned int) * nNewMaxRecords));
+        if (panRecOffsetNew == SHPLIB_NULLPTR)
             return -1;
         psSHP->panRecOffset = panRecOffsetNew;
 
-        panRecSizeNew = STATIC_CAST(unsigned int *,
+        panRecSizeNew = STATIC_CAST(
+            unsigned int *,
             realloc(psSHP->panRecSize, sizeof(unsigned int) * nNewMaxRecords));
-        if( panRecSizeNew == SHPLIB_NULLPTR )
+        if (panRecSizeNew == SHPLIB_NULLPTR)
             return -1;
         psSHP->panRecSize = panRecSizeNew;
 
         psSHP->nMaxRecords = nNewMaxRecords;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Initialize record.                                              */
-/* -------------------------------------------------------------------- */
-    uchar *pabyRec = STATIC_CAST(uchar *, malloc(psObject->nVertices * 4 * sizeof(double)
-                               + psObject->nParts * 8 + 128));
-    if( pabyRec == SHPLIB_NULLPTR )
+    /* -------------------------------------------------------------------- */
+    /*      Initialize record.                                              */
+    /* -------------------------------------------------------------------- */
+    uchar *pabyRec =
+        STATIC_CAST(uchar *, malloc(psObject->nVertices * 4 * sizeof(double) +
+                                    psObject->nParts * 8 + 128));
+    if (pabyRec == SHPLIB_NULLPTR)
         return -1;
 
-/* -------------------------------------------------------------------- */
-/*  Extract vertices for a Polygon or Arc.				*/
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*  Extract vertices for a Polygon or Arc.				*/
+    /* -------------------------------------------------------------------- */
     unsigned int nRecordSize = 0;
     const bool bFirstFeature = psSHP->nRecords == 0;
 
-    if( psObject->nSHPType == SHPT_POLYGON
-        || psObject->nSHPType == SHPT_POLYGONZ
-        || psObject->nSHPType == SHPT_POLYGONM
-        || psObject->nSHPType == SHPT_ARC
-        || psObject->nSHPType == SHPT_ARCZ
-        || psObject->nSHPType == SHPT_ARCM
-        || psObject->nSHPType == SHPT_MULTIPATCH )
+    if (psObject->nSHPType == SHPT_POLYGON ||
+        psObject->nSHPType == SHPT_POLYGONZ ||
+        psObject->nSHPType == SHPT_POLYGONM || psObject->nSHPType == SHPT_ARC ||
+        psObject->nSHPType == SHPT_ARCZ || psObject->nSHPType == SHPT_ARCM ||
+        psObject->nSHPType == SHPT_MULTIPATCH)
     {
         int32 nPoints = psObject->nVertices;
         int32 nParts = psObject->nParts;
 
-        _SHPSetBounds( pabyRec + 12, psObject );
+        _SHPSetBounds(pabyRec + 12, psObject);
 
-        if( bBigEndian ) SwapWord( 4, &nPoints );
-        if( bBigEndian ) SwapWord( 4, &nParts );
+        if (bBigEndian)
+            SwapWord(4, &nPoints);
+        if (bBigEndian)
+            SwapWord(4, &nParts);
 
-        ByteCopy( &nPoints, pabyRec + 40 + 8, 4 );
-        ByteCopy( &nParts, pabyRec + 36 + 8, 4 );
+        ByteCopy(&nPoints, pabyRec + 40 + 8, 4);
+        ByteCopy(&nParts, pabyRec + 36 + 8, 4);
 
         nRecordSize = 52;
 
         /*
          * Write part start positions.
          */
-        ByteCopy( psObject->panPartStart, pabyRec + 44 + 8,
-                  4 * psObject->nParts );
-        for( int i = 0; i < psObject->nParts; i++ )
+        ByteCopy(psObject->panPartStart, pabyRec + 44 + 8,
+                 4 * psObject->nParts);
+        for (int i = 0; i < psObject->nParts; i++)
         {
-            if( bBigEndian ) SwapWord( 4, pabyRec + 44 + 8 + 4*i );
+            if (bBigEndian)
+                SwapWord(4, pabyRec + 44 + 8 + 4 * i);
             nRecordSize += 4;
         }
 
         /*
          * Write multipatch part types if needed.
          */
-        if( psObject->nSHPType == SHPT_MULTIPATCH )
+        if (psObject->nSHPType == SHPT_MULTIPATCH)
         {
-            memcpy( pabyRec + nRecordSize, psObject->panPartType,
-                    4*psObject->nParts );
-            for( int i = 0; i < psObject->nParts; i++ )
+            memcpy(pabyRec + nRecordSize, psObject->panPartType,
+                   4 * psObject->nParts);
+            for (int i = 0; i < psObject->nParts; i++)
             {
-                if( bBigEndian ) SwapWord( 4, pabyRec + nRecordSize );
+                if (bBigEndian)
+                    SwapWord(4, pabyRec + nRecordSize);
                 nRecordSize += 4;
             }
         }
@@ -1365,16 +1425,16 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject ) {
         /*
          * Write the (x,y) vertex values.
          */
-        for( int i = 0; i < psObject->nVertices; i++ )
+        for (int i = 0; i < psObject->nVertices; i++)
         {
-            ByteCopy( psObject->padfX + i, pabyRec + nRecordSize, 8 );
-            ByteCopy( psObject->padfY + i, pabyRec + nRecordSize + 8, 8 );
+            ByteCopy(psObject->padfX + i, pabyRec + nRecordSize, 8);
+            ByteCopy(psObject->padfY + i, pabyRec + nRecordSize + 8, 8);
 
-            if( bBigEndian )
-                SwapWord( 8, pabyRec + nRecordSize );
+            if (bBigEndian)
+                SwapWord(8, pabyRec + nRecordSize);
 
-            if( bBigEndian )
-                SwapWord( 8, pabyRec + nRecordSize + 8 );
+            if (bBigEndian)
+                SwapWord(8, pabyRec + nRecordSize + 8);
 
             nRecordSize += 2 * 8;
         }
@@ -1382,22 +1442,25 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject ) {
         /*
          * Write the Z coordinates (if any).
          */
-        if( psObject->nSHPType == SHPT_POLYGONZ
-            || psObject->nSHPType == SHPT_ARCZ
-            || psObject->nSHPType == SHPT_MULTIPATCH )
+        if (psObject->nSHPType == SHPT_POLYGONZ ||
+            psObject->nSHPType == SHPT_ARCZ ||
+            psObject->nSHPType == SHPT_MULTIPATCH)
         {
-            ByteCopy( &(psObject->dfZMin), pabyRec + nRecordSize, 8 );
-            if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
+            ByteCopy(&(psObject->dfZMin), pabyRec + nRecordSize, 8);
+            if (bBigEndian)
+                SwapWord(8, pabyRec + nRecordSize);
             nRecordSize += 8;
 
-            ByteCopy( &(psObject->dfZMax), pabyRec + nRecordSize, 8 );
-            if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
+            ByteCopy(&(psObject->dfZMax), pabyRec + nRecordSize, 8);
+            if (bBigEndian)
+                SwapWord(8, pabyRec + nRecordSize);
             nRecordSize += 8;
 
-            for( int i = 0; i < psObject->nVertices; i++ )
+            for (int i = 0; i < psObject->nVertices; i++)
             {
-                ByteCopy( psObject->padfZ + i, pabyRec + nRecordSize, 8 );
-                if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
+                ByteCopy(psObject->padfZ + i, pabyRec + nRecordSize, 8);
+                if (bBigEndian)
+                    SwapWord(8, pabyRec + nRecordSize);
                 nRecordSize += 8;
             }
         }
@@ -1405,166 +1468,185 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject ) {
         /*
          * Write the M values, if any.
          */
-        if( psObject->bMeasureIsUsed
-            && (psObject->nSHPType == SHPT_POLYGONM
-                || psObject->nSHPType == SHPT_ARCM
+        if (psObject->bMeasureIsUsed &&
+            (psObject->nSHPType == SHPT_POLYGONM ||
+             psObject->nSHPType == SHPT_ARCM
 #ifndef DISABLE_MULTIPATCH_MEASURE
-                || psObject->nSHPType == SHPT_MULTIPATCH
+             || psObject->nSHPType == SHPT_MULTIPATCH
 #endif
-                || psObject->nSHPType == SHPT_POLYGONZ
-                || psObject->nSHPType == SHPT_ARCZ) )
+             || psObject->nSHPType == SHPT_POLYGONZ ||
+             psObject->nSHPType == SHPT_ARCZ))
         {
-            ByteCopy( &(psObject->dfMMin), pabyRec + nRecordSize, 8 );
-            if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
+            ByteCopy(&(psObject->dfMMin), pabyRec + nRecordSize, 8);
+            if (bBigEndian)
+                SwapWord(8, pabyRec + nRecordSize);
             nRecordSize += 8;
 
-            ByteCopy( &(psObject->dfMMax), pabyRec + nRecordSize, 8 );
-            if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
+            ByteCopy(&(psObject->dfMMax), pabyRec + nRecordSize, 8);
+            if (bBigEndian)
+                SwapWord(8, pabyRec + nRecordSize);
             nRecordSize += 8;
 
-            for( int i = 0; i < psObject->nVertices; i++ )
+            for (int i = 0; i < psObject->nVertices; i++)
             {
-                ByteCopy( psObject->padfM + i, pabyRec + nRecordSize, 8 );
-                if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
+                ByteCopy(psObject->padfM + i, pabyRec + nRecordSize, 8);
+                if (bBigEndian)
+                    SwapWord(8, pabyRec + nRecordSize);
                 nRecordSize += 8;
             }
         }
     }
 
-/* -------------------------------------------------------------------- */
-/*  Extract vertices for a MultiPoint.					*/
-/* -------------------------------------------------------------------- */
-    else if( psObject->nSHPType == SHPT_MULTIPOINT
-             || psObject->nSHPType == SHPT_MULTIPOINTZ
-             || psObject->nSHPType == SHPT_MULTIPOINTM )
+    /* -------------------------------------------------------------------- */
+    /*  Extract vertices for a MultiPoint.					*/
+    /* -------------------------------------------------------------------- */
+    else if (psObject->nSHPType == SHPT_MULTIPOINT ||
+             psObject->nSHPType == SHPT_MULTIPOINTZ ||
+             psObject->nSHPType == SHPT_MULTIPOINTM)
     {
         int32 nPoints = psObject->nVertices;
 
-        _SHPSetBounds( pabyRec + 12, psObject );
+        _SHPSetBounds(pabyRec + 12, psObject);
 
-        if( bBigEndian ) SwapWord( 4, &nPoints );
-        ByteCopy( &nPoints, pabyRec + 44, 4 );
+        if (bBigEndian)
+            SwapWord(4, &nPoints);
+        ByteCopy(&nPoints, pabyRec + 44, 4);
 
-        for( int i = 0; i < psObject->nVertices; i++ )
+        for (int i = 0; i < psObject->nVertices; i++)
         {
-            ByteCopy( psObject->padfX + i, pabyRec + 48 + i*16, 8 );
-            ByteCopy( psObject->padfY + i, pabyRec + 48 + i*16 + 8, 8 );
+            ByteCopy(psObject->padfX + i, pabyRec + 48 + i * 16, 8);
+            ByteCopy(psObject->padfY + i, pabyRec + 48 + i * 16 + 8, 8);
 
-            if( bBigEndian ) SwapWord( 8, pabyRec + 48 + i*16 );
-            if( bBigEndian ) SwapWord( 8, pabyRec + 48 + i*16 + 8 );
+            if (bBigEndian)
+                SwapWord(8, pabyRec + 48 + i * 16);
+            if (bBigEndian)
+                SwapWord(8, pabyRec + 48 + i * 16 + 8);
         }
 
         nRecordSize = 48 + 16 * psObject->nVertices;
 
-        if( psObject->nSHPType == SHPT_MULTIPOINTZ )
+        if (psObject->nSHPType == SHPT_MULTIPOINTZ)
         {
-            ByteCopy( &(psObject->dfZMin), pabyRec + nRecordSize, 8 );
-            if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
+            ByteCopy(&(psObject->dfZMin), pabyRec + nRecordSize, 8);
+            if (bBigEndian)
+                SwapWord(8, pabyRec + nRecordSize);
             nRecordSize += 8;
 
-            ByteCopy( &(psObject->dfZMax), pabyRec + nRecordSize, 8 );
-            if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
+            ByteCopy(&(psObject->dfZMax), pabyRec + nRecordSize, 8);
+            if (bBigEndian)
+                SwapWord(8, pabyRec + nRecordSize);
             nRecordSize += 8;
 
-            for( int i = 0; i < psObject->nVertices; i++ )
+            for (int i = 0; i < psObject->nVertices; i++)
             {
-                ByteCopy( psObject->padfZ + i, pabyRec + nRecordSize, 8 );
-                if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
+                ByteCopy(psObject->padfZ + i, pabyRec + nRecordSize, 8);
+                if (bBigEndian)
+                    SwapWord(8, pabyRec + nRecordSize);
                 nRecordSize += 8;
             }
         }
 
-        if( psObject->bMeasureIsUsed
-            && (psObject->nSHPType == SHPT_MULTIPOINTZ
-                || psObject->nSHPType == SHPT_MULTIPOINTM) )
+        if (psObject->bMeasureIsUsed &&
+            (psObject->nSHPType == SHPT_MULTIPOINTZ ||
+             psObject->nSHPType == SHPT_MULTIPOINTM))
         {
-            ByteCopy( &(psObject->dfMMin), pabyRec + nRecordSize, 8 );
-            if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
+            ByteCopy(&(psObject->dfMMin), pabyRec + nRecordSize, 8);
+            if (bBigEndian)
+                SwapWord(8, pabyRec + nRecordSize);
             nRecordSize += 8;
 
-            ByteCopy( &(psObject->dfMMax), pabyRec + nRecordSize, 8 );
-            if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
+            ByteCopy(&(psObject->dfMMax), pabyRec + nRecordSize, 8);
+            if (bBigEndian)
+                SwapWord(8, pabyRec + nRecordSize);
             nRecordSize += 8;
 
-            for( int i = 0; i < psObject->nVertices; i++ )
+            for (int i = 0; i < psObject->nVertices; i++)
             {
-                ByteCopy( psObject->padfM + i, pabyRec + nRecordSize, 8 );
-                if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
+                ByteCopy(psObject->padfM + i, pabyRec + nRecordSize, 8);
+                if (bBigEndian)
+                    SwapWord(8, pabyRec + nRecordSize);
                 nRecordSize += 8;
             }
         }
     }
 
-/* -------------------------------------------------------------------- */
-/*      Write point.							*/
-/* -------------------------------------------------------------------- */
-    else if( psObject->nSHPType == SHPT_POINT
-             || psObject->nSHPType == SHPT_POINTZ
-             || psObject->nSHPType == SHPT_POINTM )
+    /* -------------------------------------------------------------------- */
+    /*      Write point.							*/
+    /* -------------------------------------------------------------------- */
+    else if (psObject->nSHPType == SHPT_POINT ||
+             psObject->nSHPType == SHPT_POINTZ ||
+             psObject->nSHPType == SHPT_POINTM)
     {
-        ByteCopy( psObject->padfX, pabyRec + 12, 8 );
-        ByteCopy( psObject->padfY, pabyRec + 20, 8 );
+        ByteCopy(psObject->padfX, pabyRec + 12, 8);
+        ByteCopy(psObject->padfY, pabyRec + 20, 8);
 
-        if( bBigEndian ) SwapWord( 8, pabyRec + 12 );
-        if( bBigEndian ) SwapWord( 8, pabyRec + 20 );
+        if (bBigEndian)
+            SwapWord(8, pabyRec + 12);
+        if (bBigEndian)
+            SwapWord(8, pabyRec + 20);
 
         nRecordSize = 28;
 
-        if( psObject->nSHPType == SHPT_POINTZ )
+        if (psObject->nSHPType == SHPT_POINTZ)
         {
-            ByteCopy( psObject->padfZ, pabyRec + nRecordSize, 8 );
-            if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
+            ByteCopy(psObject->padfZ, pabyRec + nRecordSize, 8);
+            if (bBigEndian)
+                SwapWord(8, pabyRec + nRecordSize);
             nRecordSize += 8;
         }
 
-        if( psObject->bMeasureIsUsed
-            && (psObject->nSHPType == SHPT_POINTZ
-                || psObject->nSHPType == SHPT_POINTM) )
+        if (psObject->bMeasureIsUsed && (psObject->nSHPType == SHPT_POINTZ ||
+                                         psObject->nSHPType == SHPT_POINTM))
         {
-            ByteCopy( psObject->padfM, pabyRec + nRecordSize, 8 );
-            if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
+            ByteCopy(psObject->padfM, pabyRec + nRecordSize, 8);
+            if (bBigEndian)
+                SwapWord(8, pabyRec + nRecordSize);
             nRecordSize += 8;
         }
     }
 
-/* -------------------------------------------------------------------- */
-/*      Not much to do for null geometries.                             */
-/* -------------------------------------------------------------------- */
-    else if( psObject->nSHPType == SHPT_NULL )
+    /* -------------------------------------------------------------------- */
+    /*      Not much to do for null geometries.                             */
+    /* -------------------------------------------------------------------- */
+    else if (psObject->nSHPType == SHPT_NULL)
     {
         nRecordSize = 12;
-    } else {
+    }
+    else
+    {
         /* unknown type */
-        assert( false );
+        assert(false);
     }
 
-/* -------------------------------------------------------------------- */
-/*      Establish where we are going to put this record. If we are      */
-/*      rewriting the last record of the file, then we can update it in */
-/*      place. Otherwise if rewriting an existing record, and it will   */
-/*      fit, then put it  back where the original came from.  Otherwise */
-/*      write at the end.                                               */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Establish where we are going to put this record. If we are      */
+    /*      rewriting the last record of the file, then we can update it in */
+    /*      place. Otherwise if rewriting an existing record, and it will   */
+    /*      fit, then put it  back where the original came from.  Otherwise */
+    /*      write at the end.                                               */
+    /* -------------------------------------------------------------------- */
     SAOffset nRecordOffset;
     bool bAppendToLastRecord = false;
     bool bAppendToFile = false;
-    if( nShapeId != -1 && psSHP->panRecOffset[nShapeId] +
-                        psSHP->panRecSize[nShapeId] + 8 == psSHP->nFileSize )
+    if (nShapeId != -1 &&
+        psSHP->panRecOffset[nShapeId] + psSHP->panRecSize[nShapeId] + 8 ==
+            psSHP->nFileSize)
     {
         nRecordOffset = psSHP->panRecOffset[nShapeId];
         bAppendToLastRecord = true;
     }
-    else if( nShapeId == -1 || psSHP->panRecSize[nShapeId] < nRecordSize-8 )
+    else if (nShapeId == -1 || psSHP->panRecSize[nShapeId] < nRecordSize - 8)
     {
-        if( psSHP->nFileSize > UINT_MAX - nRecordSize)
+        if (psSHP->nFileSize > UINT_MAX - nRecordSize)
         {
             char str[128];
-            snprintf( str, sizeof(str), "Failed to write shape object. "
+            snprintf(str, sizeof(str),
+                     "Failed to write shape object. "
                      "File size cannot reach %u + %u.",
-                     psSHP->nFileSize, nRecordSize );
-            str[sizeof(str)-1] = '\0';
-            psSHP->sHooks.Error( str );
-            free( pabyRec );
+                     psSHP->nFileSize, nRecordSize);
+            str[sizeof(str) - 1] = '\0';
+            psSHP->sHooks.Error(str);
+            free(pabyRec);
             return -1;
         }
 
@@ -1576,80 +1658,87 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject ) {
         nRecordOffset = psSHP->panRecOffset[nShapeId];
     }
 
-/* -------------------------------------------------------------------- */
-/*      Set the shape type, record number, and record size.             */
-/* -------------------------------------------------------------------- */
-    int32 i32 = (nShapeId < 0) ? psSHP->nRecords+1 : nShapeId+1;  /* record # */
-    if( !bBigEndian ) SwapWord( 4, &i32 );
-    ByteCopy( &i32, pabyRec, 4 );
+    /* -------------------------------------------------------------------- */
+    /*      Set the shape type, record number, and record size.             */
+    /* -------------------------------------------------------------------- */
+    int32 i32 =
+        (nShapeId < 0) ? psSHP->nRecords + 1 : nShapeId + 1; /* record # */
+    if (!bBigEndian)
+        SwapWord(4, &i32);
+    ByteCopy(&i32, pabyRec, 4);
 
-    i32 = (nRecordSize-8)/2;				/* record size */
-    if( !bBigEndian ) SwapWord( 4, &i32 );
-    ByteCopy( &i32, pabyRec + 4, 4 );
+    i32 = (nRecordSize - 8) / 2; /* record size */
+    if (!bBigEndian)
+        SwapWord(4, &i32);
+    ByteCopy(&i32, pabyRec + 4, 4);
 
-    i32 = psObject->nSHPType;				/* shape type */
-    if( bBigEndian ) SwapWord( 4, &i32 );
-    ByteCopy( &i32, pabyRec + 8, 4 );
+    i32 = psObject->nSHPType; /* shape type */
+    if (bBigEndian)
+        SwapWord(4, &i32);
+    ByteCopy(&i32, pabyRec + 8, 4);
 
-/* -------------------------------------------------------------------- */
-/*      Write out record.                                               */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Write out record.                                               */
+    /* -------------------------------------------------------------------- */
 
-/* -------------------------------------------------------------------- */
-/*      Guard FSeek with check for whether we're already at position;   */
-/*      no-op FSeeks defeat network filesystems' write buffering.       */
-/* -------------------------------------------------------------------- */
-    if ( psSHP->sHooks.FTell( psSHP->fpSHP ) != nRecordOffset ) {
-        if( psSHP->sHooks.FSeek( psSHP->fpSHP, nRecordOffset, 0 ) != 0 )
+    /* -------------------------------------------------------------------- */
+    /*      Guard FSeek with check for whether we're already at position;   */
+    /*      no-op FSeeks defeat network filesystems' write buffering.       */
+    /* -------------------------------------------------------------------- */
+    if (psSHP->sHooks.FTell(psSHP->fpSHP) != nRecordOffset)
+    {
+        if (psSHP->sHooks.FSeek(psSHP->fpSHP, nRecordOffset, 0) != 0)
         {
             char szErrorMsg[200];
 
-            snprintf( szErrorMsg, sizeof(szErrorMsg),
-                     "Error in psSHP->sHooks.FSeek() while writing object to .shp file: %s",
-                      strerror(errno) );
-            szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-            psSHP->sHooks.Error( szErrorMsg );
+            snprintf(szErrorMsg, sizeof(szErrorMsg),
+                     "Error in psSHP->sHooks.FSeek() while writing object to "
+                     ".shp file: %s",
+                     strerror(errno));
+            szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+            psSHP->sHooks.Error(szErrorMsg);
 
-            free( pabyRec );
+            free(pabyRec);
             return -1;
         }
     }
-    if( psSHP->sHooks.FWrite( pabyRec, nRecordSize, 1, psSHP->fpSHP ) < 1 )
+    if (psSHP->sHooks.FWrite(pabyRec, nRecordSize, 1, psSHP->fpSHP) < 1)
     {
         char szErrorMsg[200];
 
-        snprintf( szErrorMsg, sizeof(szErrorMsg),
-                 "Error in psSHP->sHooks.FWrite() while writing object of %u bytes to .shp file: %s",
-                  nRecordSize, strerror(errno) );
-        szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-        psSHP->sHooks.Error( szErrorMsg );
+        snprintf(szErrorMsg, sizeof(szErrorMsg),
+                 "Error in psSHP->sHooks.FWrite() while writing object of %u "
+                 "bytes to .shp file: %s",
+                 nRecordSize, strerror(errno));
+        szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+        psSHP->sHooks.Error(szErrorMsg);
 
-        free( pabyRec );
+        free(pabyRec);
         return -1;
     }
 
-    free( pabyRec );
+    free(pabyRec);
 
-    if( bAppendToLastRecord )
+    if (bAppendToLastRecord)
     {
         psSHP->nFileSize = psSHP->panRecOffset[nShapeId] + nRecordSize;
     }
-    else if( bAppendToFile )
+    else if (bAppendToFile)
     {
-        if( nShapeId == -1 )
+        if (nShapeId == -1)
             nShapeId = psSHP->nRecords++;
 
         psSHP->panRecOffset[nShapeId] = psSHP->nFileSize;
         psSHP->nFileSize += nRecordSize;
     }
-    psSHP->panRecSize[nShapeId] = nRecordSize-8;
+    psSHP->panRecSize[nShapeId] = nRecordSize - 8;
 
-/* -------------------------------------------------------------------- */
-/*	Expand file wide bounds based on this shape.			*/
-/* -------------------------------------------------------------------- */
-    if( bFirstFeature )
+    /* -------------------------------------------------------------------- */
+    /*	Expand file wide bounds based on this shape.			*/
+    /* -------------------------------------------------------------------- */
+    if (bFirstFeature)
     {
-        if( psObject->nSHPType == SHPT_NULL || psObject->nVertices == 0 )
+        if (psObject->nSHPType == SHPT_NULL || psObject->nVertices == 0)
         {
             psSHP->adBoundsMin[0] = psSHP->adBoundsMax[0] = 0.0;
             psSHP->adBoundsMin[1] = psSHP->adBoundsMax[1] = 0.0;
@@ -1660,42 +1749,49 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject ) {
         {
             psSHP->adBoundsMin[0] = psSHP->adBoundsMax[0] = psObject->padfX[0];
             psSHP->adBoundsMin[1] = psSHP->adBoundsMax[1] = psObject->padfY[0];
-            psSHP->adBoundsMin[2] = psSHP->adBoundsMax[2] = psObject->padfZ ? psObject->padfZ[0] : 0.0;
-            psSHP->adBoundsMin[3] = psSHP->adBoundsMax[3] = psObject->padfM ? psObject->padfM[0] : 0.0;
+            psSHP->adBoundsMin[2] = psSHP->adBoundsMax[2] =
+                psObject->padfZ ? psObject->padfZ[0] : 0.0;
+            psSHP->adBoundsMin[3] = psSHP->adBoundsMax[3] =
+                psObject->padfM ? psObject->padfM[0] : 0.0;
         }
     }
 
-    for( int i = 0; i < psObject->nVertices; i++ )
+    for (int i = 0; i < psObject->nVertices; i++)
     {
-        psSHP->adBoundsMin[0] = MIN(psSHP->adBoundsMin[0],psObject->padfX[i]);
-        psSHP->adBoundsMin[1] = MIN(psSHP->adBoundsMin[1],psObject->padfY[i]);
-        psSHP->adBoundsMax[0] = MAX(psSHP->adBoundsMax[0],psObject->padfX[i]);
-        psSHP->adBoundsMax[1] = MAX(psSHP->adBoundsMax[1],psObject->padfY[i]);
-        if( psObject->padfZ )
+        psSHP->adBoundsMin[0] = MIN(psSHP->adBoundsMin[0], psObject->padfX[i]);
+        psSHP->adBoundsMin[1] = MIN(psSHP->adBoundsMin[1], psObject->padfY[i]);
+        psSHP->adBoundsMax[0] = MAX(psSHP->adBoundsMax[0], psObject->padfX[i]);
+        psSHP->adBoundsMax[1] = MAX(psSHP->adBoundsMax[1], psObject->padfY[i]);
+        if (psObject->padfZ)
         {
-            psSHP->adBoundsMin[2] = MIN(psSHP->adBoundsMin[2],psObject->padfZ[i]);
-            psSHP->adBoundsMax[2] = MAX(psSHP->adBoundsMax[2],psObject->padfZ[i]);
+            psSHP->adBoundsMin[2] =
+                MIN(psSHP->adBoundsMin[2], psObject->padfZ[i]);
+            psSHP->adBoundsMax[2] =
+                MAX(psSHP->adBoundsMax[2], psObject->padfZ[i]);
         }
-        if( psObject->padfM )
+        if (psObject->padfM)
         {
-            psSHP->adBoundsMin[3] = MIN(psSHP->adBoundsMin[3],psObject->padfM[i]);
-            psSHP->adBoundsMax[3] = MAX(psSHP->adBoundsMax[3],psObject->padfM[i]);
+            psSHP->adBoundsMin[3] =
+                MIN(psSHP->adBoundsMin[3], psObject->padfM[i]);
+            psSHP->adBoundsMax[3] =
+                MAX(psSHP->adBoundsMax[3], psObject->padfM[i]);
         }
     }
 
-    return( nShapeId  );
+    return (nShapeId);
 }
 
 /************************************************************************/
 /*                         SHPAllocBuffer()                             */
 /************************************************************************/
 
-static void* SHPAllocBuffer(unsigned char** pBuffer, int nSize) {
-    if( pBuffer == SHPLIB_NULLPTR )
+static void *SHPAllocBuffer(unsigned char **pBuffer, int nSize)
+{
+    if (pBuffer == SHPLIB_NULLPTR)
         return calloc(1, nSize);
 
-    unsigned char* pRet = *pBuffer;
-    if( pRet == SHPLIB_NULLPTR )
+    unsigned char *pRet = *pBuffer;
+    if (pRet == SHPLIB_NULLPTR)
         return SHPLIB_NULLPTR;
 
     (*pBuffer) += nSize;
@@ -1706,23 +1802,27 @@ static void* SHPAllocBuffer(unsigned char** pBuffer, int nSize) {
 /*                    SHPReallocObjectBufIfNecessary()                  */
 /************************************************************************/
 
-static unsigned char* SHPReallocObjectBufIfNecessary ( SHPHandle psSHP,
-                                                       int nObjectBufSize ) {
-    if( nObjectBufSize == 0 )
+static unsigned char *SHPReallocObjectBufIfNecessary(SHPHandle psSHP,
+                                                     int nObjectBufSize)
+{
+    if (nObjectBufSize == 0)
     {
         nObjectBufSize = 4 * sizeof(double);
     }
 
-    unsigned char* pBuffer;
-    if( nObjectBufSize > psSHP->nObjectBufSize )
+    unsigned char *pBuffer;
+    if (nObjectBufSize > psSHP->nObjectBufSize)
     {
-        pBuffer = STATIC_CAST(unsigned char*, realloc( psSHP->pabyObjectBuf, nObjectBufSize ));
-        if( pBuffer != SHPLIB_NULLPTR )
+        pBuffer = STATIC_CAST(unsigned char *,
+                              realloc(psSHP->pabyObjectBuf, nObjectBufSize));
+        if (pBuffer != SHPLIB_NULLPTR)
         {
             psSHP->pabyObjectBuf = pBuffer;
             psSHP->nObjectBufSize = nObjectBufSize;
         }
-    } else {
+    }
+    else
+    {
         pBuffer = psSHP->pabyObjectBuf;
     }
 
@@ -1736,71 +1836,72 @@ static unsigned char* SHPReallocObjectBufIfNecessary ( SHPHandle psSHP,
 /*	for one shape.							*/
 /************************************************************************/
 
-SHPObject SHPAPI_CALL1(*)
-SHPReadObject( SHPHandle psSHP, int hEntity ) {
-/* -------------------------------------------------------------------- */
-/*      Validate the record/entity number.                              */
-/* -------------------------------------------------------------------- */
-    if( hEntity < 0 || hEntity >= psSHP->nRecords )
+SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
+{
+    /* -------------------------------------------------------------------- */
+    /*      Validate the record/entity number.                              */
+    /* -------------------------------------------------------------------- */
+    if (hEntity < 0 || hEntity >= psSHP->nRecords)
         return SHPLIB_NULLPTR;
 
-/* -------------------------------------------------------------------- */
-/*      Read offset/length from SHX loading if necessary.               */
-/* -------------------------------------------------------------------- */
-    if( psSHP->panRecOffset[hEntity] == 0 && psSHP->fpSHX != SHPLIB_NULLPTR )
+    /* -------------------------------------------------------------------- */
+    /*      Read offset/length from SHX loading if necessary.               */
+    /* -------------------------------------------------------------------- */
+    if (psSHP->panRecOffset[hEntity] == 0 && psSHP->fpSHX != SHPLIB_NULLPTR)
     {
         unsigned int nOffset;
         unsigned int nLength;
 
-        if( psSHP->sHooks.FSeek( psSHP->fpSHX, 100 + 8 * hEntity, 0 ) != 0 ||
-            psSHP->sHooks.FRead( &nOffset, 1, 4, psSHP->fpSHX ) != 4 ||
-            psSHP->sHooks.FRead( &nLength, 1, 4, psSHP->fpSHX ) != 4 )
+        if (psSHP->sHooks.FSeek(psSHP->fpSHX, 100 + 8 * hEntity, 0) != 0 ||
+            psSHP->sHooks.FRead(&nOffset, 1, 4, psSHP->fpSHX) != 4 ||
+            psSHP->sHooks.FRead(&nLength, 1, 4, psSHP->fpSHX) != 4)
         {
             char str[128];
-            snprintf( str, sizeof(str),
-                    "Error in fseek()/fread() reading object from .shx file at offset %d",
-                    100 + 8 * hEntity);
-            str[sizeof(str)-1] = '\0';
+            snprintf(str, sizeof(str),
+                     "Error in fseek()/fread() reading object from .shx file "
+                     "at offset %d",
+                     100 + 8 * hEntity);
+            str[sizeof(str) - 1] = '\0';
 
-            psSHP->sHooks.Error( str );
+            psSHP->sHooks.Error(str);
             return SHPLIB_NULLPTR;
         }
-        if( !bBigEndian ) SwapWord( 4, &nOffset );
-        if( !bBigEndian ) SwapWord( 4, &nLength );
+        if (!bBigEndian)
+            SwapWord(4, &nOffset);
+        if (!bBigEndian)
+            SwapWord(4, &nLength);
 
-        if( nOffset > STATIC_CAST(unsigned int, INT_MAX) )
+        if (nOffset > STATIC_CAST(unsigned int, INT_MAX))
         {
             char str[128];
-            snprintf( str, sizeof(str),
-                    "Invalid offset for entity %d", hEntity);
-            str[sizeof(str)-1] = '\0';
+            snprintf(str, sizeof(str), "Invalid offset for entity %d", hEntity);
+            str[sizeof(str) - 1] = '\0';
 
-            psSHP->sHooks.Error( str );
+            psSHP->sHooks.Error(str);
             return SHPLIB_NULLPTR;
         }
-        if( nLength > STATIC_CAST(unsigned int, INT_MAX / 2 - 4) )
+        if (nLength > STATIC_CAST(unsigned int, INT_MAX / 2 - 4))
         {
             char str[128];
-            snprintf( str, sizeof(str),
-                    "Invalid length for entity %d", hEntity);
-            str[sizeof(str)-1] = '\0';
+            snprintf(str, sizeof(str), "Invalid length for entity %d", hEntity);
+            str[sizeof(str) - 1] = '\0';
 
-            psSHP->sHooks.Error( str );
+            psSHP->sHooks.Error(str);
             return SHPLIB_NULLPTR;
         }
 
-        psSHP->panRecOffset[hEntity] = nOffset*2;
-        psSHP->panRecSize[hEntity] = nLength*2;
+        psSHP->panRecOffset[hEntity] = nOffset * 2;
+        psSHP->panRecSize[hEntity] = nLength * 2;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Ensure our record buffer is large enough.                       */
-/* -------------------------------------------------------------------- */
-    const int nEntitySize = psSHP->panRecSize[hEntity]+8;
-    if( nEntitySize > psSHP->nBufSize )
+    /* -------------------------------------------------------------------- */
+    /*      Ensure our record buffer is large enough.                       */
+    /* -------------------------------------------------------------------- */
+    const int nEntitySize = psSHP->panRecSize[hEntity] + 8;
+    if (nEntitySize > psSHP->nBufSize)
     {
         int nNewBufSize = nEntitySize;
-        if( nNewBufSize < INT_MAX - nNewBufSize / 3 )
+        if (nNewBufSize < INT_MAX - nNewBufSize / 3)
             nNewBufSize += nNewBufSize / 3;
         else
             nNewBufSize = INT_MAX;
@@ -1808,46 +1909,51 @@ SHPReadObject( SHPHandle psSHP, int hEntity ) {
         /* Before allocating too much memory, check that the file is big enough */
         /* and do not trust the file size in the header the first time we */
         /* need to allocate more than 10 MB */
-        if( nNewBufSize >= 10 * 1024 * 1024 )
+        if (nNewBufSize >= 10 * 1024 * 1024)
         {
-            if( psSHP->nBufSize < 10 * 1024 * 1024 )
+            if (psSHP->nBufSize < 10 * 1024 * 1024)
             {
                 SAOffset nFileSize;
-                psSHP->sHooks.FSeek( psSHP->fpSHP, 0, 2 );
+                psSHP->sHooks.FSeek(psSHP->fpSHP, 0, 2);
                 nFileSize = psSHP->sHooks.FTell(psSHP->fpSHP);
-                if( nFileSize >= UINT_MAX )
+                if (nFileSize >= UINT_MAX)
                     psSHP->nFileSize = UINT_MAX;
                 else
                     psSHP->nFileSize = STATIC_CAST(unsigned int, nFileSize);
             }
 
-            if( psSHP->panRecOffset[hEntity] >= psSHP->nFileSize ||
+            if (psSHP->panRecOffset[hEntity] >= psSHP->nFileSize ||
                 /* We should normally use nEntitySize instead of*/
                 /* psSHP->panRecSize[hEntity] in the below test, but because of */
                 /* the case of non conformant .shx files detailed a bit below, */
                 /* let be more tolerant */
-                psSHP->panRecSize[hEntity] > psSHP->nFileSize - psSHP->panRecOffset[hEntity] )
+                psSHP->panRecSize[hEntity] >
+                    psSHP->nFileSize - psSHP->panRecOffset[hEntity])
             {
                 char str[128];
-                snprintf( str, sizeof(str),
-                            "Error in fread() reading object of size %d at offset %u from .shp file",
-                            nEntitySize, psSHP->panRecOffset[hEntity] );
-                str[sizeof(str)-1] = '\0';
+                snprintf(str, sizeof(str),
+                         "Error in fread() reading object of size %d at offset "
+                         "%u from .shp file",
+                         nEntitySize, psSHP->panRecOffset[hEntity]);
+                str[sizeof(str) - 1] = '\0';
 
-                psSHP->sHooks.Error( str );
+                psSHP->sHooks.Error(str);
                 return SHPLIB_NULLPTR;
             }
         }
 
-        uchar* pabyRecNew = STATIC_CAST(uchar *, realloc(psSHP->pabyRec, nNewBufSize));
+        uchar *pabyRecNew =
+            STATIC_CAST(uchar *, realloc(psSHP->pabyRec, nNewBufSize));
         if (pabyRecNew == SHPLIB_NULLPTR)
         {
             char szErrorMsg[160];
-            snprintf( szErrorMsg, sizeof(szErrorMsg),
-                     "Not enough memory to allocate requested memory (nNewBufSize=%d). "
-                     "Probably broken SHP file", nNewBufSize);
-            szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-            psSHP->sHooks.Error( szErrorMsg );
+            snprintf(szErrorMsg, sizeof(szErrorMsg),
+                     "Not enough memory to allocate requested memory "
+                     "(nNewBufSize=%d). "
+                     "Probably broken SHP file",
+                     nNewBufSize);
+            szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+            psSHP->sHooks.Error(szErrorMsg);
             return SHPLIB_NULLPTR;
         }
 
@@ -1862,26 +1968,27 @@ SHPReadObject( SHPHandle psSHP, int hEntity ) {
         return SHPLIB_NULLPTR;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Read the record.                                                */
-/* -------------------------------------------------------------------- */
-    if( psSHP->sHooks.FSeek( psSHP->fpSHP, psSHP->panRecOffset[hEntity], 0 ) != 0 )
+    /* -------------------------------------------------------------------- */
+    /*      Read the record.                                                */
+    /* -------------------------------------------------------------------- */
+    if (psSHP->sHooks.FSeek(psSHP->fpSHP, psSHP->panRecOffset[hEntity], 0) != 0)
     {
         /*
          * TODO - mloskot: Consider detailed diagnostics of shape file,
          * for example to detect if file is truncated.
          */
         char str[128];
-        snprintf( str, sizeof(str),
+        snprintf(str, sizeof(str),
                  "Error in fseek() reading object from .shp file at offset %u",
                  psSHP->panRecOffset[hEntity]);
-        str[sizeof(str)-1] = '\0';
+        str[sizeof(str) - 1] = '\0';
 
-        psSHP->sHooks.Error( str );
+        psSHP->sHooks.Error(str);
         return SHPLIB_NULLPTR;
     }
 
-    const int nBytesRead = STATIC_CAST(int, psSHP->sHooks.FRead( psSHP->pabyRec, 1, nEntitySize, psSHP->fpSHP ));
+    const int nBytesRead = STATIC_CAST(
+        int, psSHP->sHooks.FRead(psSHP->pabyRec, 1, nEntitySize, psSHP->fpSHP));
 
     /* Special case for a shapefile whose .shx content length field is not equal */
     /* to the content length field of the .shp, which is a violation of "The */
@@ -1889,125 +1996,134 @@ SHPReadObject( SHPHandle psSHP, int hEntity ) {
     /* file record header." (http://www.esri.com/library/whitepapers/pdfs/shapefile.pdf, page 24) */
     /* Actually in that case the .shx content length is equal to the .shp content length + */
     /* 4 (16 bit words), representing the 8 bytes of the record header... */
-    if( nBytesRead >= 8 && nBytesRead == nEntitySize - 8 )
+    if (nBytesRead >= 8 && nBytesRead == nEntitySize - 8)
     {
         /* Do a sanity check */
         int nSHPContentLength;
-        memcpy( &nSHPContentLength, psSHP->pabyRec + 4, 4 );
-        if( !bBigEndian ) SwapWord( 4, &(nSHPContentLength) );
-        if( nSHPContentLength < 0 ||
-            nSHPContentLength > INT_MAX / 2 - 4 ||
-            2 * nSHPContentLength + 8 != nBytesRead )
+        memcpy(&nSHPContentLength, psSHP->pabyRec + 4, 4);
+        if (!bBigEndian)
+            SwapWord(4, &(nSHPContentLength));
+        if (nSHPContentLength < 0 || nSHPContentLength > INT_MAX / 2 - 4 ||
+            2 * nSHPContentLength + 8 != nBytesRead)
         {
             char str[128];
-            snprintf( str, sizeof(str),
-                    "Sanity check failed when trying to recover from inconsistent .shx/.shp with shape %d",
-                    hEntity );
-            str[sizeof(str)-1] = '\0';
+            snprintf(str, sizeof(str),
+                     "Sanity check failed when trying to recover from "
+                     "inconsistent .shx/.shp with shape %d",
+                     hEntity);
+            str[sizeof(str) - 1] = '\0';
 
-            psSHP->sHooks.Error( str );
+            psSHP->sHooks.Error(str);
             return SHPLIB_NULLPTR;
         }
     }
-    else if( nBytesRead != nEntitySize )
+    else if (nBytesRead != nEntitySize)
     {
         /*
          * TODO - mloskot: Consider detailed diagnostics of shape file,
          * for example to detect if file is truncated.
          */
         char str[128];
-        snprintf( str, sizeof(str),
-                 "Error in fread() reading object of size %d at offset %u from .shp file",
-                 nEntitySize, psSHP->panRecOffset[hEntity] );
-        str[sizeof(str)-1] = '\0';
+        snprintf(str, sizeof(str),
+                 "Error in fread() reading object of size %d at offset %u from "
+                 ".shp file",
+                 nEntitySize, psSHP->panRecOffset[hEntity]);
+        str[sizeof(str) - 1] = '\0';
 
-        psSHP->sHooks.Error( str );
+        psSHP->sHooks.Error(str);
         return SHPLIB_NULLPTR;
     }
 
-    if ( 8 + 4 > nEntitySize )
+    if (8 + 4 > nEntitySize)
     {
         char szErrorMsg[160];
         snprintf(szErrorMsg, sizeof(szErrorMsg),
-                 "Corrupted .shp file : shape %d : nEntitySize = %d",
-                 hEntity, nEntitySize);
-        szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-        psSHP->sHooks.Error( szErrorMsg );
+                 "Corrupted .shp file : shape %d : nEntitySize = %d", hEntity,
+                 nEntitySize);
+        szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+        psSHP->sHooks.Error(szErrorMsg);
         return SHPLIB_NULLPTR;
     }
     int nSHPType;
-    memcpy( &nSHPType, psSHP->pabyRec + 8, 4 );
+    memcpy(&nSHPType, psSHP->pabyRec + 8, 4);
 
-    if( bBigEndian ) SwapWord( 4, &(nSHPType) );
+    if (bBigEndian)
+        SwapWord(4, &(nSHPType));
 
-/* -------------------------------------------------------------------- */
-/*	Allocate and minimally initialize the object.			*/
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*	Allocate and minimally initialize the object.			*/
+    /* -------------------------------------------------------------------- */
     SHPObject *psShape;
-    if( psSHP->bFastModeReadObject )
+    if (psSHP->bFastModeReadObject)
     {
-        if( psSHP->psCachedObject->bFastModeReadObject )
+        if (psSHP->psCachedObject->bFastModeReadObject)
         {
-            psSHP->sHooks.Error( "Invalid read pattern in fast read mode. "
-                                 "SHPDestroyObject() should be called." );
+            psSHP->sHooks.Error("Invalid read pattern in fast read mode. "
+                                "SHPDestroyObject() should be called.");
             return SHPLIB_NULLPTR;
         }
 
         psShape = psSHP->psCachedObject;
         memset(psShape, 0, sizeof(SHPObject));
-    } else {
-        psShape = STATIC_CAST(SHPObject *, calloc(1,sizeof(SHPObject)));
+    }
+    else
+    {
+        psShape = STATIC_CAST(SHPObject *, calloc(1, sizeof(SHPObject)));
     }
     psShape->nShapeId = hEntity;
     psShape->nSHPType = nSHPType;
     psShape->bMeasureIsUsed = FALSE;
     psShape->bFastModeReadObject = psSHP->bFastModeReadObject;
 
-/* ==================================================================== */
-/*  Extract vertices for a Polygon or Arc.				*/
-/* ==================================================================== */
-    if( psShape->nSHPType == SHPT_POLYGON || psShape->nSHPType == SHPT_ARC
-        || psShape->nSHPType == SHPT_POLYGONZ
-        || psShape->nSHPType == SHPT_POLYGONM
-        || psShape->nSHPType == SHPT_ARCZ
-        || psShape->nSHPType == SHPT_ARCM
-        || psShape->nSHPType == SHPT_MULTIPATCH )
+    /* ==================================================================== */
+    /*  Extract vertices for a Polygon or Arc.				*/
+    /* ==================================================================== */
+    if (psShape->nSHPType == SHPT_POLYGON || psShape->nSHPType == SHPT_ARC ||
+        psShape->nSHPType == SHPT_POLYGONZ ||
+        psShape->nSHPType == SHPT_POLYGONM || psShape->nSHPType == SHPT_ARCZ ||
+        psShape->nSHPType == SHPT_ARCM || psShape->nSHPType == SHPT_MULTIPATCH)
     {
-        if ( 40 + 8 + 4 > nEntitySize )
+        if (40 + 8 + 4 > nEntitySize)
         {
             char szErrorMsg[160];
             snprintf(szErrorMsg, sizeof(szErrorMsg),
                      "Corrupted .shp file : shape %d : nEntitySize = %d",
                      hEntity, nEntitySize);
-            szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-            psSHP->sHooks.Error( szErrorMsg );
+            szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+            psSHP->sHooks.Error(szErrorMsg);
             SHPDestroyObject(psShape);
             return SHPLIB_NULLPTR;
         }
-/* -------------------------------------------------------------------- */
-/*	Get the X/Y bounds.						*/
-/* -------------------------------------------------------------------- */
-        memcpy( &(psShape->dfXMin), psSHP->pabyRec + 8 +  4, 8 );
-        memcpy( &(psShape->dfYMin), psSHP->pabyRec + 8 + 12, 8 );
-        memcpy( &(psShape->dfXMax), psSHP->pabyRec + 8 + 20, 8 );
-        memcpy( &(psShape->dfYMax), psSHP->pabyRec + 8 + 28, 8 );
+        /* -------------------------------------------------------------------- */
+        /*	Get the X/Y bounds.						*/
+        /* -------------------------------------------------------------------- */
+        memcpy(&(psShape->dfXMin), psSHP->pabyRec + 8 + 4, 8);
+        memcpy(&(psShape->dfYMin), psSHP->pabyRec + 8 + 12, 8);
+        memcpy(&(psShape->dfXMax), psSHP->pabyRec + 8 + 20, 8);
+        memcpy(&(psShape->dfYMax), psSHP->pabyRec + 8 + 28, 8);
 
-        if( bBigEndian ) SwapWord( 8, &(psShape->dfXMin) );
-        if( bBigEndian ) SwapWord( 8, &(psShape->dfYMin) );
-        if( bBigEndian ) SwapWord( 8, &(psShape->dfXMax) );
-        if( bBigEndian ) SwapWord( 8, &(psShape->dfYMax) );
+        if (bBigEndian)
+            SwapWord(8, &(psShape->dfXMin));
+        if (bBigEndian)
+            SwapWord(8, &(psShape->dfYMin));
+        if (bBigEndian)
+            SwapWord(8, &(psShape->dfXMax));
+        if (bBigEndian)
+            SwapWord(8, &(psShape->dfYMax));
 
-/* -------------------------------------------------------------------- */
-/*      Extract part/point count, and build vertex and part arrays      */
-/*      to proper size.                                                 */
-/* -------------------------------------------------------------------- */
+        /* -------------------------------------------------------------------- */
+        /*      Extract part/point count, and build vertex and part arrays      */
+        /*      to proper size.                                                 */
+        /* -------------------------------------------------------------------- */
         int32 nPoints;
-        memcpy( &nPoints, psSHP->pabyRec + 40 + 8, 4 );
+        memcpy(&nPoints, psSHP->pabyRec + 40 + 8, 4);
         int32 nParts;
-        memcpy( &nParts, psSHP->pabyRec + 36 + 8, 4 );
+        memcpy(&nParts, psSHP->pabyRec + 36 + 8, 4);
 
-        if( bBigEndian ) SwapWord( 4, &nPoints );
-        if( bBigEndian ) SwapWord( 4, &nParts );
+        if (bBigEndian)
+            SwapWord(4, &nPoints);
+        if (bBigEndian)
+            SwapWord(4, &nParts);
 
         /* nPoints and nParts are unsigned */
         if (/* nPoints < 0 || nParts < 0 || */
@@ -2017,8 +2133,8 @@ SHPReadObject( SHPHandle psSHP, int hEntity ) {
             snprintf(szErrorMsg, sizeof(szErrorMsg),
                      "Corrupted .shp file : shape %d, nPoints=%u, nParts=%u.",
                      hEntity, nPoints, nParts);
-            szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-            psSHP->sHooks.Error( szErrorMsg );
+            szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+            psSHP->sHooks.Error(szErrorMsg);
             SHPDestroyObject(psShape);
             return SHPLIB_NULLPTR;
         }
@@ -2027,13 +2143,13 @@ SHPReadObject( SHPHandle psSHP, int hEntity ) {
         /* we should not overflow here and after */
         /* since 50 M * (16 + 8 + 8) = 1 600 MB */
         int nRequiredSize = 44 + 8 + 4 * nParts + 16 * nPoints;
-        if ( psShape->nSHPType == SHPT_POLYGONZ
-             || psShape->nSHPType == SHPT_ARCZ
-             || psShape->nSHPType == SHPT_MULTIPATCH )
+        if (psShape->nSHPType == SHPT_POLYGONZ ||
+            psShape->nSHPType == SHPT_ARCZ ||
+            psShape->nSHPType == SHPT_MULTIPATCH)
         {
             nRequiredSize += 16 + 8 * nPoints;
         }
-        if( psShape->nSHPType == SHPT_MULTIPATCH )
+        if (psShape->nSHPType == SHPT_MULTIPATCH)
         {
             nRequiredSize += 4 * nParts;
         }
@@ -2041,33 +2157,41 @@ SHPReadObject( SHPHandle psSHP, int hEntity ) {
         {
             char szErrorMsg[160];
             snprintf(szErrorMsg, sizeof(szErrorMsg),
-                     "Corrupted .shp file : shape %d, nPoints=%u, nParts=%u, nEntitySize=%d.",
+                     "Corrupted .shp file : shape %d, nPoints=%u, nParts=%u, "
+                     "nEntitySize=%d.",
                      hEntity, nPoints, nParts, nEntitySize);
-            szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-            psSHP->sHooks.Error( szErrorMsg );
+            szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+            psSHP->sHooks.Error(szErrorMsg);
             SHPDestroyObject(psShape);
             return SHPLIB_NULLPTR;
         }
 
-        unsigned char* pBuffer = SHPLIB_NULLPTR;
-        unsigned char** ppBuffer = SHPLIB_NULLPTR;
+        unsigned char *pBuffer = SHPLIB_NULLPTR;
+        unsigned char **ppBuffer = SHPLIB_NULLPTR;
 
-        if( psShape->bFastModeReadObject )
+        if (psShape->bFastModeReadObject)
         {
-            const int nObjectBufSize = 4 * sizeof(double) * nPoints + 2 * sizeof(int) * nParts;
+            const int nObjectBufSize =
+                4 * sizeof(double) * nPoints + 2 * sizeof(int) * nParts;
             pBuffer = SHPReallocObjectBufIfNecessary(psSHP, nObjectBufSize);
             ppBuffer = &pBuffer;
         }
 
         psShape->nVertices = nPoints;
-        psShape->padfX = STATIC_CAST(double *, SHPAllocBuffer(ppBuffer, sizeof(double) * nPoints));
-        psShape->padfY = STATIC_CAST(double *, SHPAllocBuffer(ppBuffer, sizeof(double) * nPoints));
-        psShape->padfZ = STATIC_CAST(double *, SHPAllocBuffer(ppBuffer, sizeof(double) * nPoints));
-        psShape->padfM = STATIC_CAST(double *, SHPAllocBuffer(ppBuffer, sizeof(double) * nPoints));
+        psShape->padfX = STATIC_CAST(
+            double *, SHPAllocBuffer(ppBuffer, sizeof(double) * nPoints));
+        psShape->padfY = STATIC_CAST(
+            double *, SHPAllocBuffer(ppBuffer, sizeof(double) * nPoints));
+        psShape->padfZ = STATIC_CAST(
+            double *, SHPAllocBuffer(ppBuffer, sizeof(double) * nPoints));
+        psShape->padfM = STATIC_CAST(
+            double *, SHPAllocBuffer(ppBuffer, sizeof(double) * nPoints));
 
         psShape->nParts = nParts;
-        psShape->panPartStart = STATIC_CAST(int *, SHPAllocBuffer(ppBuffer, nParts * sizeof(int)));
-        psShape->panPartType = STATIC_CAST(int *, SHPAllocBuffer(ppBuffer, nParts * sizeof(int)));
+        psShape->panPartStart =
+            STATIC_CAST(int *, SHPAllocBuffer(ppBuffer, nParts * sizeof(int)));
+        psShape->panPartType =
+            STATIC_CAST(int *, SHPAllocBuffer(ppBuffer, nParts * sizeof(int)));
 
         if (psShape->padfX == SHPLIB_NULLPTR ||
             psShape->padfY == SHPLIB_NULLPTR ||
@@ -2078,181 +2202,196 @@ SHPReadObject( SHPHandle psSHP, int hEntity ) {
         {
             char szErrorMsg[160];
             snprintf(szErrorMsg, sizeof(szErrorMsg),
-                    "Not enough memory to allocate requested memory (nPoints=%u, nParts=%u) for shape %d. "
-                    "Probably broken SHP file", nPoints, nParts, hEntity );
-            szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-            psSHP->sHooks.Error( szErrorMsg );
+                     "Not enough memory to allocate requested memory "
+                     "(nPoints=%u, nParts=%u) for shape %d. "
+                     "Probably broken SHP file",
+                     nPoints, nParts, hEntity);
+            szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+            psSHP->sHooks.Error(szErrorMsg);
             SHPDestroyObject(psShape);
             return SHPLIB_NULLPTR;
         }
 
-        for( int i = 0; STATIC_CAST(int32, i) < nParts; i++ )
+        for (int i = 0; STATIC_CAST(int32, i) < nParts; i++)
             psShape->panPartType[i] = SHPP_RING;
 
-/* -------------------------------------------------------------------- */
-/*      Copy out the part array from the record.                        */
-/* -------------------------------------------------------------------- */
-        memcpy( psShape->panPartStart, psSHP->pabyRec + 44 + 8, 4 * nParts );
-        for( int i = 0; STATIC_CAST(int32, i) < nParts; i++ )
+        /* -------------------------------------------------------------------- */
+        /*      Copy out the part array from the record.                        */
+        /* -------------------------------------------------------------------- */
+        memcpy(psShape->panPartStart, psSHP->pabyRec + 44 + 8, 4 * nParts);
+        for (int i = 0; STATIC_CAST(int32, i) < nParts; i++)
         {
-            if( bBigEndian ) SwapWord( 4, psShape->panPartStart+i );
+            if (bBigEndian)
+                SwapWord(4, psShape->panPartStart + i);
 
             /* We check that the offset is inside the vertex array */
-            if (psShape->panPartStart[i] < 0
-                || (psShape->panPartStart[i] >= psShape->nVertices
-                    && psShape->nVertices > 0)
-                || (psShape->panPartStart[i] > 0 && psShape->nVertices == 0) )
+            if (psShape->panPartStart[i] < 0 ||
+                (psShape->panPartStart[i] >= psShape->nVertices &&
+                 psShape->nVertices > 0) ||
+                (psShape->panPartStart[i] > 0 && psShape->nVertices == 0))
             {
                 char szErrorMsg[160];
                 snprintf(szErrorMsg, sizeof(szErrorMsg),
-                         "Corrupted .shp file : shape %d : panPartStart[%d] = %d, nVertices = %d",
-                         hEntity, i, psShape->panPartStart[i], psShape->nVertices);
-                szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-                psSHP->sHooks.Error( szErrorMsg );
+                         "Corrupted .shp file : shape %d : panPartStart[%d] = "
+                         "%d, nVertices = %d",
+                         hEntity, i, psShape->panPartStart[i],
+                         psShape->nVertices);
+                szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+                psSHP->sHooks.Error(szErrorMsg);
                 SHPDestroyObject(psShape);
                 return SHPLIB_NULLPTR;
             }
-            if (i > 0 && psShape->panPartStart[i] <= psShape->panPartStart[i-1])
+            if (i > 0 &&
+                psShape->panPartStart[i] <= psShape->panPartStart[i - 1])
             {
                 char szErrorMsg[160];
                 snprintf(szErrorMsg, sizeof(szErrorMsg),
-                         "Corrupted .shp file : shape %d : panPartStart[%d] = %d, panPartStart[%d] = %d",
-                         hEntity, i, psShape->panPartStart[i], i - 1, psShape->panPartStart[i - 1]);
-                szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-                psSHP->sHooks.Error( szErrorMsg );
+                         "Corrupted .shp file : shape %d : panPartStart[%d] = "
+                         "%d, panPartStart[%d] = %d",
+                         hEntity, i, psShape->panPartStart[i], i - 1,
+                         psShape->panPartStart[i - 1]);
+                szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+                psSHP->sHooks.Error(szErrorMsg);
                 SHPDestroyObject(psShape);
                 return SHPLIB_NULLPTR;
             }
         }
 
-        int nOffset = 44 + 8 + 4*nParts;
+        int nOffset = 44 + 8 + 4 * nParts;
 
-/* -------------------------------------------------------------------- */
-/*      If this is a multipatch, we will also have parts types.         */
-/* -------------------------------------------------------------------- */
-        if( psShape->nSHPType == SHPT_MULTIPATCH )
+        /* -------------------------------------------------------------------- */
+        /*      If this is a multipatch, we will also have parts types.         */
+        /* -------------------------------------------------------------------- */
+        if (psShape->nSHPType == SHPT_MULTIPATCH)
         {
-            memcpy( psShape->panPartType, psSHP->pabyRec + nOffset, 4*nParts );
-            for( int i = 0; STATIC_CAST(int32, i) < nParts; i++ )
+            memcpy(psShape->panPartType, psSHP->pabyRec + nOffset, 4 * nParts);
+            for (int i = 0; STATIC_CAST(int32, i) < nParts; i++)
             {
-                if( bBigEndian ) SwapWord( 4, psShape->panPartType+i );
+                if (bBigEndian)
+                    SwapWord(4, psShape->panPartType + i);
             }
 
-            nOffset += 4*nParts;
+            nOffset += 4 * nParts;
         }
 
-/* -------------------------------------------------------------------- */
-/*      Copy out the vertices from the record.                          */
-/* -------------------------------------------------------------------- */
-        for( int i = 0; STATIC_CAST(int32, i) < nPoints; i++ )
+        /* -------------------------------------------------------------------- */
+        /*      Copy out the vertices from the record.                          */
+        /* -------------------------------------------------------------------- */
+        for (int i = 0; STATIC_CAST(int32, i) < nPoints; i++)
         {
-            memcpy(psShape->padfX + i,
-                   psSHP->pabyRec + nOffset + i * 16,
-                   8 );
+            memcpy(psShape->padfX + i, psSHP->pabyRec + nOffset + i * 16, 8);
 
-            memcpy(psShape->padfY + i,
-                   psSHP->pabyRec + nOffset + i * 16 + 8,
-                   8 );
+            memcpy(psShape->padfY + i, psSHP->pabyRec + nOffset + i * 16 + 8,
+                   8);
 
-            if( bBigEndian ) SwapWord( 8, psShape->padfX + i );
-            if( bBigEndian ) SwapWord( 8, psShape->padfY + i );
+            if (bBigEndian)
+                SwapWord(8, psShape->padfX + i);
+            if (bBigEndian)
+                SwapWord(8, psShape->padfY + i);
         }
 
-        nOffset += 16*nPoints;
+        nOffset += 16 * nPoints;
 
-/* -------------------------------------------------------------------- */
-/*      If we have a Z coordinate, collect that now.                    */
-/* -------------------------------------------------------------------- */
-        if( psShape->nSHPType == SHPT_POLYGONZ
-            || psShape->nSHPType == SHPT_ARCZ
-            || psShape->nSHPType == SHPT_MULTIPATCH )
+        /* -------------------------------------------------------------------- */
+        /*      If we have a Z coordinate, collect that now.                    */
+        /* -------------------------------------------------------------------- */
+        if (psShape->nSHPType == SHPT_POLYGONZ ||
+            psShape->nSHPType == SHPT_ARCZ ||
+            psShape->nSHPType == SHPT_MULTIPATCH)
         {
-            memcpy( &(psShape->dfZMin), psSHP->pabyRec + nOffset, 8 );
-            memcpy( &(psShape->dfZMax), psSHP->pabyRec + nOffset + 8, 8 );
+            memcpy(&(psShape->dfZMin), psSHP->pabyRec + nOffset, 8);
+            memcpy(&(psShape->dfZMax), psSHP->pabyRec + nOffset + 8, 8);
 
-            if( bBigEndian ) SwapWord( 8, &(psShape->dfZMin) );
-            if( bBigEndian ) SwapWord( 8, &(psShape->dfZMax) );
+            if (bBigEndian)
+                SwapWord(8, &(psShape->dfZMin));
+            if (bBigEndian)
+                SwapWord(8, &(psShape->dfZMax));
 
-            for( int i = 0; STATIC_CAST(int32, i) < nPoints; i++ )
+            for (int i = 0; STATIC_CAST(int32, i) < nPoints; i++)
             {
-                memcpy( psShape->padfZ + i,
-                        psSHP->pabyRec + nOffset + 16 + i*8, 8 );
-                if( bBigEndian ) SwapWord( 8, psShape->padfZ + i );
+                memcpy(psShape->padfZ + i,
+                       psSHP->pabyRec + nOffset + 16 + i * 8, 8);
+                if (bBigEndian)
+                    SwapWord(8, psShape->padfZ + i);
             }
 
-            nOffset += 16 + 8*nPoints;
+            nOffset += 16 + 8 * nPoints;
         }
-        else if( psShape->bFastModeReadObject )
+        else if (psShape->bFastModeReadObject)
         {
             psShape->padfZ = SHPLIB_NULLPTR;
         }
 
-/* -------------------------------------------------------------------- */
-/*      If we have a M measure value, then read it now.  We assume      */
-/*      that the measure can be present for any shape if the size is    */
-/*      big enough, but really it will only occur for the Z shapes      */
-/*      (options), and the M shapes.                                    */
-/* -------------------------------------------------------------------- */
-        if( nEntitySize >= STATIC_CAST(int, nOffset + 16 + 8*nPoints) )
+        /* -------------------------------------------------------------------- */
+        /*      If we have a M measure value, then read it now.  We assume      */
+        /*      that the measure can be present for any shape if the size is    */
+        /*      big enough, but really it will only occur for the Z shapes      */
+        /*      (options), and the M shapes.                                    */
+        /* -------------------------------------------------------------------- */
+        if (nEntitySize >= STATIC_CAST(int, nOffset + 16 + 8 * nPoints))
         {
-            memcpy( &(psShape->dfMMin), psSHP->pabyRec + nOffset, 8 );
-            memcpy( &(psShape->dfMMax), psSHP->pabyRec + nOffset + 8, 8 );
+            memcpy(&(psShape->dfMMin), psSHP->pabyRec + nOffset, 8);
+            memcpy(&(psShape->dfMMax), psSHP->pabyRec + nOffset + 8, 8);
 
-            if( bBigEndian ) SwapWord( 8, &(psShape->dfMMin) );
-            if( bBigEndian ) SwapWord( 8, &(psShape->dfMMax) );
+            if (bBigEndian)
+                SwapWord(8, &(psShape->dfMMin));
+            if (bBigEndian)
+                SwapWord(8, &(psShape->dfMMax));
 
-            for( int i = 0; STATIC_CAST(int32, i) < nPoints; i++ )
+            for (int i = 0; STATIC_CAST(int32, i) < nPoints; i++)
             {
-                memcpy( psShape->padfM + i,
-                        psSHP->pabyRec + nOffset + 16 + i*8, 8 );
-                if( bBigEndian ) SwapWord( 8, psShape->padfM + i );
+                memcpy(psShape->padfM + i,
+                       psSHP->pabyRec + nOffset + 16 + i * 8, 8);
+                if (bBigEndian)
+                    SwapWord(8, psShape->padfM + i);
             }
             psShape->bMeasureIsUsed = TRUE;
         }
-        else if( psShape->bFastModeReadObject )
+        else if (psShape->bFastModeReadObject)
         {
             psShape->padfM = SHPLIB_NULLPTR;
         }
     }
 
-/* ==================================================================== */
-/*  Extract vertices for a MultiPoint.					*/
-/* ==================================================================== */
-    else if( psShape->nSHPType == SHPT_MULTIPOINT
-             || psShape->nSHPType == SHPT_MULTIPOINTM
-             || psShape->nSHPType == SHPT_MULTIPOINTZ )
+    /* ==================================================================== */
+    /*  Extract vertices for a MultiPoint.					*/
+    /* ==================================================================== */
+    else if (psShape->nSHPType == SHPT_MULTIPOINT ||
+             psShape->nSHPType == SHPT_MULTIPOINTM ||
+             psShape->nSHPType == SHPT_MULTIPOINTZ)
     {
-        if ( 44 + 4 > nEntitySize )
+        if (44 + 4 > nEntitySize)
         {
             char szErrorMsg[160];
             snprintf(szErrorMsg, sizeof(szErrorMsg),
                      "Corrupted .shp file : shape %d : nEntitySize = %d",
                      hEntity, nEntitySize);
-            szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-            psSHP->sHooks.Error( szErrorMsg );
+            szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+            psSHP->sHooks.Error(szErrorMsg);
             SHPDestroyObject(psShape);
             return SHPLIB_NULLPTR;
         }
         int32 nPoints;
-        memcpy( &nPoints, psSHP->pabyRec + 44, 4 );
+        memcpy(&nPoints, psSHP->pabyRec + 44, 4);
 
-        if( bBigEndian ) SwapWord( 4, &nPoints );
+        if (bBigEndian)
+            SwapWord(4, &nPoints);
 
         /* nPoints is unsigned */
         if (/* nPoints < 0 || */ nPoints > 50 * 1000 * 1000)
         {
             char szErrorMsg[160];
             snprintf(szErrorMsg, sizeof(szErrorMsg),
-                     "Corrupted .shp file : shape %d : nPoints = %u",
-                     hEntity, nPoints);
-            szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-            psSHP->sHooks.Error( szErrorMsg );
+                     "Corrupted .shp file : shape %d : nPoints = %u", hEntity,
+                     nPoints);
+            szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+            psSHP->sHooks.Error(szErrorMsg);
             SHPDestroyObject(psShape);
             return SHPLIB_NULLPTR;
         }
 
         int nRequiredSize = 48 + nPoints * 16;
-        if( psShape->nSHPType == SHPT_MULTIPOINTZ )
+        if (psShape->nSHPType == SHPT_MULTIPOINTZ)
         {
             nRequiredSize += 16 + nPoints * 8;
         }
@@ -2260,18 +2399,19 @@ SHPReadObject( SHPHandle psSHP, int hEntity ) {
         {
             char szErrorMsg[160];
             snprintf(szErrorMsg, sizeof(szErrorMsg),
-                     "Corrupted .shp file : shape %d : nPoints = %u, nEntitySize = %d",
+                     "Corrupted .shp file : shape %d : nPoints = %u, "
+                     "nEntitySize = %d",
                      hEntity, nPoints, nEntitySize);
-            szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-            psSHP->sHooks.Error( szErrorMsg );
+            szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+            psSHP->sHooks.Error(szErrorMsg);
             SHPDestroyObject(psShape);
             return SHPLIB_NULLPTR;
         }
 
-        unsigned char* pBuffer = SHPLIB_NULLPTR;
-        unsigned char** ppBuffer = SHPLIB_NULLPTR;
+        unsigned char *pBuffer = SHPLIB_NULLPTR;
+        unsigned char **ppBuffer = SHPLIB_NULLPTR;
 
-        if( psShape->bFastModeReadObject )
+        if (psShape->bFastModeReadObject)
         {
             const int nObjectBufSize = 4 * sizeof(double) * nPoints;
             pBuffer = SHPReallocObjectBufIfNecessary(psSHP, nObjectBufSize);
@@ -2280,10 +2420,14 @@ SHPReadObject( SHPHandle psSHP, int hEntity ) {
 
         psShape->nVertices = nPoints;
 
-        psShape->padfX = STATIC_CAST(double *, SHPAllocBuffer(ppBuffer, sizeof(double) * nPoints));
-        psShape->padfY = STATIC_CAST(double *, SHPAllocBuffer(ppBuffer, sizeof(double) * nPoints));
-        psShape->padfZ = STATIC_CAST(double *, SHPAllocBuffer(ppBuffer, sizeof(double) * nPoints));
-        psShape->padfM = STATIC_CAST(double *, SHPAllocBuffer(ppBuffer, sizeof(double) * nPoints));
+        psShape->padfX = STATIC_CAST(
+            double *, SHPAllocBuffer(ppBuffer, sizeof(double) * nPoints));
+        psShape->padfY = STATIC_CAST(
+            double *, SHPAllocBuffer(ppBuffer, sizeof(double) * nPoints));
+        psShape->padfZ = STATIC_CAST(
+            double *, SHPAllocBuffer(ppBuffer, sizeof(double) * nPoints));
+        psShape->padfM = STATIC_CAST(
+            double *, SHPAllocBuffer(ppBuffer, sizeof(double) * nPoints));
 
         if (psShape->padfX == SHPLIB_NULLPTR ||
             psShape->padfY == SHPLIB_NULLPTR ||
@@ -2292,96 +2436,110 @@ SHPReadObject( SHPHandle psSHP, int hEntity ) {
         {
             char szErrorMsg[160];
             snprintf(szErrorMsg, sizeof(szErrorMsg),
-                     "Not enough memory to allocate requested memory (nPoints=%u) for shape %d. "
-                     "Probably broken SHP file", nPoints, hEntity );
-            szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-            psSHP->sHooks.Error( szErrorMsg );
+                     "Not enough memory to allocate requested memory "
+                     "(nPoints=%u) for shape %d. "
+                     "Probably broken SHP file",
+                     nPoints, hEntity);
+            szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+            psSHP->sHooks.Error(szErrorMsg);
             SHPDestroyObject(psShape);
             return SHPLIB_NULLPTR;
         }
 
-        for( int i = 0; STATIC_CAST(int32, i) < nPoints; i++ )
+        for (int i = 0; STATIC_CAST(int32, i) < nPoints; i++)
         {
-            memcpy(psShape->padfX+i, psSHP->pabyRec + 48 + 16 * i, 8 );
-            memcpy(psShape->padfY+i, psSHP->pabyRec + 48 + 16 * i + 8, 8 );
+            memcpy(psShape->padfX + i, psSHP->pabyRec + 48 + 16 * i, 8);
+            memcpy(psShape->padfY + i, psSHP->pabyRec + 48 + 16 * i + 8, 8);
 
-            if( bBigEndian ) SwapWord( 8, psShape->padfX + i );
-            if( bBigEndian ) SwapWord( 8, psShape->padfY + i );
+            if (bBigEndian)
+                SwapWord(8, psShape->padfX + i);
+            if (bBigEndian)
+                SwapWord(8, psShape->padfY + i);
         }
 
-        int nOffset = 48 + 16*nPoints;
+        int nOffset = 48 + 16 * nPoints;
 
-/* -------------------------------------------------------------------- */
-/*	Get the X/Y bounds.						*/
-/* -------------------------------------------------------------------- */
-        memcpy( &(psShape->dfXMin), psSHP->pabyRec + 8 +  4, 8 );
-        memcpy( &(psShape->dfYMin), psSHP->pabyRec + 8 + 12, 8 );
-        memcpy( &(psShape->dfXMax), psSHP->pabyRec + 8 + 20, 8 );
-        memcpy( &(psShape->dfYMax), psSHP->pabyRec + 8 + 28, 8 );
+        /* -------------------------------------------------------------------- */
+        /*	Get the X/Y bounds.						*/
+        /* -------------------------------------------------------------------- */
+        memcpy(&(psShape->dfXMin), psSHP->pabyRec + 8 + 4, 8);
+        memcpy(&(psShape->dfYMin), psSHP->pabyRec + 8 + 12, 8);
+        memcpy(&(psShape->dfXMax), psSHP->pabyRec + 8 + 20, 8);
+        memcpy(&(psShape->dfYMax), psSHP->pabyRec + 8 + 28, 8);
 
-        if( bBigEndian ) SwapWord( 8, &(psShape->dfXMin) );
-        if( bBigEndian ) SwapWord( 8, &(psShape->dfYMin) );
-        if( bBigEndian ) SwapWord( 8, &(psShape->dfXMax) );
-        if( bBigEndian ) SwapWord( 8, &(psShape->dfYMax) );
+        if (bBigEndian)
+            SwapWord(8, &(psShape->dfXMin));
+        if (bBigEndian)
+            SwapWord(8, &(psShape->dfYMin));
+        if (bBigEndian)
+            SwapWord(8, &(psShape->dfXMax));
+        if (bBigEndian)
+            SwapWord(8, &(psShape->dfYMax));
 
-/* -------------------------------------------------------------------- */
-/*      If we have a Z coordinate, collect that now.                    */
-/* -------------------------------------------------------------------- */
-        if( psShape->nSHPType == SHPT_MULTIPOINTZ )
+        /* -------------------------------------------------------------------- */
+        /*      If we have a Z coordinate, collect that now.                    */
+        /* -------------------------------------------------------------------- */
+        if (psShape->nSHPType == SHPT_MULTIPOINTZ)
         {
-            memcpy( &(psShape->dfZMin), psSHP->pabyRec + nOffset, 8 );
-            memcpy( &(psShape->dfZMax), psSHP->pabyRec + nOffset + 8, 8 );
+            memcpy(&(psShape->dfZMin), psSHP->pabyRec + nOffset, 8);
+            memcpy(&(psShape->dfZMax), psSHP->pabyRec + nOffset + 8, 8);
 
-            if( bBigEndian ) SwapWord( 8, &(psShape->dfZMin) );
-            if( bBigEndian ) SwapWord( 8, &(psShape->dfZMax) );
+            if (bBigEndian)
+                SwapWord(8, &(psShape->dfZMin));
+            if (bBigEndian)
+                SwapWord(8, &(psShape->dfZMax));
 
-            for( int i = 0; STATIC_CAST(int32, i) < nPoints; i++ )
+            for (int i = 0; STATIC_CAST(int32, i) < nPoints; i++)
             {
-                memcpy( psShape->padfZ + i,
-                        psSHP->pabyRec + nOffset + 16 + i*8, 8 );
-                if( bBigEndian ) SwapWord( 8, psShape->padfZ + i );
+                memcpy(psShape->padfZ + i,
+                       psSHP->pabyRec + nOffset + 16 + i * 8, 8);
+                if (bBigEndian)
+                    SwapWord(8, psShape->padfZ + i);
             }
 
-            nOffset += 16 + 8*nPoints;
+            nOffset += 16 + 8 * nPoints;
         }
-        else if( psShape->bFastModeReadObject )
+        else if (psShape->bFastModeReadObject)
             psShape->padfZ = SHPLIB_NULLPTR;
 
-/* -------------------------------------------------------------------- */
-/*      If we have a M measure value, then read it now.  We assume      */
-/*      that the measure can be present for any shape if the size is    */
-/*      big enough, but really it will only occur for the Z shapes      */
-/*      (options), and the M shapes.                                    */
-/* -------------------------------------------------------------------- */
-        if( nEntitySize >= STATIC_CAST(int, nOffset + 16 + 8*nPoints) )
+        /* -------------------------------------------------------------------- */
+        /*      If we have a M measure value, then read it now.  We assume      */
+        /*      that the measure can be present for any shape if the size is    */
+        /*      big enough, but really it will only occur for the Z shapes      */
+        /*      (options), and the M shapes.                                    */
+        /* -------------------------------------------------------------------- */
+        if (nEntitySize >= STATIC_CAST(int, nOffset + 16 + 8 * nPoints))
         {
-            memcpy( &(psShape->dfMMin), psSHP->pabyRec + nOffset, 8 );
-            memcpy( &(psShape->dfMMax), psSHP->pabyRec + nOffset + 8, 8 );
+            memcpy(&(psShape->dfMMin), psSHP->pabyRec + nOffset, 8);
+            memcpy(&(psShape->dfMMax), psSHP->pabyRec + nOffset + 8, 8);
 
-            if( bBigEndian ) SwapWord( 8, &(psShape->dfMMin) );
-            if( bBigEndian ) SwapWord( 8, &(psShape->dfMMax) );
+            if (bBigEndian)
+                SwapWord(8, &(psShape->dfMMin));
+            if (bBigEndian)
+                SwapWord(8, &(psShape->dfMMax));
 
-            for( int i = 0; STATIC_CAST(int32, i) < nPoints; i++ )
+            for (int i = 0; STATIC_CAST(int32, i) < nPoints; i++)
             {
-                memcpy( psShape->padfM + i,
-                        psSHP->pabyRec + nOffset + 16 + i*8, 8 );
-                if( bBigEndian ) SwapWord( 8, psShape->padfM + i );
+                memcpy(psShape->padfM + i,
+                       psSHP->pabyRec + nOffset + 16 + i * 8, 8);
+                if (bBigEndian)
+                    SwapWord(8, psShape->padfM + i);
             }
             psShape->bMeasureIsUsed = TRUE;
         }
-        else if( psShape->bFastModeReadObject )
+        else if (psShape->bFastModeReadObject)
             psShape->padfM = SHPLIB_NULLPTR;
     }
 
-/* ==================================================================== */
-/*      Extract vertices for a point.                                   */
-/* ==================================================================== */
-    else if( psShape->nSHPType == SHPT_POINT
-             || psShape->nSHPType == SHPT_POINTM
-             || psShape->nSHPType == SHPT_POINTZ )
+    /* ==================================================================== */
+    /*      Extract vertices for a point.                                   */
+    /* ==================================================================== */
+    else if (psShape->nSHPType == SHPT_POINT ||
+             psShape->nSHPType == SHPT_POINTM ||
+             psShape->nSHPType == SHPT_POINTZ)
     {
         psShape->nVertices = 1;
-        if( psShape->bFastModeReadObject )
+        if (psShape->bFastModeReadObject)
         {
             psShape->padfX = &(psShape->dfXMin);
             psShape->padfY = &(psShape->dfYMin);
@@ -2392,122 +2550,126 @@ SHPReadObject( SHPHandle psSHP, int hEntity ) {
         }
         else
         {
-            psShape->padfX = STATIC_CAST(double *, calloc(1,sizeof(double)));
-            psShape->padfY = STATIC_CAST(double *, calloc(1,sizeof(double)));
-            psShape->padfZ = STATIC_CAST(double *, calloc(1,sizeof(double)));
-            psShape->padfM = STATIC_CAST(double *, calloc(1,sizeof(double)));
+            psShape->padfX = STATIC_CAST(double *, calloc(1, sizeof(double)));
+            psShape->padfY = STATIC_CAST(double *, calloc(1, sizeof(double)));
+            psShape->padfZ = STATIC_CAST(double *, calloc(1, sizeof(double)));
+            psShape->padfM = STATIC_CAST(double *, calloc(1, sizeof(double)));
         }
 
-        if (20 + 8 + (( psShape->nSHPType == SHPT_POINTZ ) ? 8 : 0)> nEntitySize)
+        if (20 + 8 + ((psShape->nSHPType == SHPT_POINTZ) ? 8 : 0) > nEntitySize)
         {
             char szErrorMsg[160];
             snprintf(szErrorMsg, sizeof(szErrorMsg),
                      "Corrupted .shp file : shape %d : nEntitySize = %d",
                      hEntity, nEntitySize);
-            szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
-            psSHP->sHooks.Error( szErrorMsg );
+            szErrorMsg[sizeof(szErrorMsg) - 1] = '\0';
+            psSHP->sHooks.Error(szErrorMsg);
             SHPDestroyObject(psShape);
             return SHPLIB_NULLPTR;
         }
-        memcpy( psShape->padfX, psSHP->pabyRec + 12, 8 );
-        memcpy( psShape->padfY, psSHP->pabyRec + 20, 8 );
+        memcpy(psShape->padfX, psSHP->pabyRec + 12, 8);
+        memcpy(psShape->padfY, psSHP->pabyRec + 20, 8);
 
-        if( bBigEndian ) SwapWord( 8, psShape->padfX );
-        if( bBigEndian ) SwapWord( 8, psShape->padfY );
+        if (bBigEndian)
+            SwapWord(8, psShape->padfX);
+        if (bBigEndian)
+            SwapWord(8, psShape->padfY);
 
         int nOffset = 20 + 8;
 
-/* -------------------------------------------------------------------- */
-/*      If we have a Z coordinate, collect that now.                    */
-/* -------------------------------------------------------------------- */
-        if( psShape->nSHPType == SHPT_POINTZ )
+        /* -------------------------------------------------------------------- */
+        /*      If we have a Z coordinate, collect that now.                    */
+        /* -------------------------------------------------------------------- */
+        if (psShape->nSHPType == SHPT_POINTZ)
         {
-            memcpy( psShape->padfZ, psSHP->pabyRec + nOffset, 8 );
+            memcpy(psShape->padfZ, psSHP->pabyRec + nOffset, 8);
 
-            if( bBigEndian ) SwapWord( 8, psShape->padfZ );
+            if (bBigEndian)
+                SwapWord(8, psShape->padfZ);
 
             nOffset += 8;
         }
 
-/* -------------------------------------------------------------------- */
-/*      If we have a M measure value, then read it now.  We assume      */
-/*      that the measure can be present for any shape if the size is    */
-/*      big enough, but really it will only occur for the Z shapes      */
-/*      (options), and the M shapes.                                    */
-/* -------------------------------------------------------------------- */
-        if( nEntitySize >= nOffset + 8 )
+        /* -------------------------------------------------------------------- */
+        /*      If we have a M measure value, then read it now.  We assume      */
+        /*      that the measure can be present for any shape if the size is    */
+        /*      big enough, but really it will only occur for the Z shapes      */
+        /*      (options), and the M shapes.                                    */
+        /* -------------------------------------------------------------------- */
+        if (nEntitySize >= nOffset + 8)
         {
-            memcpy( psShape->padfM, psSHP->pabyRec + nOffset, 8 );
+            memcpy(psShape->padfM, psSHP->pabyRec + nOffset, 8);
 
-            if( bBigEndian ) SwapWord( 8, psShape->padfM );
+            if (bBigEndian)
+                SwapWord(8, psShape->padfM);
             psShape->bMeasureIsUsed = TRUE;
         }
 
-/* -------------------------------------------------------------------- */
-/*      Since no extents are supplied in the record, we will apply      */
-/*      them from the single vertex.                                    */
-/* -------------------------------------------------------------------- */
+        /* -------------------------------------------------------------------- */
+        /*      Since no extents are supplied in the record, we will apply      */
+        /*      them from the single vertex.                                    */
+        /* -------------------------------------------------------------------- */
         psShape->dfXMin = psShape->dfXMax = psShape->padfX[0];
         psShape->dfYMin = psShape->dfYMax = psShape->padfY[0];
         psShape->dfZMin = psShape->dfZMax = psShape->padfZ[0];
         psShape->dfMMin = psShape->dfMMax = psShape->padfM[0];
     }
 
-    return( psShape );
+    return (psShape);
 }
 
 /************************************************************************/
 /*                            SHPTypeName()                             */
 /************************************************************************/
 
-const char SHPAPI_CALL1(*)
-SHPTypeName( int nSHPType ) {
-    switch( nSHPType )
+const char SHPAPI_CALL1(*) SHPTypeName(int nSHPType)
+{
+    switch (nSHPType)
     {
-      case SHPT_NULL:
-        return "NullShape";
+        case SHPT_NULL:
+            return "NullShape";
 
-      case SHPT_POINT:
-        return "Point";
+        case SHPT_POINT:
+            return "Point";
 
-      case SHPT_ARC:
-        return "Arc";
+        case SHPT_ARC:
+            return "Arc";
 
-      case SHPT_POLYGON:
-        return "Polygon";
+        case SHPT_POLYGON:
+            return "Polygon";
 
-      case SHPT_MULTIPOINT:
-        return "MultiPoint";
+        case SHPT_MULTIPOINT:
+            return "MultiPoint";
 
-      case SHPT_POINTZ:
-        return "PointZ";
+        case SHPT_POINTZ:
+            return "PointZ";
 
-      case SHPT_ARCZ:
-        return "ArcZ";
+        case SHPT_ARCZ:
+            return "ArcZ";
 
-      case SHPT_POLYGONZ:
-        return "PolygonZ";
+        case SHPT_POLYGONZ:
+            return "PolygonZ";
 
-      case SHPT_MULTIPOINTZ:
-        return "MultiPointZ";
+        case SHPT_MULTIPOINTZ:
+            return "MultiPointZ";
 
-      case SHPT_POINTM:
-        return "PointM";
+        case SHPT_POINTM:
+            return "PointM";
 
-      case SHPT_ARCM:
-        return "ArcM";
+        case SHPT_ARCM:
+            return "ArcM";
 
-      case SHPT_POLYGONM:
-        return "PolygonM";
+        case SHPT_POLYGONM:
+            return "PolygonM";
 
-      case SHPT_MULTIPOINTM:
-        return "MultiPointM";
+        case SHPT_MULTIPOINTM:
+            return "MultiPointM";
 
-      case SHPT_MULTIPATCH:
-        return "MultiPatch";
+        case SHPT_MULTIPATCH:
+            return "MultiPatch";
 
-      default:
-        return "UnknownShapeType";
+        default:
+            return "UnknownShapeType";
     }
 }
 
@@ -2515,30 +2677,30 @@ SHPTypeName( int nSHPType ) {
 /*                          SHPPartTypeName()                           */
 /************************************************************************/
 
-const char SHPAPI_CALL1(*)
-SHPPartTypeName( int nPartType ) {
-    switch( nPartType )
+const char SHPAPI_CALL1(*) SHPPartTypeName(int nPartType)
+{
+    switch (nPartType)
     {
-      case SHPP_TRISTRIP:
-        return "TriangleStrip";
+        case SHPP_TRISTRIP:
+            return "TriangleStrip";
 
-      case SHPP_TRIFAN:
-        return "TriangleFan";
+        case SHPP_TRIFAN:
+            return "TriangleFan";
 
-      case SHPP_OUTERRING:
-        return "OuterRing";
+        case SHPP_OUTERRING:
+            return "OuterRing";
 
-      case SHPP_INNERRING:
-        return "InnerRing";
+        case SHPP_INNERRING:
+            return "InnerRing";
 
-      case SHPP_FIRSTRING:
-        return "FirstRing";
+        case SHPP_FIRSTRING:
+            return "FirstRing";
 
-      case SHPP_RING:
-        return "Ring";
+        case SHPP_RING:
+            return "Ring";
 
-      default:
-        return "UnknownPartType";
+        default:
+            return "UnknownPartType";
     }
 }
 
@@ -2546,44 +2708,45 @@ SHPPartTypeName( int nPartType ) {
 /*                          SHPDestroyObject()                          */
 /************************************************************************/
 
-void SHPAPI_CALL
-SHPDestroyObject( SHPObject * psShape ) {
-    if( psShape == SHPLIB_NULLPTR )
+void SHPAPI_CALL SHPDestroyObject(SHPObject *psShape)
+{
+    if (psShape == SHPLIB_NULLPTR)
         return;
 
-    if( psShape->bFastModeReadObject )
+    if (psShape->bFastModeReadObject)
     {
         psShape->bFastModeReadObject = FALSE;
         return;
     }
 
-    if( psShape->padfX != SHPLIB_NULLPTR )
-        free( psShape->padfX );
-    if( psShape->padfY != SHPLIB_NULLPTR )
-        free( psShape->padfY );
-    if( psShape->padfZ != SHPLIB_NULLPTR )
-        free( psShape->padfZ );
-    if( psShape->padfM != SHPLIB_NULLPTR )
-        free( psShape->padfM );
+    if (psShape->padfX != SHPLIB_NULLPTR)
+        free(psShape->padfX);
+    if (psShape->padfY != SHPLIB_NULLPTR)
+        free(psShape->padfY);
+    if (psShape->padfZ != SHPLIB_NULLPTR)
+        free(psShape->padfZ);
+    if (psShape->padfM != SHPLIB_NULLPTR)
+        free(psShape->padfM);
 
-    if( psShape->panPartStart != SHPLIB_NULLPTR )
-        free( psShape->panPartStart );
-    if( psShape->panPartType != SHPLIB_NULLPTR )
-        free( psShape->panPartType );
+    if (psShape->panPartStart != SHPLIB_NULLPTR)
+        free(psShape->panPartStart);
+    if (psShape->panPartType != SHPLIB_NULLPTR)
+        free(psShape->panPartType);
 
-    free( psShape );
+    free(psShape);
 }
 
 /************************************************************************/
 /*                       SHPGetPartVertexCount()                        */
 /************************************************************************/
 
-static int SHPGetPartVertexCount( const SHPObject * psObject, int iPart )
+static int SHPGetPartVertexCount(const SHPObject *psObject, int iPart)
 {
-    if( iPart == psObject->nParts-1 )
+    if (iPart == psObject->nParts - 1)
         return psObject->nVertices - psObject->panPartStart[iPart];
     else
-        return psObject->panPartStart[iPart+1] - psObject->panPartStart[iPart];
+        return psObject->panPartStart[iPart + 1] -
+               psObject->panPartStart[iPart];
 }
 
 /************************************************************************/
@@ -2591,32 +2754,32 @@ static int SHPGetPartVertexCount( const SHPObject * psObject, int iPart )
 /************************************************************************/
 
 /* Return -1 in case of ambiguity */
-static int SHPRewindIsInnerRing( const SHPObject * psObject,
-                                 int iOpRing,
-                                 double dfTestX, double dfTestY ) {
-/* -------------------------------------------------------------------- */
-/*      Determine if this ring is an inner ring or an outer ring        */
-/*      relative to all the other rings.  For now we assume the         */
-/*      first ring is outer and all others are inner, but eventually    */
-/*      we need to fix this to handle multiple island polygons and      */
-/*      unordered sets of rings.                                        */
-/*                                                                      */
-/* -------------------------------------------------------------------- */
+static int SHPRewindIsInnerRing(const SHPObject *psObject, int iOpRing,
+                                double dfTestX, double dfTestY)
+{
+    /* -------------------------------------------------------------------- */
+    /*      Determine if this ring is an inner ring or an outer ring        */
+    /*      relative to all the other rings.  For now we assume the         */
+    /*      first ring is outer and all others are inner, but eventually    */
+    /*      we need to fix this to handle multiple island polygons and      */
+    /*      unordered sets of rings.                                        */
+    /*                                                                      */
+    /* -------------------------------------------------------------------- */
 
     bool bInner = false;
-    for( int iCheckRing = 0; iCheckRing < psObject->nParts; iCheckRing++ )
+    for (int iCheckRing = 0; iCheckRing < psObject->nParts; iCheckRing++)
     {
-        if( iCheckRing == iOpRing )
+        if (iCheckRing == iOpRing)
             continue;
 
         const int nVertStartCheck = psObject->panPartStart[iCheckRing];
         const int nVertCountCheck = SHPGetPartVertexCount(psObject, iCheckRing);
 
-        for( int iEdge = 0; iEdge < nVertCountCheck; iEdge++ )
+        for (int iEdge = 0; iEdge < nVertCountCheck; iEdge++)
         {
             int iNext;
-            if( iEdge < nVertCountCheck-1 )
-                iNext = iEdge+1;
+            if (iEdge < nVertCountCheck - 1)
+                iNext = iEdge + 1;
             else
                 iNext = 0;
 
@@ -2625,28 +2788,28 @@ static int SHPRewindIsInnerRing( const SHPObject * psObject,
              * the test point (dfTestY,dfTestY)
              * The rule #1 also excludes edges colinear with the ray.
              */
-            if ( ( psObject->padfY[iEdge+nVertStartCheck] < dfTestY
-                    && dfTestY <= psObject->padfY[iNext+nVertStartCheck] )
-                    || ( psObject->padfY[iNext+nVertStartCheck] < dfTestY
-                        && dfTestY <= psObject->padfY[iEdge+nVertStartCheck] ) )
+            if ((psObject->padfY[iEdge + nVertStartCheck] < dfTestY &&
+                 dfTestY <= psObject->padfY[iNext + nVertStartCheck]) ||
+                (psObject->padfY[iNext + nVertStartCheck] < dfTestY &&
+                 dfTestY <= psObject->padfY[iEdge + nVertStartCheck]))
             {
                 /* Rule #2:
                  * Test if edge-ray intersection is on the right from the
                  * test point (dfTestY,dfTestY)
                  */
                 const double intersect =
-                    ( psObject->padfX[iEdge+nVertStartCheck]
-                        + ( dfTestY - psObject->padfY[iEdge+nVertStartCheck] )
-                        / ( psObject->padfY[iNext+nVertStartCheck] -
-                            psObject->padfY[iEdge+nVertStartCheck] )
-                        * ( psObject->padfX[iNext+nVertStartCheck] -
-                            psObject->padfX[iEdge+nVertStartCheck] ) );
+                    (psObject->padfX[iEdge + nVertStartCheck] +
+                     (dfTestY - psObject->padfY[iEdge + nVertStartCheck]) /
+                         (psObject->padfY[iNext + nVertStartCheck] -
+                          psObject->padfY[iEdge + nVertStartCheck]) *
+                         (psObject->padfX[iNext + nVertStartCheck] -
+                          psObject->padfX[iEdge + nVertStartCheck]));
 
                 if (intersect < dfTestX)
                 {
                     bInner = !bInner;
                 }
-                else if( intersect == dfTestX )
+                else if (intersect == dfTestX)
                 {
                     /* Potential shared edge */
                     return -1;
@@ -2664,26 +2827,24 @@ static int SHPRewindIsInnerRing( const SHPObject * psObject,
 /*      specification.                                                  */
 /************************************************************************/
 
-int SHPAPI_CALL
-SHPRewindObject( CPL_UNUSED SHPHandle hSHP,
-                 SHPObject * psObject )
+int SHPAPI_CALL SHPRewindObject(CPL_UNUSED SHPHandle hSHP, SHPObject *psObject)
 {
-/* -------------------------------------------------------------------- */
-/*      Do nothing if this is not a polygon object.                     */
-/* -------------------------------------------------------------------- */
-    if( psObject->nSHPType != SHPT_POLYGON
-        && psObject->nSHPType != SHPT_POLYGONZ
-        && psObject->nSHPType != SHPT_POLYGONM )
+    /* -------------------------------------------------------------------- */
+    /*      Do nothing if this is not a polygon object.                     */
+    /* -------------------------------------------------------------------- */
+    if (psObject->nSHPType != SHPT_POLYGON &&
+        psObject->nSHPType != SHPT_POLYGONZ &&
+        psObject->nSHPType != SHPT_POLYGONM)
         return 0;
 
-    if( psObject->nVertices == 0 || psObject->nParts == 0 )
+    if (psObject->nVertices == 0 || psObject->nParts == 0)
         return 0;
 
-/* -------------------------------------------------------------------- */
-/*      Process each of the rings.                                      */
-/* -------------------------------------------------------------------- */
-    int  bAltered = 0;
-    for( int iOpRing = 0; iOpRing < psObject->nParts; iOpRing++ )
+    /* -------------------------------------------------------------------- */
+    /*      Process each of the rings.                                      */
+    /* -------------------------------------------------------------------- */
+    int bAltered = 0;
+    for (int iOpRing = 0; iOpRing < psObject->nParts; iOpRing++)
     {
         const int nVertStart = psObject->panPartStart[iOpRing];
         const int nVertCount = SHPGetPartVertexCount(psObject, iOpRing);
@@ -2692,80 +2853,81 @@ SHPRewindObject( CPL_UNUSED SHPHandle hSHP,
             continue;
 
         int bInner = FALSE;
-        for( int iVert = nVertStart; iVert + 1 < nVertStart + nVertCount; ++iVert )
+        for (int iVert = nVertStart; iVert + 1 < nVertStart + nVertCount;
+             ++iVert)
         {
             /* Use point in the middle of segment to avoid testing
             * common points of rings.
             */
-            const double dfTestX = ( psObject->padfX[iVert] +
-                                     psObject->padfX[iVert + 1] ) / 2;
-            const double dfTestY = ( psObject->padfY[iVert] +
-                                     psObject->padfY[iVert + 1] ) / 2;
+            const double dfTestX =
+                (psObject->padfX[iVert] + psObject->padfX[iVert + 1]) / 2;
+            const double dfTestY =
+                (psObject->padfY[iVert] + psObject->padfY[iVert + 1]) / 2;
 
             bInner = SHPRewindIsInnerRing(psObject, iOpRing, dfTestX, dfTestY);
-            if( bInner >= 0 )
+            if (bInner >= 0)
                 break;
         }
-        if( bInner < 0 )
+        if (bInner < 0)
         {
             /* Completely degenerate case. Do not bother touching order. */
             continue;
         }
 
-/* -------------------------------------------------------------------- */
-/*      Determine the current order of this ring so we will know if     */
-/*      it has to be reversed.                                          */
-/* -------------------------------------------------------------------- */
+        /* -------------------------------------------------------------------- */
+        /*      Determine the current order of this ring so we will know if     */
+        /*      it has to be reversed.                                          */
+        /* -------------------------------------------------------------------- */
 
         double dfSum = psObject->padfX[nVertStart] *
-                        (psObject->padfY[nVertStart+1] -
-                         psObject->padfY[nVertStart+nVertCount-1]);
+                       (psObject->padfY[nVertStart + 1] -
+                        psObject->padfY[nVertStart + nVertCount - 1]);
         int iVert = nVertStart + 1;
-        for( ; iVert < nVertStart+nVertCount-1; iVert++ )
+        for (; iVert < nVertStart + nVertCount - 1; iVert++)
         {
-            dfSum += psObject->padfX[iVert] * (psObject->padfY[iVert+1] -
-                                               psObject->padfY[iVert-1]);
+            dfSum += psObject->padfX[iVert] *
+                     (psObject->padfY[iVert + 1] - psObject->padfY[iVert - 1]);
         }
 
-        dfSum += psObject->padfX[iVert] * (psObject->padfY[nVertStart] -
-                                           psObject->padfY[iVert-1]);
+        dfSum += psObject->padfX[iVert] *
+                 (psObject->padfY[nVertStart] - psObject->padfY[iVert - 1]);
 
-/* -------------------------------------------------------------------- */
-/*      Reverse if necessary.                                           */
-/* -------------------------------------------------------------------- */
-        if( (dfSum < 0.0 && bInner) || (dfSum > 0.0 && !bInner) )
+        /* -------------------------------------------------------------------- */
+        /*      Reverse if necessary.                                           */
+        /* -------------------------------------------------------------------- */
+        if ((dfSum < 0.0 && bInner) || (dfSum > 0.0 && !bInner))
         {
             bAltered++;
-            for( int i = 0; i < nVertCount/2; i++ )
+            for (int i = 0; i < nVertCount / 2; i++)
             {
                 /* Swap X */
-                double dfSaved = psObject->padfX[nVertStart+i];
-                psObject->padfX[nVertStart+i] =
-                    psObject->padfX[nVertStart+nVertCount-i-1];
-                psObject->padfX[nVertStart+nVertCount-i-1] = dfSaved;
+                double dfSaved = psObject->padfX[nVertStart + i];
+                psObject->padfX[nVertStart + i] =
+                    psObject->padfX[nVertStart + nVertCount - i - 1];
+                psObject->padfX[nVertStart + nVertCount - i - 1] = dfSaved;
 
                 /* Swap Y */
-                dfSaved = psObject->padfY[nVertStart+i];
-                psObject->padfY[nVertStart+i] =
-                    psObject->padfY[nVertStart+nVertCount-i-1];
-                psObject->padfY[nVertStart+nVertCount-i-1] = dfSaved;
+                dfSaved = psObject->padfY[nVertStart + i];
+                psObject->padfY[nVertStart + i] =
+                    psObject->padfY[nVertStart + nVertCount - i - 1];
+                psObject->padfY[nVertStart + nVertCount - i - 1] = dfSaved;
 
                 /* Swap Z */
-                if( psObject->padfZ )
+                if (psObject->padfZ)
                 {
-                    dfSaved = psObject->padfZ[nVertStart+i];
-                    psObject->padfZ[nVertStart+i] =
-                        psObject->padfZ[nVertStart+nVertCount-i-1];
-                    psObject->padfZ[nVertStart+nVertCount-i-1] = dfSaved;
+                    dfSaved = psObject->padfZ[nVertStart + i];
+                    psObject->padfZ[nVertStart + i] =
+                        psObject->padfZ[nVertStart + nVertCount - i - 1];
+                    psObject->padfZ[nVertStart + nVertCount - i - 1] = dfSaved;
                 }
 
                 /* Swap M */
-                if( psObject->padfM )
+                if (psObject->padfM)
                 {
-                    dfSaved = psObject->padfM[nVertStart+i];
-                    psObject->padfM[nVertStart+i] =
-                        psObject->padfM[nVertStart+nVertCount-i-1];
-                    psObject->padfM[nVertStart+nVertCount-i-1] = dfSaved;
+                    dfSaved = psObject->padfM[nVertStart + i];
+                    psObject->padfM[nVertStart + i] =
+                        psObject->padfM[nVertStart + nVertCount - i - 1];
+                    psObject->padfM[nVertStart + nVertCount - i - 1] = dfSaved;
                 }
             }
         }

--- a/shprewind.c
+++ b/shprewind.c
@@ -40,62 +40,63 @@
 #include <stdlib.h>
 #include "shapefil.h"
 
-int main( int argc, char ** argv ) {
-/* -------------------------------------------------------------------- */
-/*      Display a usage message.                                        */
-/* -------------------------------------------------------------------- */
-    if( argc != 3 )
+int main(int argc, char **argv)
+{
+    /* -------------------------------------------------------------------- */
+    /*      Display a usage message.                                        */
+    /* -------------------------------------------------------------------- */
+    if (argc != 3)
     {
-	printf( "shprewind in_shp_file out_shp_file\n" );
-	exit( 1 );
+        printf("shprewind in_shp_file out_shp_file\n");
+        exit(1);
     }
 
-/* -------------------------------------------------------------------- */
-/*      Open the passed shapefile.                                      */
-/* -------------------------------------------------------------------- */
-    SHPHandle hSHP = SHPOpen( argv[1], "rb" );
+    /* -------------------------------------------------------------------- */
+    /*      Open the passed shapefile.                                      */
+    /* -------------------------------------------------------------------- */
+    SHPHandle hSHP = SHPOpen(argv[1], "rb");
 
-    if( hSHP == NULL )
+    if (hSHP == NULL)
     {
-	printf( "Unable to open:%s\n", argv[1] );
-	exit( 1 );
+        printf("Unable to open:%s\n", argv[1]);
+        exit(1);
     }
 
     int nShapeType;
     int nEntities;
     double adfMinBound[4];
     double adfMaxBound[4];
-    SHPGetInfo( hSHP, &nEntities, &nShapeType, adfMinBound, adfMaxBound );
+    SHPGetInfo(hSHP, &nEntities, &nShapeType, adfMinBound, adfMaxBound);
 
-/* -------------------------------------------------------------------- */
-/*      Create output shapefile.                                        */
-/* -------------------------------------------------------------------- */
-    SHPHandle hSHPOut = SHPCreate( argv[2], nShapeType );
+    /* -------------------------------------------------------------------- */
+    /*      Create output shapefile.                                        */
+    /* -------------------------------------------------------------------- */
+    SHPHandle hSHPOut = SHPCreate(argv[2], nShapeType);
 
-    if( hSHPOut == NULL )
+    if (hSHPOut == NULL)
     {
-	printf( "Unable to create:%s\n", argv[2] );
-	exit( 1 );
+        printf("Unable to create:%s\n", argv[2]);
+        exit(1);
     }
 
-/* -------------------------------------------------------------------- */
-/*	Skim over the list of shapes, printing all the vertices.	*/
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*	Skim over the list of shapes, printing all the vertices.	*/
+    /* -------------------------------------------------------------------- */
     int nInvalidCount = 0;
 
-    for( int i = 0; i < nEntities; i++ )
+    for (int i = 0; i < nEntities; i++)
     {
-        SHPObject *psShape = SHPReadObject( hSHP, i );
-        if( SHPRewindObject( hSHP, psShape ) )
+        SHPObject *psShape = SHPReadObject(hSHP, i);
+        if (SHPRewindObject(hSHP, psShape))
             nInvalidCount++;
-        SHPWriteObject( hSHPOut, -1, psShape );
-        SHPDestroyObject( psShape );
+        SHPWriteObject(hSHPOut, -1, psShape);
+        SHPDestroyObject(psShape);
     }
 
-    SHPClose( hSHP );
-    SHPClose( hSHPOut );
+    SHPClose(hSHP);
+    SHPClose(hSHPOut);
 
-    printf( "%d objects rewound.\n", nInvalidCount );
+    printf("%d objects rewound.\n", nInvalidCount);
 
-    exit( 0 );
+    exit(0);
 }

--- a/shptest.c
+++ b/shptest.c
@@ -48,30 +48,29 @@ SHP_CVSID("$Id$")
 /*      Write a small point file.                                       */
 /************************************************************************/
 
-static void Test_WritePoints( int nSHPType, const char *pszFilename )
+static void Test_WritePoints(int nSHPType, const char *pszFilename)
 
 {
-    SHPHandle hSHPHandle = SHPCreate( pszFilename, nSHPType );
+    SHPHandle hSHPHandle = SHPCreate(pszFilename, nSHPType);
 
     double x = 1.0;
     double y = 2.0;
     double z = 3.0;
     double m = 4.0;
-    SHPObject *psShape = SHPCreateObject( nSHPType, -1, 0, NULL, NULL,
-                               1, &x, &y, &z, &m );
-    SHPWriteObject( hSHPHandle, -1, psShape );
-    SHPDestroyObject( psShape );
+    SHPObject *psShape =
+        SHPCreateObject(nSHPType, -1, 0, NULL, NULL, 1, &x, &y, &z, &m);
+    SHPWriteObject(hSHPHandle, -1, psShape);
+    SHPDestroyObject(psShape);
 
     x = 10.0;
     y = 20.0;
     z = 30.0;
     m = 40.0;
-    psShape = SHPCreateObject( nSHPType, -1, 0, NULL, NULL,
-                               1, &x, &y, &z, &m );
-    SHPWriteObject( hSHPHandle, -1, psShape );
-    SHPDestroyObject( psShape );
+    psShape = SHPCreateObject(nSHPType, -1, 0, NULL, NULL, 1, &x, &y, &z, &m);
+    SHPWriteObject(hSHPHandle, -1, psShape);
+    SHPDestroyObject(psShape);
 
-    SHPClose( hSHPHandle );
+    SHPClose(hSHPHandle);
 }
 
 /************************************************************************/
@@ -80,7 +79,7 @@ static void Test_WritePoints( int nSHPType, const char *pszFilename )
 /*      Write a small multipoint file.                                  */
 /************************************************************************/
 
-static void Test_WriteMultiPoints( int nSHPType, const char *pszFilename )
+static void Test_WriteMultiPoints(int nSHPType, const char *pszFilename)
 
 {
     double x[4];
@@ -88,11 +87,11 @@ static void Test_WriteMultiPoints( int nSHPType, const char *pszFilename )
     double z[4];
     double m[4];
 
-    SHPHandle hSHPHandle = SHPCreate( pszFilename, nSHPType );
+    SHPHandle hSHPHandle = SHPCreate(pszFilename, nSHPType);
 
-    for( int iShape = 0; iShape < 3; iShape++ )
+    for (int iShape = 0; iShape < 3; iShape++)
     {
-        for( int i = 0; i < 4; i++ )
+        for (int i = 0; i < 4; i++)
         {
             x[i] = iShape * 10 + i + 1.15;
             y[i] = iShape * 10 + i + 2.25;
@@ -100,13 +99,13 @@ static void Test_WriteMultiPoints( int nSHPType, const char *pszFilename )
             m[i] = iShape * 10 + i + 4.45;
         }
 
-        SHPObject *psShape = SHPCreateObject( nSHPType, -1, 0, NULL, NULL,
-                                   4, x, y, z, m );
-        SHPWriteObject( hSHPHandle, -1, psShape );
-        SHPDestroyObject( psShape );
+        SHPObject *psShape =
+            SHPCreateObject(nSHPType, -1, 0, NULL, NULL, 4, x, y, z, m);
+        SHPWriteObject(hSHPHandle, -1, psShape);
+        SHPDestroyObject(psShape);
     }
 
-    SHPClose( hSHPHandle );
+    SHPClose(hSHPHandle);
 }
 
 /************************************************************************/
@@ -115,14 +114,14 @@ static void Test_WriteMultiPoints( int nSHPType, const char *pszFilename )
 /*      Write a small arc or polygon file.                              */
 /************************************************************************/
 
-static void Test_WriteArcPoly( int nSHPType, const char *pszFilename )
+static void Test_WriteArcPoly(int nSHPType, const char *pszFilename)
 
 {
-    SHPHandle hSHPHandle = SHPCreate( pszFilename, nSHPType );
+    SHPHandle hSHPHandle = SHPCreate(pszFilename, nSHPType);
 
     int anPartType[100];
     int *panPartType;
-    if( nSHPType == SHPT_MULTIPATCH )
+    if (nSHPType == SHPT_MULTIPATCH)
         panPartType = anPartType;
     else
         panPartType = NULL;
@@ -132,35 +131,35 @@ static void Test_WriteArcPoly( int nSHPType, const char *pszFilename )
     double z[100];
     double m[100];
 
-    for( int iShape = 0; iShape < 3; iShape++ )
+    for (int iShape = 0; iShape < 3; iShape++)
     {
         x[0] = 1.0;
-        y[0] = 1.0+iShape*3;
+        y[0] = 1.0 + iShape * 3;
         x[1] = 2.0;
-        y[1] = 1.0+iShape*3;
+        y[1] = 1.0 + iShape * 3;
         x[2] = 2.0;
-        y[2] = 2.0+iShape*3;
+        y[2] = 2.0 + iShape * 3;
         x[3] = 1.0;
-        y[3] = 2.0+iShape*3;
+        y[3] = 2.0 + iShape * 3;
         x[4] = 1.0;
-        y[4] = 1.0+iShape*3;
+        y[4] = 1.0 + iShape * 3;
 
-        for( int i = 0; i < 5; i++ )
+        for (int i = 0; i < 5; i++)
         {
             z[i] = iShape * 10 + i + 3.35;
             m[i] = iShape * 10 + i + 4.45;
         }
 
-        SHPObject *psShape = SHPCreateObject( nSHPType, -1, 0, NULL, NULL,
-                                   5, x, y, z, m );
-        SHPWriteObject( hSHPHandle, -1, psShape );
-        SHPDestroyObject( psShape );
+        SHPObject *psShape =
+            SHPCreateObject(nSHPType, -1, 0, NULL, NULL, 5, x, y, z, m);
+        SHPWriteObject(hSHPHandle, -1, psShape);
+        SHPDestroyObject(psShape);
     }
 
-/* -------------------------------------------------------------------- */
-/*      Do a multi part polygon (shape).  We close it, and have two     */
-/*      inner rings.                                                    */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Do a multi part polygon (shape).  We close it, and have two     */
+    /*      inner rings.                                                    */
+    /* -------------------------------------------------------------------- */
     x[0] = 0.0;
     y[0] = 0.0;
     x[1] = 0;
@@ -194,10 +193,10 @@ static void Test_WriteArcPoly( int nSHPType, const char *pszFilename )
     x[14] = 60;
     y[14] = 20;
 
-    for( int i = 0; i < 15; i++ )
+    for (int i = 0; i < 15; i++)
     {
         z[i] = i;
-        m[i] = i*2;
+        m[i] = i * 2;
     }
 
     int anPartStart[100];
@@ -209,74 +208,74 @@ static void Test_WriteArcPoly( int nSHPType, const char *pszFilename )
     anPartType[1] = SHPP_INNERRING;
     anPartType[2] = SHPP_INNERRING;
 
-    SHPObject *psShape = SHPCreateObject( nSHPType, -1, 3, anPartStart, panPartType,
-                               15, x, y, z, m );
-    SHPWriteObject( hSHPHandle, -1, psShape );
-    SHPDestroyObject( psShape );
+    SHPObject *psShape = SHPCreateObject(nSHPType, -1, 3, anPartStart,
+                                         panPartType, 15, x, y, z, m);
+    SHPWriteObject(hSHPHandle, -1, psShape);
+    SHPDestroyObject(psShape);
 
-
-    SHPClose( hSHPHandle );
+    SHPClose(hSHPHandle);
 }
 
 /************************************************************************/
 /*                                main()                                */
 /************************************************************************/
-int main( int argc, char ** argv ) {
-/* -------------------------------------------------------------------- */
-/*      Display a usage message.                                        */
-/* -------------------------------------------------------------------- */
-    if( argc != 2 )
+int main(int argc, char **argv)
+{
+    /* -------------------------------------------------------------------- */
+    /*      Display a usage message.                                        */
+    /* -------------------------------------------------------------------- */
+    if (argc != 2)
     {
-	printf( "shptest test_number\n" );
-	exit( 1 );
+        printf("shptest test_number\n");
+        exit(1);
     }
 
-/* -------------------------------------------------------------------- */
-/*      Figure out which test to run.                                   */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Figure out which test to run.                                   */
+    /* -------------------------------------------------------------------- */
 
-    if( atoi(argv[1]) == 0 )
-        Test_WritePoints( SHPT_NULL, "test0.shp" );
+    if (atoi(argv[1]) == 0)
+        Test_WritePoints(SHPT_NULL, "test0.shp");
 
-    else if( atoi(argv[1]) == 1 )
-        Test_WritePoints( SHPT_POINT, "test1.shp" );
-    else if( atoi(argv[1]) == 2 )
-        Test_WritePoints( SHPT_POINTZ, "test2.shp" );
-    else if( atoi(argv[1]) == 3 )
-        Test_WritePoints( SHPT_POINTM, "test3.shp" );
+    else if (atoi(argv[1]) == 1)
+        Test_WritePoints(SHPT_POINT, "test1.shp");
+    else if (atoi(argv[1]) == 2)
+        Test_WritePoints(SHPT_POINTZ, "test2.shp");
+    else if (atoi(argv[1]) == 3)
+        Test_WritePoints(SHPT_POINTM, "test3.shp");
 
-    else if( atoi(argv[1]) == 4 )
-        Test_WriteMultiPoints( SHPT_MULTIPOINT, "test4.shp" );
-    else if( atoi(argv[1]) == 5 )
-        Test_WriteMultiPoints( SHPT_MULTIPOINTZ, "test5.shp" );
-    else if( atoi(argv[1]) == 6 )
-        Test_WriteMultiPoints( SHPT_MULTIPOINTM, "test6.shp" );
+    else if (atoi(argv[1]) == 4)
+        Test_WriteMultiPoints(SHPT_MULTIPOINT, "test4.shp");
+    else if (atoi(argv[1]) == 5)
+        Test_WriteMultiPoints(SHPT_MULTIPOINTZ, "test5.shp");
+    else if (atoi(argv[1]) == 6)
+        Test_WriteMultiPoints(SHPT_MULTIPOINTM, "test6.shp");
 
-    else if( atoi(argv[1]) == 7 )
-        Test_WriteArcPoly( SHPT_ARC, "test7.shp" );
-    else if( atoi(argv[1]) == 8 )
-        Test_WriteArcPoly( SHPT_ARCZ, "test8.shp" );
-    else if( atoi(argv[1]) == 9 )
-        Test_WriteArcPoly( SHPT_ARCM, "test9.shp" );
+    else if (atoi(argv[1]) == 7)
+        Test_WriteArcPoly(SHPT_ARC, "test7.shp");
+    else if (atoi(argv[1]) == 8)
+        Test_WriteArcPoly(SHPT_ARCZ, "test8.shp");
+    else if (atoi(argv[1]) == 9)
+        Test_WriteArcPoly(SHPT_ARCM, "test9.shp");
 
-    else if( atoi(argv[1]) == 10 )
-        Test_WriteArcPoly( SHPT_POLYGON, "test10.shp" );
-    else if( atoi(argv[1]) == 11 )
-        Test_WriteArcPoly( SHPT_POLYGONZ, "test11.shp" );
-    else if( atoi(argv[1]) == 12 )
-        Test_WriteArcPoly( SHPT_POLYGONM, "test12.shp" );
+    else if (atoi(argv[1]) == 10)
+        Test_WriteArcPoly(SHPT_POLYGON, "test10.shp");
+    else if (atoi(argv[1]) == 11)
+        Test_WriteArcPoly(SHPT_POLYGONZ, "test11.shp");
+    else if (atoi(argv[1]) == 12)
+        Test_WriteArcPoly(SHPT_POLYGONM, "test12.shp");
 
-    else if( atoi(argv[1]) == 13 )
-        Test_WriteArcPoly( SHPT_MULTIPATCH, "test13.shp" );
+    else if (atoi(argv[1]) == 13)
+        Test_WriteArcPoly(SHPT_MULTIPATCH, "test13.shp");
     else
     {
-        printf( "Test `%s' not recognised.\n", argv[1] );
-        exit( 10 );
+        printf("Test `%s' not recognised.\n", argv[1]);
+        exit(10);
     }
 
 #ifdef USE_DBMALLOC
     malloc_dump(2);
 #endif
 
-    exit( 0 );
+    exit(0);
 }

--- a/shptree.c
+++ b/shptree.c
@@ -51,8 +51,8 @@
 SHP_CVSID("$Id$")
 
 #ifndef TRUE
-#  define TRUE 1
-#  define FALSE 0
+#define TRUE 1
+#define FALSE 0
 #endif
 
 static bool bBigEndian = false;
@@ -65,17 +65,17 @@ static bool bBigEndian = false;
 /*      up the tree.                                                    */
 /* -------------------------------------------------------------------- */
 
-#define SHP_SPLIT_RATIO	0.55
+#define SHP_SPLIT_RATIO 0.55
 
 #ifdef __cplusplus
-#define STATIC_CAST(type,x) static_cast<type>(x)
-#define REINTERPRET_CAST(type,x) reinterpret_cast<type>(x)
-#define CONST_CAST(type,x) const_cast<type>(x)
+#define STATIC_CAST(type, x) static_cast<type>(x)
+#define REINTERPRET_CAST(type, x) reinterpret_cast<type>(x)
+#define CONST_CAST(type, x) const_cast<type>(x)
 #define SHPLIB_NULLPTR nullptr
 #else
-#define STATIC_CAST(type,x) ((type)(x))
-#define REINTERPRET_CAST(type,x) ((type)(x))
-#define CONST_CAST(type,x) ((type)(x))
+#define STATIC_CAST(type, x) ((type)(x))
+#define REINTERPRET_CAST(type, x) ((type)(x))
+#define CONST_CAST(type, x) ((type)(x))
 #define SHPLIB_NULLPTR NULL
 #endif
 
@@ -85,14 +85,14 @@ static bool bBigEndian = false;
 /*      Initialize a tree node.                                         */
 /************************************************************************/
 
-static SHPTreeNode *SHPTreeNodeCreate( double * padfBoundsMin,
-                                       double * padfBoundsMax )
+static SHPTreeNode *SHPTreeNodeCreate(double *padfBoundsMin,
+                                      double *padfBoundsMax)
 
 {
-    SHPTreeNode	*psTreeNode;
+    SHPTreeNode *psTreeNode;
 
     psTreeNode = STATIC_CAST(SHPTreeNode *, malloc(sizeof(SHPTreeNode)));
-    if( SHPLIB_NULLPTR == psTreeNode )
+    if (SHPLIB_NULLPTR == psTreeNode)
         return SHPLIB_NULLPTR;
 
     psTreeNode->nShapeCount = 0;
@@ -101,35 +101,34 @@ static SHPTreeNode *SHPTreeNodeCreate( double * padfBoundsMin,
 
     psTreeNode->nSubNodes = 0;
 
-    if( padfBoundsMin != SHPLIB_NULLPTR )
-        memcpy( psTreeNode->adfBoundsMin, padfBoundsMin, sizeof(double) * 4 );
+    if (padfBoundsMin != SHPLIB_NULLPTR)
+        memcpy(psTreeNode->adfBoundsMin, padfBoundsMin, sizeof(double) * 4);
 
-    if( padfBoundsMax != SHPLIB_NULLPTR )
-        memcpy( psTreeNode->adfBoundsMax, padfBoundsMax, sizeof(double) * 4 );
+    if (padfBoundsMax != SHPLIB_NULLPTR)
+        memcpy(psTreeNode->adfBoundsMax, padfBoundsMax, sizeof(double) * 4);
 
     return psTreeNode;
 }
-
 
 /************************************************************************/
 /*                           SHPCreateTree()                            */
 /************************************************************************/
 
 SHPTree SHPAPI_CALL1(*)
-    SHPCreateTree( SHPHandle hSHP, int nDimension, int nMaxDepth,
-                   double *padfBoundsMin, double *padfBoundsMax )
+    SHPCreateTree(SHPHandle hSHP, int nDimension, int nMaxDepth,
+                  double *padfBoundsMin, double *padfBoundsMax)
 
 {
-    SHPTree	*psTree;
+    SHPTree *psTree;
 
-    if( padfBoundsMin == SHPLIB_NULLPTR && hSHP == SHPLIB_NULLPTR )
+    if (padfBoundsMin == SHPLIB_NULLPTR && hSHP == SHPLIB_NULLPTR)
         return SHPLIB_NULLPTR;
 
-/* -------------------------------------------------------------------- */
-/*      Allocate the tree object                                        */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Allocate the tree object                                        */
+    /* -------------------------------------------------------------------- */
     psTree = STATIC_CAST(SHPTree *, malloc(sizeof(SHPTree)));
-    if( SHPLIB_NULLPTR == psTree )
+    if (SHPLIB_NULLPTR == psTree)
     {
         return SHPLIB_NULLPTR;
     }
@@ -139,84 +138,85 @@ SHPTree SHPAPI_CALL1(*)
     psTree->nDimension = nDimension;
     psTree->nTotalCount = 0;
 
-/* -------------------------------------------------------------------- */
-/*      If no max depth was defined, try to select a reasonable one     */
-/*      that implies approximately 8 shapes per node.                   */
-/* -------------------------------------------------------------------- */
-    if( psTree->nMaxDepth == 0 && hSHP != SHPLIB_NULLPTR )
+    /* -------------------------------------------------------------------- */
+    /*      If no max depth was defined, try to select a reasonable one     */
+    /*      that implies approximately 8 shapes per node.                   */
+    /* -------------------------------------------------------------------- */
+    if (psTree->nMaxDepth == 0 && hSHP != SHPLIB_NULLPTR)
     {
-        int	nMaxNodeCount = 1;
-        int	nShapeCount;
+        int nMaxNodeCount = 1;
+        int nShapeCount;
 
-        SHPGetInfo( hSHP, &nShapeCount, SHPLIB_NULLPTR, SHPLIB_NULLPTR, SHPLIB_NULLPTR );
-        while( nMaxNodeCount*4 < nShapeCount )
+        SHPGetInfo(hSHP, &nShapeCount, SHPLIB_NULLPTR, SHPLIB_NULLPTR,
+                   SHPLIB_NULLPTR);
+        while (nMaxNodeCount * 4 < nShapeCount)
         {
             psTree->nMaxDepth += 1;
             nMaxNodeCount = nMaxNodeCount * 2;
         }
 
 #ifdef USE_CPL
-        CPLDebug( "Shape",
-                  "Estimated spatial index tree depth: %d",
-                  psTree->nMaxDepth );
+        CPLDebug("Shape", "Estimated spatial index tree depth: %d",
+                 psTree->nMaxDepth);
 #endif
 
         /* NOTE: Due to problems with memory allocation for deep trees,
          * automatically estimated depth is limited up to 12 levels.
          * See Ticket #1594 for detailed discussion.
          */
-        if( psTree->nMaxDepth > MAX_DEFAULT_TREE_DEPTH )
+        if (psTree->nMaxDepth > MAX_DEFAULT_TREE_DEPTH)
         {
             psTree->nMaxDepth = MAX_DEFAULT_TREE_DEPTH;
 
 #ifdef USE_CPL
-            CPLDebug( "Shape",
-                      "Falling back to max number of allowed index tree levels (%d).",
-                      MAX_DEFAULT_TREE_DEPTH );
+            CPLDebug(
+                "Shape",
+                "Falling back to max number of allowed index tree levels (%d).",
+                MAX_DEFAULT_TREE_DEPTH);
 #endif
         }
     }
 
-/* -------------------------------------------------------------------- */
-/*      Allocate the root node.                                         */
-/* -------------------------------------------------------------------- */
-    psTree->psRoot = SHPTreeNodeCreate( padfBoundsMin, padfBoundsMax );
-    if( SHPLIB_NULLPTR == psTree->psRoot )
+    /* -------------------------------------------------------------------- */
+    /*      Allocate the root node.                                         */
+    /* -------------------------------------------------------------------- */
+    psTree->psRoot = SHPTreeNodeCreate(padfBoundsMin, padfBoundsMax);
+    if (SHPLIB_NULLPTR == psTree->psRoot)
     {
-        free( psTree );
+        free(psTree);
         return SHPLIB_NULLPTR;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Assign the bounds to the root node.  If none are passed in,     */
-/*      use the bounds of the provided file otherwise the create        */
-/*      function will have already set the bounds.                      */
-/* -------------------------------------------------------------------- */
-    if( padfBoundsMin == SHPLIB_NULLPTR )
+    /* -------------------------------------------------------------------- */
+    /*      Assign the bounds to the root node.  If none are passed in,     */
+    /*      use the bounds of the provided file otherwise the create        */
+    /*      function will have already set the bounds.                      */
+    /* -------------------------------------------------------------------- */
+    if (padfBoundsMin == SHPLIB_NULLPTR)
     {
-        SHPGetInfo( hSHP, SHPLIB_NULLPTR, SHPLIB_NULLPTR,
-                    psTree->psRoot->adfBoundsMin,
-                    psTree->psRoot->adfBoundsMax );
+        SHPGetInfo(hSHP, SHPLIB_NULLPTR, SHPLIB_NULLPTR,
+                   psTree->psRoot->adfBoundsMin, psTree->psRoot->adfBoundsMax);
     }
 
-/* -------------------------------------------------------------------- */
-/*      If we have a file, insert all its shapes into the tree.        */
-/* -------------------------------------------------------------------- */
-    if( hSHP != SHPLIB_NULLPTR )
+    /* -------------------------------------------------------------------- */
+    /*      If we have a file, insert all its shapes into the tree.        */
+    /* -------------------------------------------------------------------- */
+    if (hSHP != SHPLIB_NULLPTR)
     {
-        int	iShape, nShapeCount;
+        int iShape, nShapeCount;
 
-        SHPGetInfo( hSHP, &nShapeCount, SHPLIB_NULLPTR, SHPLIB_NULLPTR, SHPLIB_NULLPTR );
+        SHPGetInfo(hSHP, &nShapeCount, SHPLIB_NULLPTR, SHPLIB_NULLPTR,
+                   SHPLIB_NULLPTR);
 
-        for( iShape = 0; iShape < nShapeCount; iShape++ )
+        for (iShape = 0; iShape < nShapeCount; iShape++)
         {
-            SHPObject	*psShape;
+            SHPObject *psShape;
 
-            psShape = SHPReadObject( hSHP, iShape );
-            if( psShape != SHPLIB_NULLPTR )
+            psShape = SHPReadObject(hSHP, iShape);
+            if (psShape != SHPLIB_NULLPTR)
             {
-                SHPTreeAddShapeId( psTree, psShape );
-                SHPDestroyObject( psShape );
+                SHPTreeAddShapeId(psTree, psShape);
+                SHPDestroyObject(psShape);
             }
         }
     }
@@ -228,46 +228,45 @@ SHPTree SHPAPI_CALL1(*)
 /*                         SHPDestroyTreeNode()                         */
 /************************************************************************/
 
-static void SHPDestroyTreeNode( SHPTreeNode * psTreeNode )
+static void SHPDestroyTreeNode(SHPTreeNode *psTreeNode)
 
 {
-    int		i;
+    int i;
 
-	assert( SHPLIB_NULLPTR != psTreeNode );
+    assert(SHPLIB_NULLPTR != psTreeNode);
 
-    for( i = 0; i < psTreeNode->nSubNodes; i++ )
+    for (i = 0; i < psTreeNode->nSubNodes; i++)
     {
-        if( psTreeNode->apsSubNode[i] != SHPLIB_NULLPTR )
-            SHPDestroyTreeNode( psTreeNode->apsSubNode[i] );
+        if (psTreeNode->apsSubNode[i] != SHPLIB_NULLPTR)
+            SHPDestroyTreeNode(psTreeNode->apsSubNode[i]);
     }
 
-    if( psTreeNode->panShapeIds != SHPLIB_NULLPTR )
-        free( psTreeNode->panShapeIds );
+    if (psTreeNode->panShapeIds != SHPLIB_NULLPTR)
+        free(psTreeNode->panShapeIds);
 
-    if( psTreeNode->papsShapeObj != SHPLIB_NULLPTR )
+    if (psTreeNode->papsShapeObj != SHPLIB_NULLPTR)
     {
-        for( i = 0; i < psTreeNode->nShapeCount; i++ )
+        for (i = 0; i < psTreeNode->nShapeCount; i++)
         {
-            if( psTreeNode->papsShapeObj[i] != SHPLIB_NULLPTR )
-                SHPDestroyObject( psTreeNode->papsShapeObj[i] );
+            if (psTreeNode->papsShapeObj[i] != SHPLIB_NULLPTR)
+                SHPDestroyObject(psTreeNode->papsShapeObj[i]);
         }
 
-        free( psTreeNode->papsShapeObj );
+        free(psTreeNode->papsShapeObj);
     }
 
-    free( psTreeNode );
+    free(psTreeNode);
 }
 
 /************************************************************************/
 /*                           SHPDestroyTree()                           */
 /************************************************************************/
 
-void SHPAPI_CALL
-SHPDestroyTree( SHPTree * psTree )
+void SHPAPI_CALL SHPDestroyTree(SHPTree *psTree)
 
 {
-    SHPDestroyTreeNode( psTree->psRoot );
-    free( psTree );
+    SHPDestroyTreeNode(psTree->psRoot);
+    free(psTree);
 }
 
 /************************************************************************/
@@ -276,16 +275,16 @@ SHPDestroyTree( SHPTree * psTree )
 /*      Do the given boxes overlap at all?                              */
 /************************************************************************/
 
-int SHPAPI_CALL
-SHPCheckBoundsOverlap( double * padfBox1Min, double * padfBox1Max,
-                       double * padfBox2Min, double * padfBox2Max,
-                       int nDimension ) {
-    for( int iDim = 0; iDim < nDimension; iDim++ )
+int SHPAPI_CALL SHPCheckBoundsOverlap(double *padfBox1Min, double *padfBox1Max,
+                                      double *padfBox2Min, double *padfBox2Max,
+                                      int nDimension)
+{
+    for (int iDim = 0; iDim < nDimension; iDim++)
     {
-        if( padfBox2Max[iDim] < padfBox1Min[iDim] )
+        if (padfBox2Max[iDim] < padfBox1Min[iDim])
             return FALSE;
 
-        if( padfBox1Max[iDim] < padfBox2Min[iDim] )
+        if (padfBox1Max[iDim] < padfBox2Min[iDim])
             return FALSE;
     }
 
@@ -298,30 +297,31 @@ SHPCheckBoundsOverlap( double * padfBox1Min, double * padfBox1Max,
 /*      Does the given shape fit within the indicated extents?          */
 /************************************************************************/
 
-static bool SHPCheckObjectContained( SHPObject * psObject, int nDimension,
-                           double * padfBoundsMin, double * padfBoundsMax )
+static bool SHPCheckObjectContained(SHPObject *psObject, int nDimension,
+                                    double *padfBoundsMin,
+                                    double *padfBoundsMax)
 
 {
-    if( psObject->dfXMin < padfBoundsMin[0]
-        || psObject->dfXMax > padfBoundsMax[0] )
+    if (psObject->dfXMin < padfBoundsMin[0] ||
+        psObject->dfXMax > padfBoundsMax[0])
         return false;
 
-    if( psObject->dfYMin < padfBoundsMin[1]
-        || psObject->dfYMax > padfBoundsMax[1] )
+    if (psObject->dfYMin < padfBoundsMin[1] ||
+        psObject->dfYMax > padfBoundsMax[1])
         return false;
 
-    if( nDimension == 2 )
+    if (nDimension == 2)
         return true;
 
-    if( psObject->dfZMin < padfBoundsMin[2]
-        || psObject->dfZMax > padfBoundsMax[2] )
+    if (psObject->dfZMin < padfBoundsMin[2] ||
+        psObject->dfZMax > padfBoundsMax[2])
         return false;
 
-    if( nDimension == 3 )
+    if (nDimension == 3)
         return true;
 
-    if( psObject->dfMMin < padfBoundsMin[3]
-        || psObject->dfMMax > padfBoundsMax[3] )
+    if (psObject->dfMMin < padfBoundsMin[3] ||
+        psObject->dfMMax > padfBoundsMax[3])
         return false;
 
     return true;
@@ -334,39 +334,38 @@ static bool SHPCheckObjectContained( SHPObject * psObject, int nDimension,
 /*      longest dimension.                                              */
 /************************************************************************/
 
-static void
-SHPTreeSplitBounds( double *padfBoundsMinIn, double *padfBoundsMaxIn,
-                    double *padfBoundsMin1, double * padfBoundsMax1,
-                    double *padfBoundsMin2, double * padfBoundsMax2 )
+static void SHPTreeSplitBounds(double *padfBoundsMinIn, double *padfBoundsMaxIn,
+                               double *padfBoundsMin1, double *padfBoundsMax1,
+                               double *padfBoundsMin2, double *padfBoundsMax2)
 
 {
-/* -------------------------------------------------------------------- */
-/*      The output bounds will be very similar to the input bounds,     */
-/*      so just copy over to start.                                     */
-/* -------------------------------------------------------------------- */
-    memcpy( padfBoundsMin1, padfBoundsMinIn, sizeof(double) * 4 );
-    memcpy( padfBoundsMax1, padfBoundsMaxIn, sizeof(double) * 4 );
-    memcpy( padfBoundsMin2, padfBoundsMinIn, sizeof(double) * 4 );
-    memcpy( padfBoundsMax2, padfBoundsMaxIn, sizeof(double) * 4 );
+    /* -------------------------------------------------------------------- */
+    /*      The output bounds will be very similar to the input bounds,     */
+    /*      so just copy over to start.                                     */
+    /* -------------------------------------------------------------------- */
+    memcpy(padfBoundsMin1, padfBoundsMinIn, sizeof(double) * 4);
+    memcpy(padfBoundsMax1, padfBoundsMaxIn, sizeof(double) * 4);
+    memcpy(padfBoundsMin2, padfBoundsMinIn, sizeof(double) * 4);
+    memcpy(padfBoundsMax2, padfBoundsMaxIn, sizeof(double) * 4);
 
-/* -------------------------------------------------------------------- */
-/*      Split in X direction.                                           */
-/* -------------------------------------------------------------------- */
-    if( (padfBoundsMaxIn[0] - padfBoundsMinIn[0])
-        			> (padfBoundsMaxIn[1] - padfBoundsMinIn[1]) )
+    /* -------------------------------------------------------------------- */
+    /*      Split in X direction.                                           */
+    /* -------------------------------------------------------------------- */
+    if ((padfBoundsMaxIn[0] - padfBoundsMinIn[0]) >
+        (padfBoundsMaxIn[1] - padfBoundsMinIn[1]))
     {
-        double	dfRange = padfBoundsMaxIn[0] - padfBoundsMinIn[0];
+        double dfRange = padfBoundsMaxIn[0] - padfBoundsMinIn[0];
 
         padfBoundsMax1[0] = padfBoundsMinIn[0] + dfRange * SHP_SPLIT_RATIO;
         padfBoundsMin2[0] = padfBoundsMaxIn[0] - dfRange * SHP_SPLIT_RATIO;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Otherwise split in Y direction.                                 */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Otherwise split in Y direction.                                 */
+    /* -------------------------------------------------------------------- */
     else
     {
-        double	dfRange = padfBoundsMaxIn[1] - padfBoundsMinIn[1];
+        double dfRange = padfBoundsMaxIn[1] - padfBoundsMinIn[1];
 
         padfBoundsMax1[1] = padfBoundsMinIn[1] + dfRange * SHP_SPLIT_RATIO;
         padfBoundsMin2[1] = padfBoundsMaxIn[1] - dfRange * SHP_SPLIT_RATIO;
@@ -377,28 +376,28 @@ SHPTreeSplitBounds( double *padfBoundsMinIn, double *padfBoundsMaxIn,
 /*                       SHPTreeNodeAddShapeId()                        */
 /************************************************************************/
 
-static bool
-SHPTreeNodeAddShapeId( SHPTreeNode * psTreeNode, SHPObject * psObject,
-                       int nMaxDepth, int nDimension )
+static bool SHPTreeNodeAddShapeId(SHPTreeNode *psTreeNode, SHPObject *psObject,
+                                  int nMaxDepth, int nDimension)
 
 {
-    int		i;
+    int i;
 
-/* -------------------------------------------------------------------- */
-/*      If there are subnodes, then consider whether this object        */
-/*      will fit in them.                                               */
-/* -------------------------------------------------------------------- */
-    if( nMaxDepth > 1 && psTreeNode->nSubNodes > 0 )
+    /* -------------------------------------------------------------------- */
+    /*      If there are subnodes, then consider whether this object        */
+    /*      will fit in them.                                               */
+    /* -------------------------------------------------------------------- */
+    if (nMaxDepth > 1 && psTreeNode->nSubNodes > 0)
     {
-        for( i = 0; i < psTreeNode->nSubNodes; i++ )
+        for (i = 0; i < psTreeNode->nSubNodes; i++)
         {
-            if( SHPCheckObjectContained(psObject, nDimension,
-                                      psTreeNode->apsSubNode[i]->adfBoundsMin,
-                                      psTreeNode->apsSubNode[i]->adfBoundsMax))
+            if (SHPCheckObjectContained(
+                    psObject, nDimension,
+                    psTreeNode->apsSubNode[i]->adfBoundsMin,
+                    psTreeNode->apsSubNode[i]->adfBoundsMax))
             {
-                return SHPTreeNodeAddShapeId( psTreeNode->apsSubNode[i],
-                                              psObject, nMaxDepth-1,
-                                              nDimension );
+                return SHPTreeNodeAddShapeId(psTreeNode->apsSubNode[i],
+                                             psObject, nMaxDepth - 1,
+                                             nDimension);
             }
         }
     }
@@ -408,50 +407,47 @@ SHPTreeNodeAddShapeId( SHPTreeNode * psTreeNode, SHPObject * psObject,
 /*      them, and adding to the appropriate subnode.                    */
 /* -------------------------------------------------------------------- */
 #if MAX_SUBNODE == 4
-    else if( nMaxDepth > 1 && psTreeNode->nSubNodes == 0 )
+    else if (nMaxDepth > 1 && psTreeNode->nSubNodes == 0)
     {
-        double	adfBoundsMinH1[4], adfBoundsMaxH1[4];
-        double	adfBoundsMinH2[4], adfBoundsMaxH2[4];
-        double	adfBoundsMin1[4], adfBoundsMax1[4];
-        double	adfBoundsMin2[4], adfBoundsMax2[4];
-        double	adfBoundsMin3[4], adfBoundsMax3[4];
-        double	adfBoundsMin4[4], adfBoundsMax4[4];
+        double adfBoundsMinH1[4], adfBoundsMaxH1[4];
+        double adfBoundsMinH2[4], adfBoundsMaxH2[4];
+        double adfBoundsMin1[4], adfBoundsMax1[4];
+        double adfBoundsMin2[4], adfBoundsMax2[4];
+        double adfBoundsMin3[4], adfBoundsMax3[4];
+        double adfBoundsMin4[4], adfBoundsMax4[4];
 
-        SHPTreeSplitBounds( psTreeNode->adfBoundsMin,
-                            psTreeNode->adfBoundsMax,
-                            adfBoundsMinH1, adfBoundsMaxH1,
-                            adfBoundsMinH2, adfBoundsMaxH2 );
+        SHPTreeSplitBounds(psTreeNode->adfBoundsMin, psTreeNode->adfBoundsMax,
+                           adfBoundsMinH1, adfBoundsMaxH1, adfBoundsMinH2,
+                           adfBoundsMaxH2);
 
-        SHPTreeSplitBounds( adfBoundsMinH1, adfBoundsMaxH1,
-                            adfBoundsMin1, adfBoundsMax1,
-                            adfBoundsMin2, adfBoundsMax2 );
+        SHPTreeSplitBounds(adfBoundsMinH1, adfBoundsMaxH1, adfBoundsMin1,
+                           adfBoundsMax1, adfBoundsMin2, adfBoundsMax2);
 
-        SHPTreeSplitBounds( adfBoundsMinH2, adfBoundsMaxH2,
-                            adfBoundsMin3, adfBoundsMax3,
-                            adfBoundsMin4, adfBoundsMax4 );
+        SHPTreeSplitBounds(adfBoundsMinH2, adfBoundsMaxH2, adfBoundsMin3,
+                           adfBoundsMax3, adfBoundsMin4, adfBoundsMax4);
 
-        if( SHPCheckObjectContained(psObject, nDimension,
-                                    adfBoundsMin1, adfBoundsMax1)
-            || SHPCheckObjectContained(psObject, nDimension,
-                                    adfBoundsMin2, adfBoundsMax2)
-            || SHPCheckObjectContained(psObject, nDimension,
-                                    adfBoundsMin3, adfBoundsMax3)
-            || SHPCheckObjectContained(psObject, nDimension,
-                                    adfBoundsMin4, adfBoundsMax4) )
+        if (SHPCheckObjectContained(psObject, nDimension, adfBoundsMin1,
+                                    adfBoundsMax1) ||
+            SHPCheckObjectContained(psObject, nDimension, adfBoundsMin2,
+                                    adfBoundsMax2) ||
+            SHPCheckObjectContained(psObject, nDimension, adfBoundsMin3,
+                                    adfBoundsMax3) ||
+            SHPCheckObjectContained(psObject, nDimension, adfBoundsMin4,
+                                    adfBoundsMax4))
         {
             psTreeNode->nSubNodes = 4;
-            psTreeNode->apsSubNode[0] = SHPTreeNodeCreate( adfBoundsMin1,
-                                                           adfBoundsMax1 );
-            psTreeNode->apsSubNode[1] = SHPTreeNodeCreate( adfBoundsMin2,
-                                                           adfBoundsMax2 );
-            psTreeNode->apsSubNode[2] = SHPTreeNodeCreate( adfBoundsMin3,
-                                                           adfBoundsMax3 );
-            psTreeNode->apsSubNode[3] = SHPTreeNodeCreate( adfBoundsMin4,
-                                                           adfBoundsMax4 );
+            psTreeNode->apsSubNode[0] =
+                SHPTreeNodeCreate(adfBoundsMin1, adfBoundsMax1);
+            psTreeNode->apsSubNode[1] =
+                SHPTreeNodeCreate(adfBoundsMin2, adfBoundsMax2);
+            psTreeNode->apsSubNode[2] =
+                SHPTreeNodeCreate(adfBoundsMin3, adfBoundsMax3);
+            psTreeNode->apsSubNode[3] =
+                SHPTreeNodeCreate(adfBoundsMin4, adfBoundsMax4);
 
             /* recurse back on this node now that it has subnodes */
-            return( SHPTreeNodeAddShapeId( psTreeNode, psObject,
-                                           nMaxDepth, nDimension ) );
+            return (SHPTreeNodeAddShapeId(psTreeNode, psObject, nMaxDepth,
+                                          nDimension));
         }
     }
 #endif /* MAX_SUBNODE == 4 */
@@ -461,58 +457,58 @@ SHPTreeNodeAddShapeId( SHPTreeNode * psTreeNode, SHPObject * psObject,
 /*      them, and adding to the appropriate subnode.                    */
 /* -------------------------------------------------------------------- */
 #if MAX_SUBNODE == 2
-    else if( nMaxDepth > 1 && psTreeNode->nSubNodes == 0 )
+    else if (nMaxDepth > 1 && psTreeNode->nSubNodes == 0)
     {
-        double	adfBoundsMin1[4], adfBoundsMax1[4];
-        double	adfBoundsMin2[4], adfBoundsMax2[4];
+        double adfBoundsMin1[4], adfBoundsMax1[4];
+        double adfBoundsMin2[4], adfBoundsMax2[4];
 
-        SHPTreeSplitBounds( psTreeNode->adfBoundsMin, psTreeNode->adfBoundsMax,
-                            adfBoundsMin1, adfBoundsMax1,
-                            adfBoundsMin2, adfBoundsMax2 );
+        SHPTreeSplitBounds(psTreeNode->adfBoundsMin, psTreeNode->adfBoundsMax,
+                           adfBoundsMin1, adfBoundsMax1, adfBoundsMin2,
+                           adfBoundsMax2);
 
-        if( SHPCheckObjectContained(psObject, nDimension,
-                                 adfBoundsMin1, adfBoundsMax1))
+        if (SHPCheckObjectContained(psObject, nDimension, adfBoundsMin1,
+                                    adfBoundsMax1))
         {
             psTreeNode->nSubNodes = 2;
-            psTreeNode->apsSubNode[0] = SHPTreeNodeCreate( adfBoundsMin1,
-                                                           adfBoundsMax1 );
-            psTreeNode->apsSubNode[1] = SHPTreeNodeCreate( adfBoundsMin2,
-                                                           adfBoundsMax2 );
+            psTreeNode->apsSubNode[0] =
+                SHPTreeNodeCreate(adfBoundsMin1, adfBoundsMax1);
+            psTreeNode->apsSubNode[1] =
+                SHPTreeNodeCreate(adfBoundsMin2, adfBoundsMax2);
 
-            return( SHPTreeNodeAddShapeId( psTreeNode->apsSubNode[0], psObject,
-                                           nMaxDepth - 1, nDimension ) );
+            return (SHPTreeNodeAddShapeId(psTreeNode->apsSubNode[0], psObject,
+                                          nMaxDepth - 1, nDimension));
         }
-        else if( SHPCheckObjectContained(psObject, nDimension,
-                                         adfBoundsMin2, adfBoundsMax2) )
+        else if (SHPCheckObjectContained(psObject, nDimension, adfBoundsMin2,
+                                         adfBoundsMax2))
         {
             psTreeNode->nSubNodes = 2;
-            psTreeNode->apsSubNode[0] = SHPTreeNodeCreate( adfBoundsMin1,
-                                                           adfBoundsMax1 );
-            psTreeNode->apsSubNode[1] = SHPTreeNodeCreate( adfBoundsMin2,
-                                                           adfBoundsMax2 );
+            psTreeNode->apsSubNode[0] =
+                SHPTreeNodeCreate(adfBoundsMin1, adfBoundsMax1);
+            psTreeNode->apsSubNode[1] =
+                SHPTreeNodeCreate(adfBoundsMin2, adfBoundsMax2);
 
-            return( SHPTreeNodeAddShapeId( psTreeNode->apsSubNode[1], psObject,
-                                           nMaxDepth - 1, nDimension ) );
+            return (SHPTreeNodeAddShapeId(psTreeNode->apsSubNode[1], psObject,
+                                          nMaxDepth - 1, nDimension));
         }
     }
 #endif /* MAX_SUBNODE == 2 */
 
-/* -------------------------------------------------------------------- */
-/*      If none of that worked, just add it to this nodes list.         */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      If none of that worked, just add it to this nodes list.         */
+    /* -------------------------------------------------------------------- */
     psTreeNode->nShapeCount++;
 
-    psTreeNode->panShapeIds = STATIC_CAST(int *,
-        realloc( psTreeNode->panShapeIds,
-                   sizeof(int) * psTreeNode->nShapeCount ));
-    psTreeNode->panShapeIds[psTreeNode->nShapeCount-1] = psObject->nShapeId;
+    psTreeNode->panShapeIds =
+        STATIC_CAST(int *, realloc(psTreeNode->panShapeIds,
+                                   sizeof(int) * psTreeNode->nShapeCount));
+    psTreeNode->panShapeIds[psTreeNode->nShapeCount - 1] = psObject->nShapeId;
 
-    if( psTreeNode->papsShapeObj != SHPLIB_NULLPTR )
+    if (psTreeNode->papsShapeObj != SHPLIB_NULLPTR)
     {
-        psTreeNode->papsShapeObj = STATIC_CAST(SHPObject **,
-            realloc( psTreeNode->papsShapeObj,
-                       sizeof(void *) * psTreeNode->nShapeCount ));
-        psTreeNode->papsShapeObj[psTreeNode->nShapeCount-1] = SHPLIB_NULLPTR;
+        psTreeNode->papsShapeObj = STATIC_CAST(
+            SHPObject **, realloc(psTreeNode->papsShapeObj,
+                                  sizeof(void *) * psTreeNode->nShapeCount));
+        psTreeNode->papsShapeObj[psTreeNode->nShapeCount - 1] = SHPLIB_NULLPTR;
     }
 
     return true;
@@ -525,14 +521,13 @@ SHPTreeNodeAddShapeId( SHPTreeNode * psTreeNode, SHPObject * psObject,
 /*      object data, just keep the shapeid.                             */
 /************************************************************************/
 
-int SHPAPI_CALL
-SHPTreeAddShapeId( SHPTree * psTree, SHPObject * psObject )
+int SHPAPI_CALL SHPTreeAddShapeId(SHPTree *psTree, SHPObject *psObject)
 
 {
     psTree->nTotalCount++;
 
-    return( SHPTreeNodeAddShapeId( psTree->psRoot, psObject,
-                                   psTree->nMaxDepth, psTree->nDimension ) );
+    return (SHPTreeNodeAddShapeId(psTree->psRoot, psObject, psTree->nMaxDepth,
+                                  psTree->nDimension));
 }
 
 /************************************************************************/
@@ -542,54 +537,50 @@ SHPTreeAddShapeId( SHPTree * psTree, SHPObject * psObject )
 /*      tree node by tree node basis.                                   */
 /************************************************************************/
 
-static void
-SHPTreeCollectShapeIds( SHPTree *hTree, SHPTreeNode * psTreeNode,
-                        double * padfBoundsMin, double * padfBoundsMax,
-                        int * pnShapeCount, int * pnMaxShapes,
-                        int ** ppanShapeList )
+static void SHPTreeCollectShapeIds(SHPTree *hTree, SHPTreeNode *psTreeNode,
+                                   double *padfBoundsMin, double *padfBoundsMax,
+                                   int *pnShapeCount, int *pnMaxShapes,
+                                   int **ppanShapeList)
 
 {
-    int		i;
+    int i;
 
-/* -------------------------------------------------------------------- */
-/*      Does this node overlap the area of interest at all?  If not,    */
-/*      return without adding to the list at all.                       */
-/* -------------------------------------------------------------------- */
-    if( !SHPCheckBoundsOverlap( psTreeNode->adfBoundsMin,
-                                psTreeNode->adfBoundsMax,
-                                padfBoundsMin,
-                                padfBoundsMax,
-                                hTree->nDimension ) )
+    /* -------------------------------------------------------------------- */
+    /*      Does this node overlap the area of interest at all?  If not,    */
+    /*      return without adding to the list at all.                       */
+    /* -------------------------------------------------------------------- */
+    if (!SHPCheckBoundsOverlap(psTreeNode->adfBoundsMin,
+                               psTreeNode->adfBoundsMax, padfBoundsMin,
+                               padfBoundsMax, hTree->nDimension))
         return;
 
-/* -------------------------------------------------------------------- */
-/*      Grow the list to hold the shapes on this node.                  */
-/* -------------------------------------------------------------------- */
-    if( *pnShapeCount + psTreeNode->nShapeCount > *pnMaxShapes )
+    /* -------------------------------------------------------------------- */
+    /*      Grow the list to hold the shapes on this node.                  */
+    /* -------------------------------------------------------------------- */
+    if (*pnShapeCount + psTreeNode->nShapeCount > *pnMaxShapes)
     {
         *pnMaxShapes = (*pnShapeCount + psTreeNode->nShapeCount) * 2 + 20;
-        *ppanShapeList = STATIC_CAST(int *,
-            realloc(*ppanShapeList,sizeof(int) * *pnMaxShapes));
+        *ppanShapeList = STATIC_CAST(
+            int *, realloc(*ppanShapeList, sizeof(int) * *pnMaxShapes));
     }
 
-/* -------------------------------------------------------------------- */
-/*      Add the local nodes shapeids to the list.                       */
-/* -------------------------------------------------------------------- */
-    for( i = 0; i < psTreeNode->nShapeCount; i++ )
+    /* -------------------------------------------------------------------- */
+    /*      Add the local nodes shapeids to the list.                       */
+    /* -------------------------------------------------------------------- */
+    for (i = 0; i < psTreeNode->nShapeCount; i++)
     {
         (*ppanShapeList)[(*pnShapeCount)++] = psTreeNode->panShapeIds[i];
     }
 
-/* -------------------------------------------------------------------- */
-/*      Recurse to subnodes if they exist.                              */
-/* -------------------------------------------------------------------- */
-    for( i = 0; i < psTreeNode->nSubNodes; i++ )
+    /* -------------------------------------------------------------------- */
+    /*      Recurse to subnodes if they exist.                              */
+    /* -------------------------------------------------------------------- */
+    for (i = 0; i < psTreeNode->nSubNodes; i++)
     {
-        if( psTreeNode->apsSubNode[i] != SHPLIB_NULLPTR )
-            SHPTreeCollectShapeIds( hTree, psTreeNode->apsSubNode[i],
-                                    padfBoundsMin, padfBoundsMax,
-                                    pnShapeCount, pnMaxShapes,
-                                    ppanShapeList );
+        if (psTreeNode->apsSubNode[i] != SHPLIB_NULLPTR)
+            SHPTreeCollectShapeIds(hTree, psTreeNode->apsSubNode[i],
+                                   padfBoundsMin, padfBoundsMax, pnShapeCount,
+                                   pnMaxShapes, ppanShapeList);
     }
 }
 
@@ -604,35 +595,32 @@ SHPTreeCollectShapeIds( SHPTree *hTree, SHPTreeNode * psTreeNode,
 /************************************************************************/
 
 /* helper for qsort */
-static int
-compare_ints( const void * a, const void * b)
+static int compare_ints(const void *a, const void *b)
 {
-    return *REINTERPRET_CAST(const int*, a) - *REINTERPRET_CAST(const int*, b);
+    return *REINTERPRET_CAST(const int *, a) -
+           *REINTERPRET_CAST(const int *, b);
 }
 
 int SHPAPI_CALL1(*)
-SHPTreeFindLikelyShapes( SHPTree * hTree,
-                         double * padfBoundsMin, double * padfBoundsMax,
-                         int * pnShapeCount )
+    SHPTreeFindLikelyShapes(SHPTree *hTree, double *padfBoundsMin,
+                            double *padfBoundsMax, int *pnShapeCount)
 
 {
-    int	*panShapeList=SHPLIB_NULLPTR, nMaxShapes = 0;
+    int *panShapeList = SHPLIB_NULLPTR, nMaxShapes = 0;
 
-/* -------------------------------------------------------------------- */
-/*      Perform the search by recursive descent.                        */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Perform the search by recursive descent.                        */
+    /* -------------------------------------------------------------------- */
     *pnShapeCount = 0;
 
-    SHPTreeCollectShapeIds( hTree, hTree->psRoot,
-                            padfBoundsMin, padfBoundsMax,
-                            pnShapeCount, &nMaxShapes,
-                            &panShapeList );
+    SHPTreeCollectShapeIds(hTree, hTree->psRoot, padfBoundsMin, padfBoundsMax,
+                           pnShapeCount, &nMaxShapes, &panShapeList);
 
-/* -------------------------------------------------------------------- */
-/*      Sort the id array                                               */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Sort the id array                                               */
+    /* -------------------------------------------------------------------- */
 
-    if( panShapeList != SHPLIB_NULLPTR )
+    if (panShapeList != SHPLIB_NULLPTR)
         qsort(panShapeList, *pnShapeCount, sizeof(int), compare_ints);
 
     return panShapeList;
@@ -645,22 +633,22 @@ SHPTreeFindLikelyShapes( SHPTree * hTree,
 /*      walks the tree cleaning it up.                                  */
 /************************************************************************/
 
-static int SHPTreeNodeTrim( SHPTreeNode * psTreeNode )
+static int SHPTreeNodeTrim(SHPTreeNode *psTreeNode)
 
 {
-    int		i;
+    int i;
 
-/* -------------------------------------------------------------------- */
-/*      Trim subtrees, and free subnodes that come back empty.          */
-/* -------------------------------------------------------------------- */
-    for( i = 0; i < psTreeNode->nSubNodes; i++ )
+    /* -------------------------------------------------------------------- */
+    /*      Trim subtrees, and free subnodes that come back empty.          */
+    /* -------------------------------------------------------------------- */
+    for (i = 0; i < psTreeNode->nSubNodes; i++)
     {
-        if( SHPTreeNodeTrim( psTreeNode->apsSubNode[i] ) )
+        if (SHPTreeNodeTrim(psTreeNode->apsSubNode[i]))
         {
-            SHPDestroyTreeNode( psTreeNode->apsSubNode[i] );
+            SHPDestroyTreeNode(psTreeNode->apsSubNode[i]);
 
             psTreeNode->apsSubNode[i] =
-                psTreeNode->apsSubNode[psTreeNode->nSubNodes-1];
+                psTreeNode->apsSubNode[psTreeNode->nSubNodes - 1];
 
             psTreeNode->nSubNodes--;
 
@@ -668,13 +656,13 @@ static int SHPTreeNodeTrim( SHPTreeNode * psTreeNode )
         }
     }
 
-/* -------------------------------------------------------------------- */
-/*      If the current node has 1 subnode and no shapes, promote that   */
-/*      subnode to the current node position.                           */
-/* -------------------------------------------------------------------- */
-    if( psTreeNode->nSubNodes == 1 && psTreeNode->nShapeCount == 0)
+    /* -------------------------------------------------------------------- */
+    /*      If the current node has 1 subnode and no shapes, promote that   */
+    /*      subnode to the current node position.                           */
+    /* -------------------------------------------------------------------- */
+    if (psTreeNode->nSubNodes == 1 && psTreeNode->nShapeCount == 0)
     {
-        SHPTreeNode* psSubNode = psTreeNode->apsSubNode[0];
+        SHPTreeNode *psSubNode = psTreeNode->apsSubNode[0];
 
         memcpy(psTreeNode->adfBoundsMin, psSubNode->adfBoundsMin,
                sizeof(psSubNode->adfBoundsMin));
@@ -686,15 +674,15 @@ static int SHPTreeNodeTrim( SHPTreeNode * psTreeNode )
         assert(psTreeNode->papsShapeObj == SHPLIB_NULLPTR);
         psTreeNode->papsShapeObj = psSubNode->papsShapeObj;
         psTreeNode->nSubNodes = psSubNode->nSubNodes;
-        for( i = 0; i < psSubNode->nSubNodes; i++ )
+        for (i = 0; i < psSubNode->nSubNodes; i++)
             psTreeNode->apsSubNode[i] = psSubNode->apsSubNode[i];
         free(psSubNode);
     }
 
-/* -------------------------------------------------------------------- */
-/*      We should be trimmed if we have no subnodes, and no shapes.     */
-/* -------------------------------------------------------------------- */
-    return( psTreeNode->nSubNodes == 0 && psTreeNode->nShapeCount == 0 );
+    /* -------------------------------------------------------------------- */
+    /*      We should be trimmed if we have no subnodes, and no shapes.     */
+    /* -------------------------------------------------------------------- */
+    return (psTreeNode->nSubNodes == 0 && psTreeNode->nShapeCount == 0);
 }
 
 /************************************************************************/
@@ -704,11 +692,10 @@ static int SHPTreeNodeTrim( SHPTreeNode * psTreeNode )
 /*      empty root node.                                                */
 /************************************************************************/
 
-void SHPAPI_CALL
-SHPTreeTrimExtraNodes( SHPTree * hTree )
+void SHPAPI_CALL SHPTreeTrimExtraNodes(SHPTree *hTree)
 
 {
-    SHPTreeNodeTrim( hTree->psRoot );
+    SHPTreeNodeTrim(hTree->psRoot);
 }
 
 /************************************************************************/
@@ -717,42 +704,42 @@ SHPTreeTrimExtraNodes( SHPTree * hTree )
 /*      Swap a 2, 4 or 8 byte word.                                     */
 /************************************************************************/
 
-static void	SwapWord( int length, void * wordP )
+static void SwapWord(int length, void *wordP)
 
 {
-    int		i;
-    unsigned char	temp;
+    int i;
+    unsigned char temp;
 
-    for( i=0; i < length/2; i++ )
+    for (i = 0; i < length / 2; i++)
     {
-	temp = STATIC_CAST(unsigned char*, wordP)[i];
-	STATIC_CAST(unsigned char*, wordP)[i] = STATIC_CAST(unsigned char*, wordP)[length-i-1];
-	STATIC_CAST(unsigned char*, wordP)[length-i-1] = temp;
+        temp = STATIC_CAST(unsigned char *, wordP)[i];
+        STATIC_CAST(unsigned char *, wordP)
+        [i] = STATIC_CAST(unsigned char *, wordP)[length - i - 1];
+        STATIC_CAST(unsigned char *, wordP)[length - i - 1] = temp;
     }
 }
-
 
 struct SHPDiskTreeInfo
 {
     SAHooks sHooks;
-    SAFile  fpQIX;
+    SAFile fpQIX;
 };
 
 /************************************************************************/
 /*                         SHPOpenDiskTree()                            */
 /************************************************************************/
 
-SHPTreeDiskHandle SHPOpenDiskTree( const char* pszQIXFilename,
-                                   SAHooks *psHooks )
+SHPTreeDiskHandle SHPOpenDiskTree(const char *pszQIXFilename, SAHooks *psHooks)
 {
     SHPTreeDiskHandle hDiskTree;
 
-    hDiskTree = STATIC_CAST(SHPTreeDiskHandle, calloc(sizeof(struct SHPDiskTreeInfo),1));
+    hDiskTree = STATIC_CAST(SHPTreeDiskHandle,
+                            calloc(sizeof(struct SHPDiskTreeInfo), 1));
 
     if (psHooks == SHPLIB_NULLPTR)
-        SASetupDefaultHooks( &(hDiskTree->sHooks) );
+        SASetupDefaultHooks(&(hDiskTree->sHooks));
     else
-        memcpy( &(hDiskTree->sHooks), psHooks, sizeof(SAHooks) );
+        memcpy(&(hDiskTree->sHooks), psHooks, sizeof(SAHooks));
 
     hDiskTree->fpQIX = hDiskTree->sHooks.FOpen(pszQIXFilename, "rb");
     if (hDiskTree->fpQIX == SHPLIB_NULLPTR)
@@ -768,7 +755,7 @@ SHPTreeDiskHandle SHPOpenDiskTree( const char* pszQIXFilename,
 /*                         SHPCloseDiskTree()                           */
 /************************************************************************/
 
-void SHPCloseDiskTree( SHPTreeDiskHandle hDiskTree )
+void SHPCloseDiskTree(SHPTreeDiskHandle hDiskTree)
 {
     if (hDiskTree == SHPLIB_NULLPTR)
         return;
@@ -781,10 +768,11 @@ void SHPCloseDiskTree( SHPTreeDiskHandle hDiskTree )
 /*                       SHPSearchDiskTreeNode()                        */
 /************************************************************************/
 
-static bool
-SHPSearchDiskTreeNode( SHPTreeDiskHandle hDiskTree, double *padfBoundsMin, double *padfBoundsMax,
-                       int **ppanResultBuffer, int *pnBufferMax,
-                       int *pnResultCount, int bNeedSwap, int nRecLevel )
+static bool SHPSearchDiskTreeNode(SHPTreeDiskHandle hDiskTree,
+                                  double *padfBoundsMin, double *padfBoundsMax,
+                                  int **ppanResultBuffer, int *pnBufferMax,
+                                  int *pnResultCount, int bNeedSwap,
+                                  int nRecLevel)
 
 {
     unsigned int i;
@@ -793,76 +781,85 @@ SHPSearchDiskTreeNode( SHPTreeDiskHandle hDiskTree, double *padfBoundsMin, doubl
     double adfNodeBoundsMin[2], adfNodeBoundsMax[2];
     int nFReadAcc;
 
-/* -------------------------------------------------------------------- */
-/*      Read and unswap first part of node info.                        */
-/* -------------------------------------------------------------------- */
-    nFReadAcc = STATIC_CAST(int, hDiskTree->sHooks.FRead( &offset, 4, 1, hDiskTree->fpQIX ));
-    if ( bNeedSwap ) SwapWord ( 4, &offset );
+    /* -------------------------------------------------------------------- */
+    /*      Read and unswap first part of node info.                        */
+    /* -------------------------------------------------------------------- */
+    nFReadAcc = STATIC_CAST(
+        int, hDiskTree->sHooks.FRead(&offset, 4, 1, hDiskTree->fpQIX));
+    if (bNeedSwap)
+        SwapWord(4, &offset);
 
-    nFReadAcc += STATIC_CAST(int, hDiskTree->sHooks.FRead( adfNodeBoundsMin, sizeof(double), 2, hDiskTree->fpQIX ));
-    nFReadAcc += STATIC_CAST(int, hDiskTree->sHooks.FRead( adfNodeBoundsMax, sizeof(double), 2, hDiskTree->fpQIX ));
-    if ( bNeedSwap )
+    nFReadAcc += STATIC_CAST(int, hDiskTree->sHooks.FRead(adfNodeBoundsMin,
+                                                          sizeof(double), 2,
+                                                          hDiskTree->fpQIX));
+    nFReadAcc += STATIC_CAST(int, hDiskTree->sHooks.FRead(adfNodeBoundsMax,
+                                                          sizeof(double), 2,
+                                                          hDiskTree->fpQIX));
+    if (bNeedSwap)
     {
-        SwapWord( 8, adfNodeBoundsMin + 0 );
-        SwapWord( 8, adfNodeBoundsMin + 1 );
-        SwapWord( 8, adfNodeBoundsMax + 0 );
-        SwapWord( 8, adfNodeBoundsMax + 1 );
+        SwapWord(8, adfNodeBoundsMin + 0);
+        SwapWord(8, adfNodeBoundsMin + 1);
+        SwapWord(8, adfNodeBoundsMax + 0);
+        SwapWord(8, adfNodeBoundsMax + 1);
     }
 
-    nFReadAcc += STATIC_CAST(int, hDiskTree->sHooks.FRead( &numshapes, 4, 1, hDiskTree->fpQIX ));
-    if ( bNeedSwap ) SwapWord ( 4, &numshapes );
+    nFReadAcc += STATIC_CAST(
+        int, hDiskTree->sHooks.FRead(&numshapes, 4, 1, hDiskTree->fpQIX));
+    if (bNeedSwap)
+        SwapWord(4, &numshapes);
 
     /* Check that we could read all previous values */
-    if( nFReadAcc != 1 + 2 + 2 + 1 )
+    if (nFReadAcc != 1 + 2 + 2 + 1)
     {
         hDiskTree->sHooks.Error("I/O error");
         return false;
     }
 
     /* Sanity checks to avoid int overflows in later computation */
-    if( offset > INT_MAX - sizeof(int) )
+    if (offset > INT_MAX - sizeof(int))
     {
         hDiskTree->sHooks.Error("Invalid value for offset");
         return false;
     }
 
-    if( numshapes > (INT_MAX - offset - sizeof(int)) / sizeof(int) ||
-        numshapes > INT_MAX / sizeof(int) - *pnResultCount )
+    if (numshapes > (INT_MAX - offset - sizeof(int)) / sizeof(int) ||
+        numshapes > INT_MAX / sizeof(int) - *pnResultCount)
     {
         hDiskTree->sHooks.Error("Invalid value for numshapes");
         return false;
     }
 
-/* -------------------------------------------------------------------- */
-/*      If we don't overlap this node at all, we can just fseek()       */
-/*      pass this node info and all subnodes.                           */
-/* -------------------------------------------------------------------- */
-    if( !SHPCheckBoundsOverlap( adfNodeBoundsMin, adfNodeBoundsMax,
-                                padfBoundsMin, padfBoundsMax, 2 ) )
+    /* -------------------------------------------------------------------- */
+    /*      If we don't overlap this node at all, we can just fseek()       */
+    /*      pass this node info and all subnodes.                           */
+    /* -------------------------------------------------------------------- */
+    if (!SHPCheckBoundsOverlap(adfNodeBoundsMin, adfNodeBoundsMax,
+                               padfBoundsMin, padfBoundsMax, 2))
     {
-        offset += numshapes*sizeof(int) + sizeof(int);
+        offset += numshapes * sizeof(int) + sizeof(int);
         hDiskTree->sHooks.FSeek(hDiskTree->fpQIX, offset, SEEK_CUR);
         return true;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Add all the shapeids at this node to our list.                  */
-/* -------------------------------------------------------------------- */
-    if(numshapes > 0)
+    /* -------------------------------------------------------------------- */
+    /*      Add all the shapeids at this node to our list.                  */
+    /* -------------------------------------------------------------------- */
+    if (numshapes > 0)
     {
-        if( *pnResultCount + numshapes > STATIC_CAST(unsigned int, *pnBufferMax) )
+        if (*pnResultCount + numshapes >
+            STATIC_CAST(unsigned int, *pnBufferMax))
         {
-            int* pNewBuffer;
+            int *pNewBuffer;
 
             *pnBufferMax = (*pnResultCount + numshapes + 100) * 5 / 4;
 
-            if( STATIC_CAST(size_t, *pnBufferMax) > INT_MAX / sizeof(int) )
+            if (STATIC_CAST(size_t, *pnBufferMax) > INT_MAX / sizeof(int))
                 *pnBufferMax = *pnResultCount + numshapes;
 
-            pNewBuffer = STATIC_CAST(int *,
-                realloc( *ppanResultBuffer, *pnBufferMax * sizeof(int) ));
+            pNewBuffer = STATIC_CAST(
+                int *, realloc(*ppanResultBuffer, *pnBufferMax * sizeof(int)));
 
-            if( pNewBuffer == SHPLIB_NULLPTR )
+            if (pNewBuffer == SHPLIB_NULLPTR)
             {
                 hDiskTree->sHooks.Error("Out of memory error");
                 return false;
@@ -871,42 +868,44 @@ SHPSearchDiskTreeNode( SHPTreeDiskHandle hDiskTree, double *padfBoundsMin, doubl
             *ppanResultBuffer = pNewBuffer;
         }
 
-        if( hDiskTree->sHooks.FRead( *ppanResultBuffer + *pnResultCount,
-                    sizeof(int), numshapes, hDiskTree->fpQIX ) != numshapes )
+        if (hDiskTree->sHooks.FRead(*ppanResultBuffer + *pnResultCount,
+                                    sizeof(int), numshapes,
+                                    hDiskTree->fpQIX) != numshapes)
         {
             hDiskTree->sHooks.Error("I/O error");
             return false;
         }
 
-        if (bNeedSwap )
+        if (bNeedSwap)
         {
-            for( i=0; i<numshapes; i++ )
-                SwapWord( 4, *ppanResultBuffer + *pnResultCount + i );
+            for (i = 0; i < numshapes; i++)
+                SwapWord(4, *ppanResultBuffer + *pnResultCount + i);
         }
 
         *pnResultCount += numshapes;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Process the subnodes.                                           */
-/* -------------------------------------------------------------------- */
-    if( hDiskTree->sHooks.FRead( &numsubnodes, 4, 1, hDiskTree->fpQIX ) != 1 )
+    /* -------------------------------------------------------------------- */
+    /*      Process the subnodes.                                           */
+    /* -------------------------------------------------------------------- */
+    if (hDiskTree->sHooks.FRead(&numsubnodes, 4, 1, hDiskTree->fpQIX) != 1)
     {
         hDiskTree->sHooks.Error("I/O error");
         return false;
     }
-    if ( bNeedSwap  ) SwapWord ( 4, &numsubnodes );
-    if( numsubnodes > 0 && nRecLevel == 32 )
+    if (bNeedSwap)
+        SwapWord(4, &numsubnodes);
+    if (numsubnodes > 0 && nRecLevel == 32)
     {
         hDiskTree->sHooks.Error("Shape tree is too deep");
         return false;
     }
 
-    for(i=0; i<numsubnodes; i++)
+    for (i = 0; i < numsubnodes; i++)
     {
-        if( !SHPSearchDiskTreeNode( hDiskTree, padfBoundsMin, padfBoundsMax,
-                                    ppanResultBuffer, pnBufferMax,
-                                    pnResultCount, bNeedSwap, nRecLevel + 1 ) )
+        if (!SHPSearchDiskTreeNode(hDiskTree, padfBoundsMin, padfBoundsMax,
+                                   ppanResultBuffer, pnBufferMax, pnResultCount,
+                                   bNeedSwap, nRecLevel + 1))
             return false;
     }
 
@@ -917,35 +916,32 @@ SHPSearchDiskTreeNode( SHPTreeDiskHandle hDiskTree, double *padfBoundsMin, doubl
 /*                          SHPTreeReadLibc()                           */
 /************************************************************************/
 
-static
-SAOffset SHPTreeReadLibc( void *p, SAOffset size, SAOffset nmemb, SAFile file )
+static SAOffset SHPTreeReadLibc(void *p, SAOffset size, SAOffset nmemb,
+                                SAFile file)
 
 {
-    return STATIC_CAST(SAOffset, fread( p, STATIC_CAST(size_t, size),
-                             STATIC_CAST(size_t, nmemb),
-                             REINTERPRET_CAST(FILE*, file) ));
+    return STATIC_CAST(SAOffset, fread(p, STATIC_CAST(size_t, size),
+                                       STATIC_CAST(size_t, nmemb),
+                                       REINTERPRET_CAST(FILE *, file)));
 }
 
 /************************************************************************/
 /*                          SHPTreeSeekLibc()                           */
 /************************************************************************/
 
-static
-SAOffset SHPTreeSeekLibc( SAFile file, SAOffset offset, int whence )
+static SAOffset SHPTreeSeekLibc(SAFile file, SAOffset offset, int whence)
 
 {
-    return STATIC_CAST(SAOffset, fseek( REINTERPRET_CAST(FILE*, file),
-                             STATIC_CAST(long, offset), whence ));
+    return STATIC_CAST(SAOffset, fseek(REINTERPRET_CAST(FILE *, file),
+                                       STATIC_CAST(long, offset), whence));
 }
 
 /************************************************************************/
 /*                         SHPSearchDiskTree()                          */
 /************************************************************************/
 
-int SHPAPI_CALL1(*)
-SHPSearchDiskTree( FILE *fp,
-                   double *padfBoundsMin, double *padfBoundsMax,
-                   int *pnShapeCount )
+int SHPAPI_CALL1(*) SHPSearchDiskTree(FILE *fp, double *padfBoundsMin,
+                                      double *padfBoundsMax, int *pnShapeCount)
 {
     struct SHPDiskTreeInfo sDiskTree;
     memset(&sDiskTree.sHooks, 0, sizeof(sDiskTree.sHooks));
@@ -957,17 +953,16 @@ SHPSearchDiskTree( FILE *fp,
 
     sDiskTree.fpQIX = REINTERPRET_CAST(SAFile, fp);
 
-    return SHPSearchDiskTreeEx( &sDiskTree, padfBoundsMin, padfBoundsMax,
-                                 pnShapeCount );
+    return SHPSearchDiskTreeEx(&sDiskTree, padfBoundsMin, padfBoundsMax,
+                               pnShapeCount);
 }
 
 /***********************************************************************/
 /*                       SHPSearchDiskTreeEx()                         */
 /************************************************************************/
 
-int* SHPSearchDiskTreeEx( SHPTreeDiskHandle hDiskTree,
-                          double *padfBoundsMin, double *padfBoundsMax,
-                          int *pnShapeCount )
+int *SHPSearchDiskTreeEx(SHPTreeDiskHandle hDiskTree, double *padfBoundsMin,
+                         double *padfBoundsMax, int *pnShapeCount)
 
 {
     int i;
@@ -977,53 +972,51 @@ int* SHPSearchDiskTreeEx( SHPTreeDiskHandle hDiskTree,
 
     *pnShapeCount = 0;
 
-/* -------------------------------------------------------------------- */
-/*	Establish the byte order on this machine.	  	        */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*	Establish the byte order on this machine.	  	        */
+    /* -------------------------------------------------------------------- */
     i = 1;
-    if( *REINTERPRET_CAST(unsigned char *, &i) == 1 )
+    if (*REINTERPRET_CAST(unsigned char *, &i) == 1)
         bBigEndian = false;
     else
         bBigEndian = true;
 
-/* -------------------------------------------------------------------- */
-/*      Read the header.                                                */
-/* -------------------------------------------------------------------- */
-    hDiskTree->sHooks.FSeek( hDiskTree->fpQIX, 0, SEEK_SET );
-    hDiskTree->sHooks.FRead( abyBuf, 16, 1, hDiskTree->fpQIX );
+    /* -------------------------------------------------------------------- */
+    /*      Read the header.                                                */
+    /* -------------------------------------------------------------------- */
+    hDiskTree->sHooks.FSeek(hDiskTree->fpQIX, 0, SEEK_SET);
+    hDiskTree->sHooks.FRead(abyBuf, 16, 1, hDiskTree->fpQIX);
 
-    if( memcmp( abyBuf, "SQT", 3 ) != 0 )
+    if (memcmp(abyBuf, "SQT", 3) != 0)
         return SHPLIB_NULLPTR;
 
     bool bNeedSwap;
-    if( (abyBuf[3] == 2 && bBigEndian)
-        || (abyBuf[3] == 1 && !bBigEndian) )
+    if ((abyBuf[3] == 2 && bBigEndian) || (abyBuf[3] == 1 && !bBigEndian))
         bNeedSwap = false;
     else
         bNeedSwap = true;
 
-/* -------------------------------------------------------------------- */
-/*      Search through root node and its descendants.                   */
-/* -------------------------------------------------------------------- */
-    if( !SHPSearchDiskTreeNode( hDiskTree, padfBoundsMin, padfBoundsMax,
-                                &panResultBuffer, &nBufferMax,
-                                pnShapeCount, bNeedSwap, 0 ) )
+    /* -------------------------------------------------------------------- */
+    /*      Search through root node and its descendants.                   */
+    /* -------------------------------------------------------------------- */
+    if (!SHPSearchDiskTreeNode(hDiskTree, padfBoundsMin, padfBoundsMax,
+                               &panResultBuffer, &nBufferMax, pnShapeCount,
+                               bNeedSwap, 0))
     {
-        if( panResultBuffer != SHPLIB_NULLPTR )
-            free( panResultBuffer );
+        if (panResultBuffer != SHPLIB_NULLPTR)
+            free(panResultBuffer);
         *pnShapeCount = 0;
         return SHPLIB_NULLPTR;
     }
-/* -------------------------------------------------------------------- */
-/*      Sort the id array                                               */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Sort the id array                                               */
+    /* -------------------------------------------------------------------- */
 
     /* To distinguish between empty intersection from error case */
-    if( panResultBuffer == SHPLIB_NULLPTR )
-        panResultBuffer = STATIC_CAST(int*, calloc(1, sizeof(int)));
+    if (panResultBuffer == SHPLIB_NULLPTR)
+        panResultBuffer = STATIC_CAST(int *, calloc(1, sizeof(int)));
     else
         qsort(panResultBuffer, *pnShapeCount, sizeof(int), compare_ints);
-
 
     return panResultBuffer;
 }
@@ -1036,70 +1029,70 @@ int* SHPSearchDiskTreeEx( SHPTreeDiskHandle hDiskTree,
 /*      seek past them all efficiently.                                 */
 /************************************************************************/
 
-static int SHPGetSubNodeOffset( SHPTreeNode *node)
+static int SHPGetSubNodeOffset(SHPTreeNode *node)
 {
     int i;
-    int offset=0;
+    int offset = 0;
 
-    for(i=0; i<node->nSubNodes; i++ )
+    for (i = 0; i < node->nSubNodes; i++)
     {
-        if(node->apsSubNode[i])
+        if (node->apsSubNode[i])
         {
-            offset += 4*sizeof(double)
-                + (node->apsSubNode[i]->nShapeCount+3)*sizeof(int);
+            offset += 4 * sizeof(double) +
+                      (node->apsSubNode[i]->nShapeCount + 3) * sizeof(int);
             offset += SHPGetSubNodeOffset(node->apsSubNode[i]);
         }
     }
 
-    return(offset);
+    return (offset);
 }
 
 /************************************************************************/
 /*                          SHPWriteTreeNode()                          */
 /************************************************************************/
 
-static void SHPWriteTreeNode( SAFile fp, SHPTreeNode *node, SAHooks* psHooks)
+static void SHPWriteTreeNode(SAFile fp, SHPTreeNode *node, SAHooks *psHooks)
 {
-    int i,j;
+    int i, j;
     int offset;
     unsigned char *pabyRec;
-    assert( SHPLIB_NULLPTR != node );
+    assert(SHPLIB_NULLPTR != node);
 
     offset = SHPGetSubNodeOffset(node);
 
     pabyRec = STATIC_CAST(unsigned char *,
-        malloc(sizeof(double) * 4
-               + (3 * sizeof(int)) + (node->nShapeCount * sizeof(int)) ));
-    if( SHPLIB_NULLPTR == pabyRec )
+                          malloc(sizeof(double) * 4 + (3 * sizeof(int)) +
+                                 (node->nShapeCount * sizeof(int))));
+    if (SHPLIB_NULLPTR == pabyRec)
     {
 #ifdef USE_CPL
-        CPLError( CE_Fatal, CPLE_OutOfMemory, "Memory allocation failure");
+        CPLError(CE_Fatal, CPLE_OutOfMemory, "Memory allocation failure");
 #endif
-        assert( 0 );
+        assert(0);
         return;
     }
 
-    memcpy( pabyRec, &offset, 4);
+    memcpy(pabyRec, &offset, 4);
 
     /* minx, miny, maxx, maxy */
-    memcpy( pabyRec+ 4, node->adfBoundsMin+0, sizeof(double) );
-    memcpy( pabyRec+12, node->adfBoundsMin+1, sizeof(double) );
-    memcpy( pabyRec+20, node->adfBoundsMax+0, sizeof(double) );
-    memcpy( pabyRec+28, node->adfBoundsMax+1, sizeof(double) );
+    memcpy(pabyRec + 4, node->adfBoundsMin + 0, sizeof(double));
+    memcpy(pabyRec + 12, node->adfBoundsMin + 1, sizeof(double));
+    memcpy(pabyRec + 20, node->adfBoundsMax + 0, sizeof(double));
+    memcpy(pabyRec + 28, node->adfBoundsMax + 1, sizeof(double));
 
-    memcpy( pabyRec+36, &node->nShapeCount, 4);
+    memcpy(pabyRec + 36, &node->nShapeCount, 4);
     j = node->nShapeCount * sizeof(int);
-    if( j )
-        memcpy( pabyRec+40, node->panShapeIds, j);
-    memcpy( pabyRec+j+40, &node->nSubNodes, 4);
+    if (j)
+        memcpy(pabyRec + 40, node->panShapeIds, j);
+    memcpy(pabyRec + j + 40, &node->nSubNodes, 4);
 
-    psHooks->FWrite( pabyRec, 44+j, 1, fp );
-    free (pabyRec);
+    psHooks->FWrite(pabyRec, 44 + j, 1, fp);
+    free(pabyRec);
 
-    for(i=0; i<node->nSubNodes; i++ )
+    for (i = 0; i < node->nSubNodes; i++)
     {
-        if(node->apsSubNode[i])
-            SHPWriteTreeNode( fp, node->apsSubNode[i], psHooks);
+        if (node->apsSubNode[i])
+            SHPWriteTreeNode(fp, node->apsSubNode[i], psHooks);
     }
 }
 
@@ -1107,11 +1100,11 @@ static void SHPWriteTreeNode( SAFile fp, SHPTreeNode *node, SAHooks* psHooks)
 /*                            SHPWriteTree()                            */
 /************************************************************************/
 
-int SHPAPI_CALL SHPWriteTree(SHPTree *tree, const char *filename )
+int SHPAPI_CALL SHPWriteTree(SHPTree *tree, const char *filename)
 {
     SAHooks sHooks;
 
-    SASetupDefaultHooks( &sHooks );
+    SASetupDefaultHooks(&sHooks);
 
     return SHPWriteTreeLL(tree, filename, &sHooks);
 }
@@ -1120,44 +1113,44 @@ int SHPAPI_CALL SHPWriteTree(SHPTree *tree, const char *filename )
 /*                           SHPWriteTreeLL()                           */
 /************************************************************************/
 
-int SHPWriteTreeLL(SHPTree *tree, const char *filename, SAHooks* psHooks )
+int SHPWriteTreeLL(SHPTree *tree, const char *filename, SAHooks *psHooks)
 {
-    char		signature[4] = "SQT";
-    int		        i;
-    char		abyBuf[32];
-    SAFile              fp;
+    char signature[4] = "SQT";
+    int i;
+    char abyBuf[32];
+    SAFile fp;
 
     SAHooks sHooks;
     if (psHooks == SHPLIB_NULLPTR)
     {
-        SASetupDefaultHooks( &sHooks );
+        SASetupDefaultHooks(&sHooks);
         psHooks = &sHooks;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Open the output file.                                           */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Open the output file.                                           */
+    /* -------------------------------------------------------------------- */
     fp = psHooks->FOpen(filename, "wb");
-    if( fp == SHPLIB_NULLPTR )
+    if (fp == SHPLIB_NULLPTR)
     {
         return FALSE;
     }
 
-/* -------------------------------------------------------------------- */
-/*	Establish the byte order on this machine.	  	        */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*	Establish the byte order on this machine.	  	        */
+    /* -------------------------------------------------------------------- */
     i = 1;
-    if( *REINTERPRET_CAST(unsigned char *, &i) == 1 )
+    if (*REINTERPRET_CAST(unsigned char *, &i) == 1)
         bBigEndian = false;
     else
         bBigEndian = true;
 
-/* -------------------------------------------------------------------- */
-/*      Write the header.                                               */
-/* -------------------------------------------------------------------- */
-    memcpy( abyBuf+0, signature, 3 );
+    /* -------------------------------------------------------------------- */
+    /*      Write the header.                                               */
+    /* -------------------------------------------------------------------- */
+    memcpy(abyBuf + 0, signature, 3);
 
-    if( bBigEndian )
+    if (bBigEndian)
         abyBuf[3] = 2; /* New MSB */
     else
         abyBuf[3] = 1; /* New LSB */
@@ -1167,21 +1160,21 @@ int SHPWriteTreeLL(SHPTree *tree, const char *filename, SAHooks* psHooks )
     abyBuf[6] = 0;
     abyBuf[7] = 0;
 
-    psHooks->FWrite( abyBuf, 8, 1, fp );
+    psHooks->FWrite(abyBuf, 8, 1, fp);
 
-    psHooks->FWrite( &(tree->nTotalCount), 4, 1, fp );
+    psHooks->FWrite(&(tree->nTotalCount), 4, 1, fp);
 
     /* write maxdepth */
 
-    psHooks->FWrite( &(tree->nMaxDepth), 4, 1, fp );
+    psHooks->FWrite(&(tree->nMaxDepth), 4, 1, fp);
 
-/* -------------------------------------------------------------------- */
-/*      Write all the nodes "in order".                                 */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Write all the nodes "in order".                                 */
+    /* -------------------------------------------------------------------- */
 
-    SHPWriteTreeNode( fp, tree->psRoot, psHooks );
+    SHPWriteTreeNode(fp, tree->psRoot, psHooks);
 
-    psHooks->FClose( fp );
+    psHooks->FClose(fp);
 
     return TRUE;
 }

--- a/shptreedump.c
+++ b/shptreedump.c
@@ -46,8 +46,8 @@
 
 SHP_CVSID("$Id$")
 
-static void SHPTreeNodeDump( SHPTree *, SHPTreeNode *, const char *, int );
-static void SHPTreeNodeSearchAndDump( SHPTree *, double *, double * );
+static void SHPTreeNodeDump(SHPTree *, SHPTreeNode *, const char *, int);
+static void SHPTreeNodeSearchAndDump(SHPTree *, double *, double *);
 
 /************************************************************************/
 /*                               Usage()                                */
@@ -56,18 +56,16 @@ static void SHPTreeNodeSearchAndDump( SHPTree *, double *, double * );
 static void Usage()
 
 {
-    printf( "shptreedump [-maxdepth n] [-search xmin ymin xmax ymax]\n"
-            "            [-v] [-o indexfilename] [-i indexfilename]\n"
-            "            shp_file\n" );
-    exit( 1 );
+    printf("shptreedump [-maxdepth n] [-search xmin ymin xmax ymax]\n"
+           "            [-v] [-o indexfilename] [-i indexfilename]\n"
+           "            shp_file\n");
+    exit(1);
 }
-
-
 
 /************************************************************************/
 /*                                main()                                */
 /************************************************************************/
-int main( int argc, char ** argv )
+int main(int argc, char **argv)
 
 {
     int nExpandShapes = 0;
@@ -79,36 +77,36 @@ int main( int argc, char ** argv )
     const char *pszInputIndexFilename = NULL;
     const char *pszTargetFile = NULL;
 
-/* -------------------------------------------------------------------- */
-/*	Consume flags.							*/
-/* -------------------------------------------------------------------- */
-    while( argc > 1 )
+    /* -------------------------------------------------------------------- */
+    /*	Consume flags.							*/
+    /* -------------------------------------------------------------------- */
+    while (argc > 1)
     {
-        if( strcmp(argv[1],"-v") == 0 )
+        if (strcmp(argv[1], "-v") == 0)
         {
             nExpandShapes = 1;
             argv++;
             argc--;
         }
-        else if( strcmp(argv[1],"-maxdepth") == 0 && argc > 2 )
+        else if (strcmp(argv[1], "-maxdepth") == 0 && argc > 2)
         {
             nMaxDepth = atoi(argv[2]);
             argv += 2;
             argc -= 2;
         }
-        else if( strcmp(argv[1],"-o") == 0 && argc > 2 )
+        else if (strcmp(argv[1], "-o") == 0 && argc > 2)
         {
             pszOutputIndexFilename = argv[2];
             argv += 2;
             argc -= 2;
         }
-        else if( strcmp(argv[1],"-i") == 0 && argc > 2 )
+        else if (strcmp(argv[1], "-i") == 0 && argc > 2)
         {
             pszInputIndexFilename = argv[2];
             argv += 2;
             argc -= 2;
         }
-        else if( strcmp(argv[1],"-search") == 0 && argc > 5 )
+        else if (strcmp(argv[1], "-search") == 0 && argc > 5)
         {
             bDoSearch = true;
 
@@ -120,17 +118,17 @@ int main( int argc, char ** argv )
             adfSearchMin[2] = adfSearchMax[2] = 0.0;
             adfSearchMin[3] = adfSearchMax[3] = 0.0;
 
-            if( adfSearchMin[0] > adfSearchMax[0]
-                || adfSearchMin[1] > adfSearchMax[1] )
+            if (adfSearchMin[0] > adfSearchMax[0] ||
+                adfSearchMin[1] > adfSearchMax[1])
             {
-                printf( "Min greater than max in search criteria.\n" );
+                printf("Min greater than max in search criteria.\n");
                 Usage();
             }
 
             argv += 5;
             argc -= 5;
         }
-        else if( pszTargetFile == NULL )
+        else if (pszTargetFile == NULL)
         {
             pszTargetFile = argv[1];
             argv++;
@@ -138,129 +136,129 @@ int main( int argc, char ** argv )
         }
         else
         {
-            printf( "Unrecognised argument: %s\n", argv[1] );
+            printf("Unrecognised argument: %s\n", argv[1]);
             Usage();
         }
     }
 
-/* -------------------------------------------------------------------- */
-/*      Do a search with an existing index file?                        */
-/* -------------------------------------------------------------------- */
-    if( bDoSearch && pszInputIndexFilename != NULL )
+    /* -------------------------------------------------------------------- */
+    /*      Do a search with an existing index file?                        */
+    /* -------------------------------------------------------------------- */
+    if (bDoSearch && pszInputIndexFilename != NULL)
     {
-        FILE *fp = fopen( pszInputIndexFilename, "rb" );
+        FILE *fp = fopen(pszInputIndexFilename, "rb");
 
-        if( fp == NULL )
+        if (fp == NULL)
         {
-            perror( pszInputIndexFilename );
-            exit( 1 );
+            perror(pszInputIndexFilename);
+            exit(1);
         }
 
         int nResultCount = 0;
-        int *panResult = SHPSearchDiskTree( fp, adfSearchMin, adfSearchMax,
-                                       &nResultCount );
+        int *panResult =
+            SHPSearchDiskTree(fp, adfSearchMin, adfSearchMax, &nResultCount);
 
-        printf( "Result: " );
-        for( int iResult = 0; iResult < nResultCount; iResult++ )
-            printf( "%d ", panResult[iResult] );
-        printf( "\n" );
-        free( panResult );
+        printf("Result: ");
+        for (int iResult = 0; iResult < nResultCount; iResult++)
+            printf("%d ", panResult[iResult]);
+        printf("\n");
+        free(panResult);
 
-        fclose( fp );
+        fclose(fp);
 
-        exit( 0 );
+        exit(0);
     }
 
-/* -------------------------------------------------------------------- */
-/*      Display a usage message.                                        */
-/* -------------------------------------------------------------------- */
-    if( pszTargetFile == NULL )
+    /* -------------------------------------------------------------------- */
+    /*      Display a usage message.                                        */
+    /* -------------------------------------------------------------------- */
+    if (pszTargetFile == NULL)
     {
         Usage();
     }
 
-/* -------------------------------------------------------------------- */
-/*      Open the passed shapefile.                                      */
-/* -------------------------------------------------------------------- */
-    SHPHandle hSHP = SHPOpen( pszTargetFile, "rb" );
+    /* -------------------------------------------------------------------- */
+    /*      Open the passed shapefile.                                      */
+    /* -------------------------------------------------------------------- */
+    SHPHandle hSHP = SHPOpen(pszTargetFile, "rb");
 
-    if( hSHP == NULL )
+    if (hSHP == NULL)
     {
-	printf( "Unable to open:%s\n", pszTargetFile );
-	exit( 1 );
+        printf("Unable to open:%s\n", pszTargetFile);
+        exit(1);
     }
 
-/* -------------------------------------------------------------------- */
-/*      Build a quadtree structure for this file.                       */
-/* -------------------------------------------------------------------- */
-    SHPTree *psTree = SHPCreateTree( hSHP, 2, nMaxDepth, NULL, NULL );
+    /* -------------------------------------------------------------------- */
+    /*      Build a quadtree structure for this file.                       */
+    /* -------------------------------------------------------------------- */
+    SHPTree *psTree = SHPCreateTree(hSHP, 2, nMaxDepth, NULL, NULL);
 
-/* -------------------------------------------------------------------- */
-/*      Trim unused nodes from the tree.                                */
-/* -------------------------------------------------------------------- */
-    SHPTreeTrimExtraNodes( psTree );
+    /* -------------------------------------------------------------------- */
+    /*      Trim unused nodes from the tree.                                */
+    /* -------------------------------------------------------------------- */
+    SHPTreeTrimExtraNodes(psTree);
 
-/* -------------------------------------------------------------------- */
-/*      Dump tree to .qix file.                                         */
-/* -------------------------------------------------------------------- */
-    if( pszOutputIndexFilename != NULL )
+    /* -------------------------------------------------------------------- */
+    /*      Dump tree to .qix file.                                         */
+    /* -------------------------------------------------------------------- */
+    if (pszOutputIndexFilename != NULL)
     {
-        SHPWriteTree( psTree, pszOutputIndexFilename );
+        SHPWriteTree(psTree, pszOutputIndexFilename);
     }
 
-/* -------------------------------------------------------------------- */
-/*      Dump tree by recursive descent.                                 */
-/* -------------------------------------------------------------------- */
-    else if( !bDoSearch )
-        SHPTreeNodeDump( psTree, psTree->psRoot, "", nExpandShapes );
+    /* -------------------------------------------------------------------- */
+    /*      Dump tree by recursive descent.                                 */
+    /* -------------------------------------------------------------------- */
+    else if (!bDoSearch)
+        SHPTreeNodeDump(psTree, psTree->psRoot, "", nExpandShapes);
 
-/* -------------------------------------------------------------------- */
-/*      or do a search instead.                                         */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      or do a search instead.                                         */
+    /* -------------------------------------------------------------------- */
     else
-        SHPTreeNodeSearchAndDump( psTree, adfSearchMin, adfSearchMax );
+        SHPTreeNodeSearchAndDump(psTree, adfSearchMin, adfSearchMax);
 
-/* -------------------------------------------------------------------- */
-/*      cleanup                                                         */
-/* -------------------------------------------------------------------- */
-    SHPDestroyTree( psTree );
+    /* -------------------------------------------------------------------- */
+    /*      cleanup                                                         */
+    /* -------------------------------------------------------------------- */
+    SHPDestroyTree(psTree);
 
-    SHPClose( hSHP );
+    SHPClose(hSHP);
 
 #ifdef USE_DBMALLOC
     malloc_dump(2);
 #endif
 
-    exit( 0 );
+    exit(0);
 }
 
 /************************************************************************/
 /*                           EmitCoordinate()                           */
 /************************************************************************/
 
-static void EmitCoordinate( double * padfCoord, int nDimension )
+static void EmitCoordinate(double *padfCoord, int nDimension)
 
 {
-    const char	*pszFormat;
+    const char *pszFormat;
 
-    if( fabs(padfCoord[0]) < 180 && fabs(padfCoord[1]) < 180 )
+    if (fabs(padfCoord[0]) < 180 && fabs(padfCoord[1]) < 180)
         pszFormat = "%.9f";
     else
         pszFormat = "%.2f";
 
-    printf( pszFormat, padfCoord[0] );
-    printf( "," );
-    printf( pszFormat, padfCoord[1] );
+    printf(pszFormat, padfCoord[0]);
+    printf(",");
+    printf(pszFormat, padfCoord[1]);
 
-    if( nDimension > 2 )
+    if (nDimension > 2)
     {
-        printf( "," );
-        printf( pszFormat, padfCoord[2] );
+        printf(",");
+        printf(pszFormat, padfCoord[2]);
     }
-    if( nDimension > 3 )
+    if (nDimension > 3)
     {
-        printf( "," );
-        printf( pszFormat, padfCoord[3] );
+        printf(",");
+        printf(pszFormat, padfCoord[3]);
     }
 }
 
@@ -268,36 +266,36 @@ static void EmitCoordinate( double * padfCoord, int nDimension )
 /*                             EmitShape()                              */
 /************************************************************************/
 
-static void EmitShape( SHPObject * psObject, const char * pszPrefix,
-                       int nDimension )
+static void EmitShape(SHPObject *psObject, const char *pszPrefix,
+                      int nDimension)
 
 {
-    printf( "%s( Shape\n", pszPrefix );
-    printf( "%s  ShapeId = %d\n", pszPrefix, psObject->nShapeId );
+    printf("%s( Shape\n", pszPrefix);
+    printf("%s  ShapeId = %d\n", pszPrefix, psObject->nShapeId);
 
-    printf( "%s  Min = (", pszPrefix );
-    EmitCoordinate( &(psObject->dfXMin), nDimension );
-    printf( ")\n" );
+    printf("%s  Min = (", pszPrefix);
+    EmitCoordinate(&(psObject->dfXMin), nDimension);
+    printf(")\n");
 
-    printf( "%s  Max = (", pszPrefix );
-    EmitCoordinate( &(psObject->dfXMax), nDimension );
-    printf( ")\n" );
+    printf("%s  Max = (", pszPrefix);
+    EmitCoordinate(&(psObject->dfXMax), nDimension);
+    printf(")\n");
 
-    for( int i = 0; i < psObject->nVertices; i++ )
+    for (int i = 0; i < psObject->nVertices; i++)
     {
-        double	adfVertex[4];
+        double adfVertex[4];
 
-        printf( "%s  Vertex[%d] = (", pszPrefix, i );
+        printf("%s  Vertex[%d] = (", pszPrefix, i);
 
         adfVertex[0] = psObject->padfX[i];
         adfVertex[1] = psObject->padfY[i];
         adfVertex[2] = psObject->padfZ[i];
         adfVertex[3] = psObject->padfM[i];
 
-        EmitCoordinate( adfVertex, nDimension );
-        printf( ")\n" );
+        EmitCoordinate(adfVertex, nDimension);
+        printf(")\n");
     }
-    printf( "%s)\n", pszPrefix );
+    printf("%s)\n", pszPrefix);
 }
 
 /************************************************************************/
@@ -306,73 +304,70 @@ static void EmitShape( SHPObject * psObject, const char * pszPrefix,
 /*      Dump a tree node in a readable form.                            */
 /************************************************************************/
 
-static void SHPTreeNodeDump( SHPTree * psTree,
-                             SHPTreeNode * psTreeNode,
-                             const char * pszPrefix,
-                             int nExpandShapes )
+static void SHPTreeNodeDump(SHPTree *psTree, SHPTreeNode *psTreeNode,
+                            const char *pszPrefix, int nExpandShapes)
 
 {
-    char	szNextPrefix[150];
+    char szNextPrefix[150];
 
-    strcpy( szNextPrefix, pszPrefix );
-    if( strlen(pszPrefix) < sizeof(szNextPrefix) - 3 )
-        strcat( szNextPrefix, "  " );
+    strcpy(szNextPrefix, pszPrefix);
+    if (strlen(pszPrefix) < sizeof(szNextPrefix) - 3)
+        strcat(szNextPrefix, "  ");
 
-    printf( "%s( SHPTreeNode\n", pszPrefix );
+    printf("%s( SHPTreeNode\n", pszPrefix);
 
-/* -------------------------------------------------------------------- */
-/*      Emit the bounds.                                                */
-/* -------------------------------------------------------------------- */
-    printf( "%s  Min = (", pszPrefix );
-    EmitCoordinate( psTreeNode->adfBoundsMin, psTree->nDimension );
-    printf( ")\n" );
+    /* -------------------------------------------------------------------- */
+    /*      Emit the bounds.                                                */
+    /* -------------------------------------------------------------------- */
+    printf("%s  Min = (", pszPrefix);
+    EmitCoordinate(psTreeNode->adfBoundsMin, psTree->nDimension);
+    printf(")\n");
 
-    printf( "%s  Max = (", pszPrefix );
-    EmitCoordinate( psTreeNode->adfBoundsMax, psTree->nDimension );
-    printf( ")\n" );
+    printf("%s  Max = (", pszPrefix);
+    EmitCoordinate(psTreeNode->adfBoundsMax, psTree->nDimension);
+    printf(")\n");
 
-/* -------------------------------------------------------------------- */
-/*      Emit the list of shapes on this node.                           */
-/* -------------------------------------------------------------------- */
-    if( nExpandShapes )
+    /* -------------------------------------------------------------------- */
+    /*      Emit the list of shapes on this node.                           */
+    /* -------------------------------------------------------------------- */
+    if (nExpandShapes)
     {
-        printf( "%s  Shapes(%d):\n", pszPrefix, psTreeNode->nShapeCount );
-        for( int i = 0; i < psTreeNode->nShapeCount; i++ )
+        printf("%s  Shapes(%d):\n", pszPrefix, psTreeNode->nShapeCount);
+        for (int i = 0; i < psTreeNode->nShapeCount; i++)
         {
-            SHPObject	*psObject;
+            SHPObject *psObject;
 
-            psObject = SHPReadObject( psTree->hSHP,
-                                      psTreeNode->panShapeIds[i] );
-            assert( psObject != NULL );
-            if( psObject != NULL )
+            psObject = SHPReadObject(psTree->hSHP, psTreeNode->panShapeIds[i]);
+            assert(psObject != NULL);
+            if (psObject != NULL)
             {
-                EmitShape( psObject, szNextPrefix, psTree->nDimension );
+                EmitShape(psObject, szNextPrefix, psTree->nDimension);
             }
 
-            SHPDestroyObject( psObject );
+            SHPDestroyObject(psObject);
         }
     }
     else
     {
-        printf( "%s  Shapes(%d): ", pszPrefix, psTreeNode->nShapeCount );
-        for( int i = 0; i < psTreeNode->nShapeCount; i++ )
+        printf("%s  Shapes(%d): ", pszPrefix, psTreeNode->nShapeCount);
+        for (int i = 0; i < psTreeNode->nShapeCount; i++)
         {
-            printf( "%d ", psTreeNode->panShapeIds[i] );
+            printf("%d ", psTreeNode->panShapeIds[i]);
         }
-        printf( "\n" );
+        printf("\n");
     }
 
-/* -------------------------------------------------------------------- */
-/*      Emit subnodes.                                                  */
-/* -------------------------------------------------------------------- */
-    for( int i = 0; i < psTreeNode->nSubNodes; i++ )
+    /* -------------------------------------------------------------------- */
+    /*      Emit subnodes.                                                  */
+    /* -------------------------------------------------------------------- */
+    for (int i = 0; i < psTreeNode->nSubNodes; i++)
     {
-        if( psTreeNode->apsSubNode[i] != NULL )
-            SHPTreeNodeDump( psTree, psTreeNode->apsSubNode[i],
-                             szNextPrefix, nExpandShapes );
+        if (psTreeNode->apsSubNode[i] != NULL)
+            SHPTreeNodeDump(psTree, psTreeNode->apsSubNode[i], szNextPrefix,
+                            nExpandShapes);
     }
 
-    printf( "%s)\n", pszPrefix );
+    printf("%s)\n", pszPrefix);
 
     return;
 }
@@ -381,50 +376,48 @@ static void SHPTreeNodeDump( SHPTree * psTree,
 /*                      SHPTreeNodeSearchAndDump()                      */
 /************************************************************************/
 
-static void SHPTreeNodeSearchAndDump( SHPTree * hTree,
-                                      double *padfBoundsMin,
-                                      double *padfBoundsMax )
+static void SHPTreeNodeSearchAndDump(SHPTree *hTree, double *padfBoundsMin,
+                                     double *padfBoundsMax)
 
 {
-/* -------------------------------------------------------------------- */
-/*      Perform the search for likely candidates.  These are shapes     */
-/*      that fall into a tree node whose bounding box intersects our    */
-/*      area of interest.                                               */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Perform the search for likely candidates.  These are shapes     */
+    /*      that fall into a tree node whose bounding box intersects our    */
+    /*      area of interest.                                               */
+    /* -------------------------------------------------------------------- */
     int nShapeCount;
-    int *panHits = SHPTreeFindLikelyShapes( hTree, padfBoundsMin, padfBoundsMax,
-                                       &nShapeCount );
+    int *panHits = SHPTreeFindLikelyShapes(hTree, padfBoundsMin, padfBoundsMax,
+                                           &nShapeCount);
 
-/* -------------------------------------------------------------------- */
-/*      Read all of these shapes, and establish whether the shape's     */
-/*      bounding box actually intersects the area of interest.  Note    */
-/*      that the bounding box could intersect the area of interest,     */
-/*      and the shape itself still not cross it but we don't try to     */
-/*      address that here.                                              */
-/* -------------------------------------------------------------------- */
-    for( int i = 0; i < nShapeCount; i++ )
+    /* -------------------------------------------------------------------- */
+    /*      Read all of these shapes, and establish whether the shape's     */
+    /*      bounding box actually intersects the area of interest.  Note    */
+    /*      that the bounding box could intersect the area of interest,     */
+    /*      and the shape itself still not cross it but we don't try to     */
+    /*      address that here.                                              */
+    /* -------------------------------------------------------------------- */
+    for (int i = 0; i < nShapeCount; i++)
     {
-        SHPObject *psObject = SHPReadObject( hTree->hSHP, panHits[i] );
-        if( psObject == NULL )
+        SHPObject *psObject = SHPReadObject(hTree->hSHP, panHits[i]);
+        if (psObject == NULL)
             continue;
 
-        if( !SHPCheckBoundsOverlap( padfBoundsMin, padfBoundsMax,
-                                    &(psObject->dfXMin),
-                                    &(psObject->dfXMax),
-                                    hTree->nDimension ) )
+        if (!SHPCheckBoundsOverlap(padfBoundsMin, padfBoundsMax,
+                                   &(psObject->dfXMin), &(psObject->dfXMax),
+                                   hTree->nDimension))
         {
-            printf( "Shape %d: not in area of interest, but fetched.\n",
-                    panHits[i] );
+            printf("Shape %d: not in area of interest, but fetched.\n",
+                   panHits[i]);
         }
         else
         {
-            printf( "Shape %d: appears to be in area of interest.\n",
-                    panHits[i] );
+            printf("Shape %d: appears to be in area of interest.\n",
+                   panHits[i]);
         }
 
-        SHPDestroyObject( psObject );
+        SHPDestroyObject(psObject);
     }
 
-    if( nShapeCount == 0 )
-        printf( "No shapes found in search.\n" );
+    if (nShapeCount == 0)
+        printf("No shapes found in search.\n");
 }

--- a/shputils.c
+++ b/shputils.c
@@ -61,31 +61,31 @@
 
 SHP_CVSID("$Id$")
 
-char            infile[80], outfile[80], temp[400];
+char infile[80], outfile[80], temp[400];
 
 /* Variables for shape files */
-SHPHandle	hSHP;
-SHPHandle	hSHPappend;
-int		nShapeType, nEntities, iPart;
-int		nShapeTypeAppend, nEntitiesAppend;
-SHPObject	*psCShape;
-double		adfBoundsMin[4], adfBoundsMax[4];
+SHPHandle hSHP;
+SHPHandle hSHPappend;
+int nShapeType, nEntities, iPart;
+int nShapeTypeAppend, nEntitiesAppend;
+SHPObject *psCShape;
+double adfBoundsMin[4], adfBoundsMax[4];
 
 /* Variables for DBF files */
-DBFHandle	hDBF;
-DBFHandle	hDBFappend;
+DBFHandle hDBF;
+DBFHandle hDBFappend;
 
-DBFFieldType    iType;
-DBFFieldType    jType;
+DBFFieldType iType;
+DBFFieldType jType;
 
-char	iszTitle[12];
-char	jszTitle[12];
+char iszTitle[12];
+char jszTitle[12];
 
-int	*pt;  // TODO(schwehr): Danger.  Shadowed
-char	iszFormat[32], iszField[1024];
-char	jszFormat[32], jszField[1024];
-int	ti, iWidth, iDecimals;
-int	tj, jWidth, jDecimals;
+int *pt;  // TODO(schwehr): Danger.  Shadowed
+char iszFormat[32], iszField[1024];
+char jszFormat[32], jszField[1024];
+int ti, iWidth, iDecimals;
+int tj, jWidth, jDecimals;
 
 /* -------------------------------------------------------------------- */
 /* Variables for the DESCRIBE function */
@@ -97,33 +97,33 @@ bool iall = false;
 /* -------------------------------------------------------------------- */
 bool found = false;
 bool newdbf = false;
-char      selectitem[40], *cpt;
-long int  selectvalues[150], selcount=0;
+char selectitem[40], *cpt;
+long int selectvalues[150], selcount = 0;
 bool iselect = false;
-int       iselectitem = -1;
+int iselectitem = -1;
 bool iunselect = false;
 
 /* -------------------------------------------------------------------- */
 /* Variables for the CLIP and ERASE functions */
 /* -------------------------------------------------------------------- */
-double  cxmin, cymin, cxmax, cymax;
+double cxmin, cymin, cxmax, cymax;
 bool iclip = false;
 bool ierase = false;
 bool itouch = false;
 bool iinside = false;
 bool icut = false;
-char    clipfile[80];
+char clipfile[80];
 
 /* -------------------------------------------------------------------- */
 /* Variables for the FACTOR function */
 /* -------------------------------------------------------------------- */
-double  infactor,outfactor,factor = 0;  /* NO FACTOR */
+double infactor, outfactor, factor = 0; /* NO FACTOR */
 bool iunit = false;
 
 /* -------------------------------------------------------------------- */
 /* Variables for the SHIFT function */
 /* -------------------------------------------------------------------- */
-double  xshift = 0, yshift = 0;  /* NO SHIFT */
+double xshift = 0, yshift = 0; /* NO SHIFT */
 
 /* -------------------------------------------------------------------- */
 /*	Change the extension.  If there is any extension on the 	*/
@@ -132,88 +132,90 @@ double  xshift = 0, yshift = 0;  /* NO SHIFT */
 void setext(char *pt, const char *ext)
 {
     int i = strlen(pt) - 1;
-    for( ;
-	 i > 0 && pt[i] != '.' && pt[i] != '/' && pt[i] != '\\';
-	 i-- ) {}
+    for (; i > 0 && pt[i] != '.' && pt[i] != '/' && pt[i] != '\\'; i--)
+    {
+    }
 
-    if( pt[i] == '.' )
+    if (pt[i] == '.')
         pt[i] = '\0';
 
-    strcat(pt,".");
-    strcat(pt,ext);
+    strcat(pt, ".");
+    strcat(pt, ext);
 }
 
 /************************************************************************/
 /*                             openfiles()                              */
 /************************************************************************/
 
-void openfiles() {
-/* -------------------------------------------------------------------- */
-/*      Open the DBF file.                                              */
-/* -------------------------------------------------------------------- */
+void openfiles()
+{
+    /* -------------------------------------------------------------------- */
+    /*      Open the DBF file.                                              */
+    /* -------------------------------------------------------------------- */
     setext(infile, "dbf");
-    hDBF = DBFOpen( infile, "rb" );
-    if( hDBF == NULL )
+    hDBF = DBFOpen(infile, "rb");
+    if (hDBF == NULL)
     {
-	printf( "ERROR: Unable to open the input DBF:%s\n", infile );
-	exit( 1 );
+        printf("ERROR: Unable to open the input DBF:%s\n", infile);
+        exit(1);
     }
-/* -------------------------------------------------------------------- */
-/*      Open the append DBF file.                                       */
-/* -------------------------------------------------------------------- */
-    if (strcmp(outfile,"")) {
+    /* -------------------------------------------------------------------- */
+    /*      Open the append DBF file.                                       */
+    /* -------------------------------------------------------------------- */
+    if (strcmp(outfile, ""))
+    {
         setext(outfile, "dbf");
-        hDBFappend = DBFOpen( outfile, "rb+" );
+        hDBFappend = DBFOpen(outfile, "rb+");
         newdbf = false;
-        if( hDBFappend == NULL )
+        if (hDBFappend == NULL)
         {
             newdbf = true;
-            hDBFappend = DBFCreate( outfile );
-            if( hDBFappend == NULL )
+            hDBFappend = DBFCreate(outfile);
+            if (hDBFappend == NULL)
             {
-                printf( "ERROR: Unable to open the append DBF:%s\n", outfile );
-                exit( 1 );
+                printf("ERROR: Unable to open the append DBF:%s\n", outfile);
+                exit(1);
             }
         }
     }
-/* -------------------------------------------------------------------- */
-/*      Open the passed shapefile.                                      */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*      Open the passed shapefile.                                      */
+    /* -------------------------------------------------------------------- */
     setext(infile, "shp");
-    hSHP = SHPOpen( infile, "rb" );
+    hSHP = SHPOpen(infile, "rb");
 
-    if( hSHP == NULL )
+    if (hSHP == NULL)
     {
-	printf( "ERROR: Unable to open the input shape file:%s\n", infile );
-	exit( 1 );
+        printf("ERROR: Unable to open the input shape file:%s\n", infile);
+        exit(1);
     }
 
-    SHPGetInfo( hSHP, &nEntities, &nShapeType, NULL, NULL );
+    SHPGetInfo(hSHP, &nEntities, &nShapeType, NULL, NULL);
 
-/* -------------------------------------------------------------------- */
-/*      Open the passed append shapefile.                               */
-/* -------------------------------------------------------------------- */
-    if (strcmp(outfile,"")) {
+    /* -------------------------------------------------------------------- */
+    /*      Open the passed append shapefile.                               */
+    /* -------------------------------------------------------------------- */
+    if (strcmp(outfile, ""))
+    {
         setext(outfile, "shp");
-        hSHPappend = SHPOpen( outfile, "rb+" );
+        hSHPappend = SHPOpen(outfile, "rb+");
 
-        if( hSHPappend == NULL )
+        if (hSHPappend == NULL)
         {
-            hSHPappend = SHPCreate( outfile, nShapeType );
-            if( hSHPappend == NULL )
+            hSHPappend = SHPCreate(outfile, nShapeType);
+            if (hSHPappend == NULL)
             {
-                printf( "ERROR: Unable to open the append shape file:%s\n",
-                        outfile );
-                exit( 1 );
+                printf("ERROR: Unable to open the append shape file:%s\n",
+                       outfile);
+                exit(1);
             }
         }
-        SHPGetInfo( hSHPappend, &nEntitiesAppend, &nShapeTypeAppend,
-                    NULL, NULL );
+        SHPGetInfo(hSHPappend, &nEntitiesAppend, &nShapeTypeAppend, NULL, NULL);
 
         if (nShapeType != nShapeTypeAppend)
         {
-            puts( "ERROR: Input and Append shape files are of different types.");
-            exit( 1 );
+            puts("ERROR: Input and Append shape files are of different types.");
+            exit(1);
         }
     }
 }
@@ -224,62 +226,70 @@ void openfiles() {
 /* -------------------------------------------------------------------- */
 void mergefields()
 {
-    ti = DBFGetFieldCount( hDBF );
-    tj = DBFGetFieldCount( hDBFappend );
+    ti = DBFGetFieldCount(hDBF);
+    tj = DBFGetFieldCount(hDBFappend);
     /* Create a pointer array for the max # of fields in the output file */
-    pt = (int *) malloc( (ti+tj+1) * sizeof(int) );
+    pt = (int *)malloc((ti + tj + 1) * sizeof(int));
 
-    for( int i = 0; i < ti; i++ )
+    for (int i = 0; i < ti; i++)
     {
-        pt[i]= -1;  /* Initial pt values to -1 */
+        pt[i] = -1; /* Initial pt values to -1 */
     }
     /* DBF must be empty before adding items */
-    const int jRecord = DBFGetRecordCount( hDBFappend );
+    const int jRecord = DBFGetRecordCount(hDBFappend);
     int j;
-    for( int i = 0; i < ti; i++ )
+    for (int i = 0; i < ti; i++)
     {
-	iType = DBFGetFieldInfo( hDBF, i, iszTitle, &iWidth, &iDecimals );
+        iType = DBFGetFieldInfo(hDBF, i, iszTitle, &iWidth, &iDecimals);
         found = false;
 
-        for( j = 0; j < tj; j++ )   /* Search all field names for a match */
-    	{
-	    jType = DBFGetFieldInfo( hDBFappend, j, jszTitle, &jWidth, &jDecimals );
-	    if (iType == jType && (strcmp(iszTitle, jszTitle) == 0) )
-	    {
-	        if (found || newdbf)
-	        {
-	            if (i == j)  pt[i]=j;
-	            printf("Warning: Duplicate field name found (%s)\n",iszTitle);
-	            /* Duplicate field name
+        for (j = 0; j < tj; j++) /* Search all field names for a match */
+        {
+            jType =
+                DBFGetFieldInfo(hDBFappend, j, jszTitle, &jWidth, &jDecimals);
+            if (iType == jType && (strcmp(iszTitle, jszTitle) == 0))
+            {
+                if (found || newdbf)
+                {
+                    if (i == j)
+                        pt[i] = j;
+                    printf("Warning: Duplicate field name found (%s)\n",
+                           iszTitle);
+                    /* Duplicate field name
 	               (Try to guess the correct field by position) */
-	        }
-	        else
-	        {
-                    pt[i]=j;  found = true;
-	        }
-	    }
-	}
+                }
+                else
+                {
+                    pt[i] = j;
+                    found = true;
+                }
+            }
+        }
 
-	if (pt[i] == -1  && (! found) )  /* Try to force into an existing field */
-	{                                /* Ignore the field name, width, and decimal places */
-	    jType = DBFGetFieldInfo( hDBFappend, j, jszTitle, &jWidth, &jDecimals );
-	    if (iType == jType)
-	    {
-                pt[i]=i;  found = true;
-	    }
-	}
-	if ( (! found) &&  jRecord == 0)  /* Add missing field to the append table */
-	{                 /* The output DBF must be is empty */
-	    pt[i]=tj;
-	    tj++;
-	    if( DBFAddField( hDBFappend, iszTitle, iType, iWidth, iDecimals )
-                == -1 )
-	    {
-		printf( "Warning: DBFAddField(%s, TYPE:%d, WIDTH:%d  DEC:%d, ITEM#:%d of %d) failed.\n",
-                        iszTitle, iType, iWidth, iDecimals, (i+1), (ti+1) );
-		pt[i]=-1;
-	    }
-	}
+        if (pt[i] == -1 && (!found)) /* Try to force into an existing field */
+        { /* Ignore the field name, width, and decimal places */
+            jType =
+                DBFGetFieldInfo(hDBFappend, j, jszTitle, &jWidth, &jDecimals);
+            if (iType == jType)
+            {
+                pt[i] = i;
+                found = true;
+            }
+        }
+        if ((!found) &&
+            jRecord == 0) /* Add missing field to the append table */
+        {                 /* The output DBF must be is empty */
+            pt[i] = tj;
+            tj++;
+            if (DBFAddField(hDBFappend, iszTitle, iType, iWidth, iDecimals) ==
+                -1)
+            {
+                printf("Warning: DBFAddField(%s, TYPE:%d, WIDTH:%d  DEC:%d, "
+                       "ITEM#:%d of %d) failed.\n",
+                       iszTitle, iType, iWidth, iDecimals, (i + 1), (ti + 1));
+                pt[i] = -1;
+            }
+        }
     }
 }
 
@@ -289,113 +299,158 @@ void mergefields()
 /*      Compare two strings up to n characters                          */
 /*      If n=0 then s1 and s2 must be an exact match                    */
 /************************************************************************/
-int strncasecmp2(char *s1, char *s2, int n) {
-   if (n<1) n=strlen(s1)+1;
+int strncasecmp2(char *s1, char *s2, int n)
+{
+    if (n < 1)
+        n = strlen(s1) + 1;
 
-   for (int i = 0; i < n; i++)
-   {
-      if (*s1 != *s2)
-      {
-         if (*s1 >= 'a' && *s1 <= 'z') {
-            const int j = *s1 - 32;
-            if (j != *s2) return(*s1-*s2);
-         } else {
-            int j;
-            if (*s1 >= 'A' && *s1 <= 'Z') { j=*s1+32; }
-                                   else   { j=*s1;    }
-            if (j != *s2) return(*s1-*s2);
-         }
-      }
-      s1++;
-      s2++;
-   }
-   return(0);
+    for (int i = 0; i < n; i++)
+    {
+        if (*s1 != *s2)
+        {
+            if (*s1 >= 'a' && *s1 <= 'z')
+            {
+                const int j = *s1 - 32;
+                if (j != *s2)
+                    return (*s1 - *s2);
+            }
+            else
+            {
+                int j;
+                if (*s1 >= 'A' && *s1 <= 'Z')
+                {
+                    j = *s1 + 32;
+                }
+                else
+                {
+                    j = *s1;
+                }
+                if (j != *s2)
+                    return (*s1 - *s2);
+            }
+        }
+        s1++;
+        s2++;
+    }
+    return (0);
 }
 
-void showitems() {
-    printf("Available Items: (%d)",ti);
+void showitems()
+{
+    printf("Available Items: (%d)", ti);
     long int maxrec = DBFGetRecordCount(hDBF);
-    if (maxrec > 5000 && ! iall) {
-      maxrec=5000;
-      printf("  ** ESTIMATED RANGES (MEAN)  For more records use \"All\"");
-    } else {
-      printf("          RANGES (MEAN)");
+    if (maxrec > 5000 && !iall)
+    {
+        maxrec = 5000;
+        printf("  ** ESTIMATED RANGES (MEAN)  For more records use \"All\"");
+    }
+    else
+    {
+        printf("          RANGES (MEAN)");
     }
 
     char stmp[40] = {0};
     char slow[40] = {0};
     char shigh[40] = {0};
 
-    for( int i = 0; i < ti; i++ )
+    for (int i = 0; i < ti; i++)
     {
-        switch( DBFGetFieldInfo( hDBF, i, iszTitle, &iWidth, &iDecimals ) )
+        switch (DBFGetFieldInfo(hDBF, i, iszTitle, &iWidth, &iDecimals))
         {
-          case FTString:
-          case FTLogical:
-          case FTDate:
-            strcpy(slow, "~");
-            strcpy(shigh,"\0");
-            printf("\n  String  %3d  %-16s",iWidth,iszTitle);
-            for (int iRecord = 0; iRecord < maxrec; iRecord++) {
-                strncpy(stmp,DBFReadStringAttribute( hDBF, iRecord, i ),39);
-                if (strcmp(stmp,"!!") > 0) {
-                    if (strncasecmp2(stmp,slow,0)  < 0) memcpy(slow, stmp,39);
-                    if (strncasecmp2(stmp,shigh,0) > 0) memcpy(shigh,stmp,39);
+            case FTString:
+            case FTLogical:
+            case FTDate:
+                strcpy(slow, "~");
+                strcpy(shigh, "\0");
+                printf("\n  String  %3d  %-16s", iWidth, iszTitle);
+                for (int iRecord = 0; iRecord < maxrec; iRecord++)
+                {
+                    strncpy(stmp, DBFReadStringAttribute(hDBF, iRecord, i), 39);
+                    if (strcmp(stmp, "!!") > 0)
+                    {
+                        if (strncasecmp2(stmp, slow, 0) < 0)
+                            memcpy(slow, stmp, 39);
+                        if (strncasecmp2(stmp, shigh, 0) > 0)
+                            memcpy(shigh, stmp, 39);
+                    }
                 }
-            }
-            char *pt = slow+strlen(slow)-1;
-            while(*pt == ' ') { *pt='\0'; pt--; }
-            pt=shigh+strlen(shigh)-1;
-            while(*pt == ' ') { *pt='\0'; pt--; }
-            if (strncasecmp2(slow,shigh,0) < 0)		printf("%s to %s",slow,shigh);
-            else if (strncasecmp2(slow,shigh,0) == 0)	printf("= %s",slow);
-            else	printf("No Values");
-            break;
-          case FTInteger:
+                char *pt = slow + strlen(slow) - 1;
+                while (*pt == ' ')
+                {
+                    *pt = '\0';
+                    pt--;
+                }
+                pt = shigh + strlen(shigh) - 1;
+                while (*pt == ' ')
+                {
+                    *pt = '\0';
+                    pt--;
+                }
+                if (strncasecmp2(slow, shigh, 0) < 0)
+                    printf("%s to %s", slow, shigh);
+                else if (strncasecmp2(slow, shigh, 0) == 0)
+                    printf("= %s", slow);
+                else
+                    printf("No Values");
+                break;
+            case FTInteger:
             {
-            printf("\n  Integer %3d  %-16s",iWidth,iszTitle);
-            long int ilow =  1999999999;
-            long int ihigh= -1999999999;
-            long int isum =  0;
-            for (int iRecord = 0; iRecord < maxrec; iRecord++) {
-                const long int itmp = DBFReadIntegerAttribute( hDBF, iRecord, i );
-                if (ilow > itmp)  ilow = itmp;
-                if (ihigh < itmp) ihigh = itmp;
-                isum = isum + itmp;
+                printf("\n  Integer %3d  %-16s", iWidth, iszTitle);
+                long int ilow = 1999999999;
+                long int ihigh = -1999999999;
+                long int isum = 0;
+                for (int iRecord = 0; iRecord < maxrec; iRecord++)
+                {
+                    const long int itmp =
+                        DBFReadIntegerAttribute(hDBF, iRecord, i);
+                    if (ilow > itmp)
+                        ilow = itmp;
+                    if (ihigh < itmp)
+                        ihigh = itmp;
+                    isum = isum + itmp;
+                }
+                const double mean = isum / maxrec;
+                if (ilow < ihigh)
+                    printf("%ld to %ld \t(%.1f)", ilow, ihigh, mean);
+                else if (ilow == ihigh)
+                    printf("= %ld", ilow);
+                else
+                    printf("No Values");
+                break;
             }
-            const double mean = isum / maxrec;
-            if (ilow < ihigh)       printf("%ld to %ld \t(%.1f)",ilow,ihigh,mean);
-            else if (ilow == ihigh) printf("= %ld",ilow);
-            else printf("No Values");
-            break;
-            }
-          case FTDouble:
+            case FTDouble:
             {
-            printf("\n  Real  %3d,%d  %-16s",iWidth,iDecimals,iszTitle);
-            double dlow =  999999999999999.0;
-            double dhigh = -999999999999999.0;
-            double dsum = 0;
-            for (int iRecord = 0; iRecord < maxrec; iRecord++) {
-                const double dtmp = DBFReadDoubleAttribute( hDBF, iRecord, i );
-                if (dlow > dtmp) dlow = dtmp;
-                if (dhigh < dtmp) dhigh = dtmp;
-                dsum = dsum + dtmp;
+                printf("\n  Real  %3d,%d  %-16s", iWidth, iDecimals, iszTitle);
+                double dlow = 999999999999999.0;
+                double dhigh = -999999999999999.0;
+                double dsum = 0;
+                for (int iRecord = 0; iRecord < maxrec; iRecord++)
+                {
+                    const double dtmp =
+                        DBFReadDoubleAttribute(hDBF, iRecord, i);
+                    if (dlow > dtmp)
+                        dlow = dtmp;
+                    if (dhigh < dtmp)
+                        dhigh = dtmp;
+                    dsum = dsum + dtmp;
+                }
+                const double mean = dsum / maxrec;
+                sprintf(stmp, "%%.%df to %%.%df \t(%%.%df)", iDecimals,
+                        iDecimals, iDecimals);
+                if (dlow < dhigh)
+                    printf(stmp, dlow, dhigh, mean);
+                else if (dlow == dhigh)
+                {
+                    sprintf(stmp, "= %%.%df", iDecimals);
+                    printf(stmp, dlow);
+                }
+                else
+                    printf("No Values");
+                break;
             }
-            const double mean = dsum / maxrec;
-            sprintf(stmp,"%%.%df to %%.%df \t(%%.%df)",iDecimals,iDecimals,iDecimals);
-            if (dlow < dhigh)       printf(stmp,dlow,dhigh,mean);
-            else if (dlow == dhigh) {
-                sprintf(stmp,"= %%.%df",iDecimals);
-                printf(stmp,dlow);
-            }
-            else printf("No Values");
-            break;
-            }
-          case FTInvalid:
-            break;
-
+            case FTInvalid:
+                break;
         }
-
     }
     printf("\n");
 }
@@ -404,160 +459,191 @@ void findselect()
 {
     /* Find the select field name */
     iselectitem = -1;
-    for( int i = 0; i < ti  &&  iselectitem < 0; i++ )
+    for (int i = 0; i < ti && iselectitem < 0; i++)
     {
-	iType = DBFGetFieldInfo( hDBF, i, iszTitle, &iWidth, &iDecimals );
-        if (strncasecmp2(iszTitle, selectitem, 0) == 0) iselectitem = i;
+        iType = DBFGetFieldInfo(hDBF, i, iszTitle, &iWidth, &iDecimals);
+        if (strncasecmp2(iszTitle, selectitem, 0) == 0)
+            iselectitem = i;
     }
     if (iselectitem == -1)
     {
-        printf("Warning: Item not found for selection (%s)\n",selectitem);
+        printf("Warning: Item not found for selection (%s)\n", selectitem);
         iselect = false;
         iall = false;
-	showitems();
+        showitems();
         printf("Continued... (Selecting entire file)\n");
     }
     /* Extract all of the select values (by field type) */
 }
 
-int selectrec(int iRecord) {
-    const long int ty = DBFGetFieldInfo( hDBF, iselectitem, NULL, &iWidth, &iDecimals);
-    switch(ty)
+int selectrec(int iRecord)
+{
+    const long int ty =
+        DBFGetFieldInfo(hDBF, iselectitem, NULL, &iWidth, &iDecimals);
+    switch (ty)
     {
-      case FTString:
-        puts("Invalid Item");
-        iselect = false;
-	break;
-      case FTInteger:
+        case FTString:
+            puts("Invalid Item");
+            iselect = false;
+            break;
+        case FTInteger:
         {
-        const long int value = DBFReadIntegerAttribute( hDBF, iRecord, iselectitem );
-        for (int j = 0; j<selcount; j++)
-        {
-            if (selectvalues[j] == value)
+            const long int value =
+                DBFReadIntegerAttribute(hDBF, iRecord, iselectitem);
+            for (int j = 0; j < selcount; j++)
             {
-                if (iunselect) return(0);  /* Keep this record */
-                else  return(1);  /* Skip this record */
+                if (selectvalues[j] == value)
+                {
+                    if (iunselect)
+                        return (0); /* Keep this record */
+                    else
+                        return (1); /* Skip this record */
+                }
             }
+            break;
         }
-	break;
-        }
-      case FTDouble:
-        puts("Invalid Item");
-        iselect = false;
-        break;
+        case FTDouble:
+            puts("Invalid Item");
+            iselect = false;
+            break;
     }
-    if (iunselect) return(1);  /* Skip this record */
-    else  return(0);  /* Keep this record */
+    if (iunselect)
+        return (1); /* Skip this record */
+    else
+        return (0); /* Keep this record */
 }
-
 
 void check_theme_bnd()
 {
-    if ( (adfBoundsMin[0] >= cxmin) && (adfBoundsMax[0] <= cxmax) &&
-         (adfBoundsMin[1] >= cymin) && (adfBoundsMax[1] <= cymax) )
-    {   /** Theme is totally inside clip area **/
-        if (ierase) nEntities=0; /** SKIP THEME  **/
-        else   iclip = false; /** WRITE THEME (Clip not needed) **/
+    if ((adfBoundsMin[0] >= cxmin) && (adfBoundsMax[0] <= cxmax) &&
+        (adfBoundsMin[1] >= cymin) && (adfBoundsMax[1] <= cymax))
+    { /** Theme is totally inside clip area **/
+        if (ierase)
+            nEntities = 0; /** SKIP THEME  **/
+        else
+            iclip = false; /** WRITE THEME (Clip not needed) **/
     }
 
-    if ( ( (adfBoundsMin[0] < cxmin) && (adfBoundsMax[0] < cxmin) ) ||
-         ( (adfBoundsMin[1] < cymin) && (adfBoundsMax[1] < cymin) ) ||
-         ( (adfBoundsMin[0] > cxmax) && (adfBoundsMax[0] > cxmax) ) ||
-         ( (adfBoundsMin[1] > cymax) && (adfBoundsMax[1] > cymax) ) )
-    {   /** Theme is totally outside clip area **/
-        if (ierase) iclip = false; /** WRITE THEME (Clip not needed) **/
-             else   nEntities=0; /** SKIP THEME  **/
+    if (((adfBoundsMin[0] < cxmin) && (adfBoundsMax[0] < cxmin)) ||
+        ((adfBoundsMin[1] < cymin) && (adfBoundsMax[1] < cymin)) ||
+        ((adfBoundsMin[0] > cxmax) && (adfBoundsMax[0] > cxmax)) ||
+        ((adfBoundsMin[1] > cymax) && (adfBoundsMax[1] > cymax)))
+    { /** Theme is totally outside clip area **/
+        if (ierase)
+            iclip = false; /** WRITE THEME (Clip not needed) **/
+        else
+            nEntities = 0; /** SKIP THEME  **/
     }
 
     if (nEntities == 0)
         puts("WARNING: Theme is outside the clip area."); /** SKIP THEME  **/
 }
 
-int clip_boundary() {
+int clip_boundary()
+{
     /*** FIRST check the boundary of the feature ***/
-    if ( ( (psCShape->dfXMin < cxmin) && (psCShape->dfXMax < cxmin) ) ||
-         ( (psCShape->dfYMin < cymin) && (psCShape->dfYMax < cymin) ) ||
-         ( (psCShape->dfXMin > cxmax) && (psCShape->dfXMax > cxmax) ) ||
-         ( (psCShape->dfYMin > cymax) && (psCShape->dfYMax > cymax) ) )
-    {   /** Feature is totally outside clip area **/
-        if (ierase) return(1); /** WRITE RECORD **/
-        else   return(0); /** SKIP  RECORD **/
+    if (((psCShape->dfXMin < cxmin) && (psCShape->dfXMax < cxmin)) ||
+        ((psCShape->dfYMin < cymin) && (psCShape->dfYMax < cymin)) ||
+        ((psCShape->dfXMin > cxmax) && (psCShape->dfXMax > cxmax)) ||
+        ((psCShape->dfYMin > cymax) && (psCShape->dfYMax > cymax)))
+    { /** Feature is totally outside clip area **/
+        if (ierase)
+            return (1); /** WRITE RECORD **/
+        else
+            return (0); /** SKIP  RECORD **/
     }
 
-    if ( (psCShape->dfXMin >= cxmin) && (psCShape->dfXMax <= cxmax) &&
-         (psCShape->dfYMin >= cymin) && (psCShape->dfYMax <= cymax) )
-    {   /** Feature is totally inside clip area **/
-        if (ierase) return(0); /** SKIP  RECORD **/
-        else   return(1); /** WRITE RECORD **/
+    if ((psCShape->dfXMin >= cxmin) && (psCShape->dfXMax <= cxmax) &&
+        (psCShape->dfYMin >= cymin) && (psCShape->dfYMax <= cymax))
+    { /** Feature is totally inside clip area **/
+        if (ierase)
+            return (0); /** SKIP  RECORD **/
+        else
+            return (1); /** WRITE RECORD **/
     }
 
     if (iinside)
     { /** INSIDE * Feature might touch the boundary or could be outside **/
-        if (ierase)  return(1); /** WRITE RECORD **/
-        else    return(0); /** SKIP  RECORD **/
+        if (ierase)
+            return (1); /** WRITE RECORD **/
+        else
+            return (0); /** SKIP  RECORD **/
     }
 
     if (itouch)
-    {   /** TOUCH **/
-        if ( ( (psCShape->dfXMin <= cxmin) || (psCShape->dfXMax >= cxmax) ) &&
-             (psCShape->dfYMin >= cymin) && (psCShape->dfYMax <= cymax)    )
-        {   /** Feature intersects the clip boundary only on the X axis **/
-            if (ierase) return(0); /** SKIP  RECORD **/
-            else   return(1); /** WRITE RECORD **/
+    { /** TOUCH **/
+        if (((psCShape->dfXMin <= cxmin) || (psCShape->dfXMax >= cxmax)) &&
+            (psCShape->dfYMin >= cymin) && (psCShape->dfYMax <= cymax))
+        { /** Feature intersects the clip boundary only on the X axis **/
+            if (ierase)
+                return (0); /** SKIP  RECORD **/
+            else
+                return (1); /** WRITE RECORD **/
         }
 
-        if (   (psCShape->dfXMin >= cxmin) && (psCShape->dfXMax <= cxmax)   &&
-               ( (psCShape->dfYMin <= cymin) || (psCShape->dfYMax >= cymax) )  )
-        {   /** Feature intersects the clip boundary only on the Y axis **/
-            if (ierase) return(0); /** SKIP  RECORD **/
-            else   return(1); /** WRITE RECORD **/
+        if ((psCShape->dfXMin >= cxmin) && (psCShape->dfXMax <= cxmax) &&
+            ((psCShape->dfYMin <= cymin) || (psCShape->dfYMax >= cymax)))
+        { /** Feature intersects the clip boundary only on the Y axis **/
+            if (ierase)
+                return (0); /** SKIP  RECORD **/
+            else
+                return (1); /** WRITE RECORD **/
         }
 
-        for( int j2 = 0; j2 < psCShape->nVertices; j2++ )
-        {   /** At least one vertex must be inside the clip boundary **/
-            if ( (psCShape->padfX[j2] >= cxmin  &&  psCShape->padfX[j2] <= cxmax) ||
-                 (psCShape->padfY[j2] >= cymin  &&  psCShape->padfY[j2] <= cymax)  )
+        for (int j2 = 0; j2 < psCShape->nVertices; j2++)
+        { /** At least one vertex must be inside the clip boundary **/
+            if ((psCShape->padfX[j2] >= cxmin &&
+                 psCShape->padfX[j2] <= cxmax) ||
+                (psCShape->padfY[j2] >= cymin && psCShape->padfY[j2] <= cymax))
             {
-                if (ierase) return(0); /** SKIP  RECORD **/
-                else   return(1); /** WRITE RECORD **/
+                if (ierase)
+                    return (0); /** SKIP  RECORD **/
+                else
+                    return (1); /** WRITE RECORD **/
             }
         }
 
         /** All vertices are outside the clip boundary **/
-        if (ierase) return(1); /** WRITE RECORD **/
-        else   return(0); /** SKIP  RECORD **/
-    }   /** End TOUCH **/
+        if (ierase)
+            return (1); /** WRITE RECORD **/
+        else
+            return (0); /** SKIP  RECORD **/
+    }                   /** End TOUCH **/
 
     if (icut)
-    {   /** CUT **/
+    { /** CUT **/
         /*** Check each vertex in the feature with the Boundary and "CUT" ***/
         /*** THIS CODE WAS NOT COMPLETED!  READ NOTE AT THE BOTTOM ***/
         int i2 = 0;
         bool prev_outside = false;
-        for( int j2 = 0; j2 < psCShape->nVertices; j2++ )
+        for (int j2 = 0; j2 < psCShape->nVertices; j2++)
         {
             bool inside =
                 psCShape->padfX[j2] >= cxmin && psCShape->padfX[j2] <= cxmax &&
                 psCShape->padfY[j2] >= cymin && psCShape->padfY[j2] <= cymax;
 
-            if (ierase) inside = !inside;
+            if (ierase)
+                inside = !inside;
             if (inside)
             {
                 if (i2 != j2)
                 {
                     if (prev_outside)
                     {
-                        /*** AddIntersection(i2); ***/  /*** Add intersection ***/
+                        /*** AddIntersection(i2); ***/ /*** Add intersection ***/
                         prev_outside = false;
                     }
-                    psCShape->padfX[i2]=psCShape->padfX[j2];     /** move vertex **/
-                    psCShape->padfY[i2]=psCShape->padfY[j2];
+                    psCShape->padfX[i2] =
+                        psCShape->padfX[j2]; /** move vertex **/
+                    psCShape->padfY[i2] = psCShape->padfY[j2];
                 }
                 i2++;
-            } else {
-                if ( (! prev_outside) && (j2 > 0) )
+            }
+            else
+            {
+                if ((!prev_outside) && (j2 > 0))
                 {
-                    /*** AddIntersection(i2); ***//*** Add intersection (Watch out for j2==i2-1) ***/
+                    /*** AddIntersection(i2); ***/ /*** Add intersection (Watch out for j2==i2-1) ***/
                     /*** Also a polygon may overlap twice and will split into a several parts  ***/
                     prev_outside = true;
                 }
@@ -565,51 +651,46 @@ int clip_boundary() {
         }
 
         printf("Vertices:%d   OUT:%d   Number of Parts:%d\n",
-               psCShape->nVertices,i2, psCShape->nParts );
+               psCShape->nVertices, i2, psCShape->nParts);
 
         psCShape->nVertices = i2;
 
-        if (i2 < 2) return(0); /** SKIP RECORD **/
+        if (i2 < 2)
+            return (0); /** SKIP RECORD **/
         /*** (WE ARE NOT CREATING INTERSECTIONS and some lines could be reduced to one point) **/
 
         // if (i2 == 0) return(0); /** SKIP  RECORD **/
         // else
-        return(1); /** WRITE RECORD **/
-    }  /** End CUT **/
+        return (1); /** WRITE RECORD **/
+    }               /** End CUT **/
 
     return 0;
 }
 
-#define  NKEYS (sizeof(unitkeytab) / sizeof(struct unitkey))
+#define NKEYS (sizeof(unitkeytab) / sizeof(struct unitkey))
 double findunit(char *unit)
-   {
-   struct unitkey {
-     char   *name;
-     double value;
-   } unitkeytab[] = {
-     {"CM",            39.37},
-     {"CENTIMETER",    39.37},
-     {"CENTIMETERS",   39.37},  /** # of inches * 100 in unit **/
-     {"METER",          3937},
-     {"METERS",         3937},
-     {"KM",          3937000},
-     {"KILOMETER",   3937000},
-     {"KILOMETERS",  3937000},
-     {"INCH",            100},
-     {"INCHES",          100},
-     {"FEET",           1200},
-     {"FOOT",           1200},
-     {"YARD",           3600},
-     {"YARDS",          3600},
-     {"MILE",        6336000},
-     {"MILES",       6336000}
-   };
+{
+    struct unitkey
+    {
+        char *name;
+        double value;
+    } unitkeytab[] = {{"CM", 39.37},           {"CENTIMETER", 39.37},
+                      {"CENTIMETERS", 39.37}, /** # of inches * 100 in unit **/
+                      {"METER", 3937},         {"METERS", 3937},
+                      {"KM", 3937000},         {"KILOMETER", 3937000},
+                      {"KILOMETERS", 3937000}, {"INCH", 100},
+                      {"INCHES", 100},         {"FEET", 1200},
+                      {"FOOT", 1200},          {"YARD", 3600},
+                      {"YARDS", 3600},         {"MILE", 6336000},
+                      {"MILES", 6336000}};
 
-   double unitfactor=0;
-   for (int j = 0; j < (int)NKEYS; j++) {
-    if (strncasecmp2(unit, unitkeytab[j].name, 0) == 0) unitfactor=unitkeytab[j].value;
-   }
-   return(unitfactor);
+    double unitfactor = 0;
+    for (int j = 0; j < (int)NKEYS; j++)
+    {
+        if (strncasecmp2(unit, unitkeytab[j].name, 0) == 0)
+            unitfactor = unitkeytab[j].value;
+    }
+    return (unitfactor);
 }
 
 /* -------------------------------------------------------------------- */
@@ -617,44 +698,56 @@ double findunit(char *unit)
 /* -------------------------------------------------------------------- */
 void error()
 {
-    puts( "The program will append to an existing shape file or it will" );
-    puts( "create a new file if needed." );
-    puts( "Only the items in the first output file will be preserved." );
-    puts( "When an item does not match with the append theme then the item");
-    puts( "might be placed to an existing item at the same position and type." );
-    puts( "  OTHER FUNCTIONS:" );
-    puts( "  - Describe all items in the dbase file (Use ALL for more than 5000 recs.)");
-    puts( "  - Select a group of shapes from a comma separated selection list.");
-    puts( "  - UnSelect a group of shapes from a comma separated selection list.");
-    puts( "  - Clip boundary extent or by theme boundary." );
-    puts( "      Touch writes all the shapes that touch the boundary.");
-    puts( "      Inside writes all the shapes that are completely within the boundary.");
-    puts( "      Boundary clips are only the min and max of a theme boundary." );
-    puts( "  - Erase boundary extent or by theme boundary." );
-    puts( "      Erase is the direct opposite of the Clip function." );
-    puts( "  - Change coordinate value units between meters and feet.");
-    puts( "      There is no way to determine the input unit of a shape file.");
-    puts( "      Skip this function if the shape file is already in the correct unit.");
-    puts( "      Clip and Erase will be done before the unit is changed.");
-    puts( "      A shift will be done after the unit is changed.");
-    puts( "  - Shift X and Y coordinates.\n" );
-    puts( "Finally, There can only be one select or unselect in the command line.");
-    puts( "         There can only be one clip or erase in the command line.");
-    puts( "         There can only be one unit and only one shift in the command line.\n");
-    puts( "Ex: shputils in.shp out.shp   SELECT countycode 3,5,9,13,17,27");
-    puts( "    shputils in.shp out.shp   CLIP   10 10 90 90 Touch   FACTOR Meter Feet");
-    puts( "    shputils in.shp out.shp   FACTOR Meter 3.0");
-    puts( "    shputils in.shp out.shp   CLIP   clip.shp Boundary Touch   SHIFT 40 40");
-    puts( "    shputils in.shp out.shp   SELECT co 112   CLIP clip.shp Boundary Touch\n");
-    puts( "USAGE: shputils  <DescribeShape>   {ALL}");
-    puts( "USAGE: shputils  <InputShape>  <OutShape|AppendShape>" );
-    puts( "   { <FACTOR>       <FEET|MILES|METERS|KM> <FEET|MILES|METERS|KM|factor> }" );
-    puts( "   { <SHIFT>        <xshift> <yshift> }" );
-    puts( "   { <SELECT|UNSEL> <Item> <valuelist> }" );
-    puts( "   { <CLIP|ERASE>   <xmin> <ymin> <xmax> <ymax> <TOUCH|INSIDE|CUT> }" );
-    puts( "   { <CLIP|ERASE>   <theme>      <BOUNDARY>     <TOUCH|INSIDE|CUT> }" );
-    puts( "     Note: CUT is not complete and does not create intersections.");
-    puts( "           For more information read programmer comment.");
+    puts("The program will append to an existing shape file or it will");
+    puts("create a new file if needed.");
+    puts("Only the items in the first output file will be preserved.");
+    puts("When an item does not match with the append theme then the item");
+    puts("might be placed to an existing item at the same position and type.");
+    puts("  OTHER FUNCTIONS:");
+    puts("  - Describe all items in the dbase file (Use ALL for more than 5000 "
+         "recs.)");
+    puts("  - Select a group of shapes from a comma separated selection list.");
+    puts("  - UnSelect a group of shapes from a comma separated selection "
+         "list.");
+    puts("  - Clip boundary extent or by theme boundary.");
+    puts("      Touch writes all the shapes that touch the boundary.");
+    puts("      Inside writes all the shapes that are completely within the "
+         "boundary.");
+    puts("      Boundary clips are only the min and max of a theme boundary.");
+    puts("  - Erase boundary extent or by theme boundary.");
+    puts("      Erase is the direct opposite of the Clip function.");
+    puts("  - Change coordinate value units between meters and feet.");
+    puts("      There is no way to determine the input unit of a shape file.");
+    puts("      Skip this function if the shape file is already in the correct "
+         "unit.");
+    puts("      Clip and Erase will be done before the unit is changed.");
+    puts("      A shift will be done after the unit is changed.");
+    puts("  - Shift X and Y coordinates.\n");
+    puts("Finally, There can only be one select or unselect in the command "
+         "line.");
+    puts("         There can only be one clip or erase in the command line.");
+    puts("         There can only be one unit and only one shift in the "
+         "command line.\n");
+    puts("Ex: shputils in.shp out.shp   SELECT countycode 3,5,9,13,17,27");
+    puts("    shputils in.shp out.shp   CLIP   10 10 90 90 Touch   FACTOR "
+         "Meter Feet");
+    puts("    shputils in.shp out.shp   FACTOR Meter 3.0");
+    puts("    shputils in.shp out.shp   CLIP   clip.shp Boundary Touch   SHIFT "
+         "40 40");
+    puts("    shputils in.shp out.shp   SELECT co 112   CLIP clip.shp Boundary "
+         "Touch\n");
+    puts("USAGE: shputils  <DescribeShape>   {ALL}");
+    puts("USAGE: shputils  <InputShape>  <OutShape|AppendShape>");
+    puts("   { <FACTOR>       <FEET|MILES|METERS|KM> "
+         "<FEET|MILES|METERS|KM|factor> }");
+    puts("   { <SHIFT>        <xshift> <yshift> }");
+    puts("   { <SELECT|UNSEL> <Item> <valuelist> }");
+    puts(
+        "   { <CLIP|ERASE>   <xmin> <ymin> <xmax> <ymax> <TOUCH|INSIDE|CUT> }");
+    puts(
+        "   { <CLIP|ERASE>   <theme>      <BOUNDARY>     <TOUCH|INSIDE|CUT> }");
+    puts("     Note: CUT is not complete and does not create intersections.");
+    puts("           For more information read programmer comment.");
 
     /****   Clip functions for Polygon and Cut is not supported
             There are several web pages that describe methods of doing this function.
@@ -716,142 +809,182 @@ det_inv = 1/(a1*b2 - a2*b1);
 } // end Intersect_Lines
     **********************************************************/
 
-    exit( 1 );
+    exit(1);
 }
 
-
-int main(int argc, char ** argv) {
+int main(int argc, char **argv)
+{
     // Check command line usage.
-    if( argc < 2 ) error();
+    if (argc < 2)
+        error();
     strcpy(infile, argv[1]);
-    if (argc > 2) {
-        strcpy(outfile,argv[2]);
-        if (strncasecmp2(outfile, "LIST",0) == 0) { ilist = true; }
-        if (strncasecmp2(outfile, "ALL",0) == 0)  { iall  = true; }
+    if (argc > 2)
+    {
+        strcpy(outfile, argv[2]);
+        if (strncasecmp2(outfile, "LIST", 0) == 0)
+        {
+            ilist = true;
+        }
+        if (strncasecmp2(outfile, "ALL", 0) == 0)
+        {
+            iall = true;
+        }
     }
-    if (ilist || iall || argc == 2 ) {
+    if (ilist || iall || argc == 2)
+    {
         setext(infile, "shp");
-        printf("DESCRIBE: %s\n",infile);
-        strcpy(outfile,"");
+        printf("DESCRIBE: %s\n", infile);
+        strcpy(outfile, "");
     }
 
     // Look for other functions on the command line. (SELECT, UNIT)
-    for (int i = 3; i < argc; i++) {
-    	if ((strncasecmp2(argv[i],  "SEL",3) == 0) ||
-            (strncasecmp2(argv[i],  "UNSEL",5) == 0))
-    	{
-            if (strncasecmp2(argv[i],  "UNSEL",5) == 0) iunselect = true;
-    	    i++;
-    	    if (i >= argc) error();
-    	    strcpy(selectitem,argv[i]);
-    	    i++;
-    	    if (i >= argc) error();
-    	    selcount=0;
-    	    strcpy(temp,argv[i]);
-    	    cpt=temp;
-    	    tj = atoi(cpt);
-    	    ti = 0;
-    	    while (tj>0) {
+    for (int i = 3; i < argc; i++)
+    {
+        if ((strncasecmp2(argv[i], "SEL", 3) == 0) ||
+            (strncasecmp2(argv[i], "UNSEL", 5) == 0))
+        {
+            if (strncasecmp2(argv[i], "UNSEL", 5) == 0)
+                iunselect = true;
+            i++;
+            if (i >= argc)
+                error();
+            strcpy(selectitem, argv[i]);
+            i++;
+            if (i >= argc)
+                error();
+            selcount = 0;
+            strcpy(temp, argv[i]);
+            cpt = temp;
+            tj = atoi(cpt);
+            ti = 0;
+            while (tj > 0)
+            {
                 selectvalues[selcount] = tj;
-                while( *cpt >= '0' && *cpt <= '9')
+                while (*cpt >= '0' && *cpt <= '9')
                     cpt++;
-                while( *cpt > '\0' && (*cpt < '0' || *cpt > '9') )
+                while (*cpt > '\0' && (*cpt < '0' || *cpt > '9'))
                     cpt++;
-                tj=atoi(cpt);
+                tj = atoi(cpt);
                 selcount++;
-    	    }
-            iselect = true;
-    	}  /*** End SEL & UNSEL ***/
-    	else
-            if ((strncasecmp2(argv[i], "CLIP",4) == 0) ||
-                (strncasecmp2(argv[i],  "ERASE",5) == 0))
-            {
-                if (strncasecmp2(argv[i],  "ERASE",5) == 0) ierase = true;
-                i++;
-                if (i >= argc) error();
-                strcpy(clipfile,argv[i]);
-                sscanf(argv[i],"%lf",&cxmin);
-                i++;
-                if (i >= argc) error();
-                if (strncasecmp2(argv[i],  "BOUND",5) == 0) {
-                    setext(clipfile, "shp");
-                    hSHP = SHPOpen( clipfile, "rb" );
-                    if( hSHP == NULL )
-                    {
-                        printf( "ERROR: Unable to open the clip shape file:%s\n", clipfile );
-                        exit( 1 );
-                    }
-                    SHPGetInfo( hSHPappend, NULL, NULL,
-                                adfBoundsMin, adfBoundsMax );
-                    cxmin = adfBoundsMin[0];
-                    cymin = adfBoundsMin[1];
-                    cxmax = adfBoundsMax[0];
-                    cymax = adfBoundsMax[1];
-                    printf("Theme Clip Boundary: (%lf,%lf) - (%lf,%lf)\n",
-                           cxmin, cymin, cxmax, cymax);
-                } else {  /*** xmin,ymin,xmax,ymax ***/
-                    sscanf(argv[i],"%lf",&cymin);
-                    i++;
-                    if (i >= argc) error();
-                    sscanf(argv[i],"%lf",&cxmax);
-                    i++;
-                    if (i >= argc) error();
-                    sscanf(argv[i],"%lf",&cymax);
-                    printf("Clip Box: (%lf,%lf) - (%lf,%lf)\n",cxmin, cymin, cxmax, cymax);
-                }
-                i++;
-                if (i >= argc) error();
-                if      (strncasecmp2(argv[i], "CUT",3) == 0)    icut = true;
-                else if (strncasecmp2(argv[i], "TOUCH",5) == 0)  itouch = true;
-                else if (strncasecmp2(argv[i], "INSIDE",6) == 0) iinside = true;
-                else error();
-                iclip = true;
-            } /*** End CLIP & ERASE ***/
-            else if (strncasecmp2(argv[i],  "FACTOR",0) == 0)
-            {
-                i++;
-    	        if (i >= argc) error();
-    	        infactor=findunit(argv[i]);
-    	        if (infactor == 0) error();
-                iunit = true;
-                i++;
-    	        if (i >= argc) error();
-    	        outfactor=findunit(argv[i]);
-    	        if (outfactor == 0)
-    	        {
-                    sscanf(argv[i],"%lf",&factor);
-                    if (factor == 0) error();
-                }
-                if (factor == 0)
-                {
-                    if (infactor ==0)
-                    { puts("ERROR: Input unit must be defined before output unit"); exit(1); }
-                    factor=infactor/outfactor;
-                }
-                printf("Output file coordinate values will be factored by %lg\n",factor);
-            } /*** End FACTOR ***/
-            else if (strncasecmp2(argv[i],"SHIFT",5) == 0)
-            {
-                i++;
-                if (i >= argc) error();
-                sscanf(argv[i],"%lf",&xshift);
-                i++;
-                if (i >= argc) error();
-                sscanf(argv[i],"%lf",&yshift);
-                iunit = true;
-                printf("X Shift: %lg   Y Shift: %lg\n",xshift,yshift);
-            } /*** End SHIFT ***/
-            else {
-                printf("ERROR: Unknown function %s\n",argv[i]);  error();
             }
+            iselect = true;
+        } /*** End SEL & UNSEL ***/
+        else if ((strncasecmp2(argv[i], "CLIP", 4) == 0) ||
+                 (strncasecmp2(argv[i], "ERASE", 5) == 0))
+        {
+            if (strncasecmp2(argv[i], "ERASE", 5) == 0)
+                ierase = true;
+            i++;
+            if (i >= argc)
+                error();
+            strcpy(clipfile, argv[i]);
+            sscanf(argv[i], "%lf", &cxmin);
+            i++;
+            if (i >= argc)
+                error();
+            if (strncasecmp2(argv[i], "BOUND", 5) == 0)
+            {
+                setext(clipfile, "shp");
+                hSHP = SHPOpen(clipfile, "rb");
+                if (hSHP == NULL)
+                {
+                    printf("ERROR: Unable to open the clip shape file:%s\n",
+                           clipfile);
+                    exit(1);
+                }
+                SHPGetInfo(hSHPappend, NULL, NULL, adfBoundsMin, adfBoundsMax);
+                cxmin = adfBoundsMin[0];
+                cymin = adfBoundsMin[1];
+                cxmax = adfBoundsMax[0];
+                cymax = adfBoundsMax[1];
+                printf("Theme Clip Boundary: (%lf,%lf) - (%lf,%lf)\n", cxmin,
+                       cymin, cxmax, cymax);
+            }
+            else
+            { /*** xmin,ymin,xmax,ymax ***/
+                sscanf(argv[i], "%lf", &cymin);
+                i++;
+                if (i >= argc)
+                    error();
+                sscanf(argv[i], "%lf", &cxmax);
+                i++;
+                if (i >= argc)
+                    error();
+                sscanf(argv[i], "%lf", &cymax);
+                printf("Clip Box: (%lf,%lf) - (%lf,%lf)\n", cxmin, cymin, cxmax,
+                       cymax);
+            }
+            i++;
+            if (i >= argc)
+                error();
+            if (strncasecmp2(argv[i], "CUT", 3) == 0)
+                icut = true;
+            else if (strncasecmp2(argv[i], "TOUCH", 5) == 0)
+                itouch = true;
+            else if (strncasecmp2(argv[i], "INSIDE", 6) == 0)
+                iinside = true;
+            else
+                error();
+            iclip = true;
+        } /*** End CLIP & ERASE ***/
+        else if (strncasecmp2(argv[i], "FACTOR", 0) == 0)
+        {
+            i++;
+            if (i >= argc)
+                error();
+            infactor = findunit(argv[i]);
+            if (infactor == 0)
+                error();
+            iunit = true;
+            i++;
+            if (i >= argc)
+                error();
+            outfactor = findunit(argv[i]);
+            if (outfactor == 0)
+            {
+                sscanf(argv[i], "%lf", &factor);
+                if (factor == 0)
+                    error();
+            }
+            if (factor == 0)
+            {
+                if (infactor == 0)
+                {
+                    puts(
+                        "ERROR: Input unit must be defined before output unit");
+                    exit(1);
+                }
+                factor = infactor / outfactor;
+            }
+            printf("Output file coordinate values will be factored by %lg\n",
+                   factor);
+        } /*** End FACTOR ***/
+        else if (strncasecmp2(argv[i], "SHIFT", 5) == 0)
+        {
+            i++;
+            if (i >= argc)
+                error();
+            sscanf(argv[i], "%lf", &xshift);
+            i++;
+            if (i >= argc)
+                error();
+            sscanf(argv[i], "%lf", &yshift);
+            iunit = true;
+            printf("X Shift: %lg   Y Shift: %lg\n", xshift, yshift);
+        } /*** End SHIFT ***/
+        else
+        {
+            printf("ERROR: Unknown function %s\n", argv[i]);
+            error();
+        }
     }
 
-
     // If there is no data in this file let the user know.
-    openfiles();  /* Open the infile and the outfile for shape and dbf. */
-    if(DBFGetFieldCount(hDBF) == 0) {
-	puts( "There are no fields in this table!" );
-	exit( 1 );
+    openfiles(); /* Open the infile and the outfile for shape and dbf. */
+    if (DBFGetFieldCount(hDBF) == 0)
+    {
+        puts("There are no fields in this table!");
+        exit(1);
     }
 
     // Print out the file bounds.
@@ -859,19 +992,21 @@ int main(int argc, char ** argv) {
         const int iRecord = DBFGetRecordCount(hDBF);
         SHPGetInfo(hSHP, NULL, NULL, adfBoundsMin, adfBoundsMax);
 
-        printf("Input Bounds:  (%lg,%lg) - (%lg,%lg)   Entities: %d   DBF: %d\n",
-               adfBoundsMin[0], adfBoundsMin[1],
-               adfBoundsMax[0], adfBoundsMax[1],
-               nEntities, iRecord);
+        printf(
+            "Input Bounds:  (%lg,%lg) - (%lg,%lg)   Entities: %d   DBF: %d\n",
+            adfBoundsMin[0], adfBoundsMin[1], adfBoundsMax[0], adfBoundsMax[1],
+            nEntities, iRecord);
 
-        if (strcmp(outfile,"") == 0) { /* Describe the shapefile; No other functions */
-            ti = DBFGetFieldCount( hDBF );
+        if (strcmp(outfile, "") == 0)
+        { /* Describe the shapefile; No other functions */
+            ti = DBFGetFieldCount(hDBF);
             showitems();
             exit(0);
         }
     }
 
-    if (iclip) check_theme_bnd();
+    if (iclip)
+        check_theme_bnd();
 
     {
         const int jRecord = DBFGetRecordCount(hDBFappend);
@@ -879,122 +1014,128 @@ int main(int argc, char ** argv) {
         if (nEntitiesAppend == 0)
             puts("New Output File\n");
         else
-            printf("Append Bounds: (%lg,%lg)-(%lg,%lg)   Entities: %d  DBF: %d\n",
-                   adfBoundsMin[0], adfBoundsMin[1],
-                   adfBoundsMax[0], adfBoundsMax[1],
-                   nEntitiesAppend, jRecord);
+            printf(
+                "Append Bounds: (%lg,%lg)-(%lg,%lg)   Entities: %d  DBF: %d\n",
+                adfBoundsMin[0], adfBoundsMin[1], adfBoundsMax[0],
+                adfBoundsMax[1], nEntitiesAppend, jRecord);
     }
-/* -------------------------------------------------------------------- */
-/*	Find matching fields in the append file or add new items.       */
-/* -------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------- */
+    /*	Find matching fields in the append file or add new items.       */
+    /* -------------------------------------------------------------------- */
     mergefields();
-/* -------------------------------------------------------------------- */
-/*	Find selection field if needed.                                 */
-/* -------------------------------------------------------------------- */
-    if (iselect)    findselect();
+    /* -------------------------------------------------------------------- */
+    /*	Find selection field if needed.                                 */
+    /* -------------------------------------------------------------------- */
+    if (iselect)
+        findselect();
 
-/* -------------------------------------------------------------------- */
-/*  Read all the records 						*/
-/* -------------------------------------------------------------------- */
-    int jRecord = DBFGetRecordCount( hDBFappend );
-    for(int iRecord = 0; iRecord < nEntities; iRecord++)  /** DBFGetRecordCount(hDBF) **/
+    /* -------------------------------------------------------------------- */
+    /*  Read all the records 						*/
+    /* -------------------------------------------------------------------- */
+    int jRecord = DBFGetRecordCount(hDBFappend);
+    for (int iRecord = 0; iRecord < nEntities;
+         iRecord++) /** DBFGetRecordCount(hDBF) **/
     {
-/* -------------------------------------------------------------------- */
-/*      SELECT for values if needed. (Can the record be skipped.)       */
-/* -------------------------------------------------------------------- */
+        /* -------------------------------------------------------------------- */
+        /*      SELECT for values if needed. (Can the record be skipped.)       */
+        /* -------------------------------------------------------------------- */
         if (iselect)
-            if (selectrec(iRecord) == 0) goto SKIP_RECORD;   /** SKIP RECORD **/
+            if (selectrec(iRecord) == 0)
+                goto SKIP_RECORD; /** SKIP RECORD **/
 
-/* -------------------------------------------------------------------- */
-/*      Read a Shape record                                             */
-/* -------------------------------------------------------------------- */
-        psCShape = SHPReadObject( hSHP, iRecord );
+        /* -------------------------------------------------------------------- */
+        /*      Read a Shape record                                             */
+        /* -------------------------------------------------------------------- */
+        psCShape = SHPReadObject(hSHP, iRecord);
 
-/* -------------------------------------------------------------------- */
-/*      Clip coordinates of shapes if needed.                           */
-/* -------------------------------------------------------------------- */
+        /* -------------------------------------------------------------------- */
+        /*      Clip coordinates of shapes if needed.                           */
+        /* -------------------------------------------------------------------- */
         if (iclip)
-            if (clip_boundary() == 0) goto SKIP_RECORD; /** SKIP RECORD **/
+            if (clip_boundary() == 0)
+                goto SKIP_RECORD; /** SKIP RECORD **/
 
-/* -------------------------------------------------------------------- */
-/*      Read a DBF record and copy each field.                          */
-/* -------------------------------------------------------------------- */
-	for( int i = 0; i < DBFGetFieldCount(hDBF); i++ )
-	{
-/* -------------------------------------------------------------------- */
-/*      Store the record according to the type and formatting           */
-/*      information implicit in the DBF field description.              */
-/* -------------------------------------------------------------------- */
-            if (pt[i] > -1)  /* if the current field exists in output file */
+        /* -------------------------------------------------------------------- */
+        /*      Read a DBF record and copy each field.                          */
+        /* -------------------------------------------------------------------- */
+        for (int i = 0; i < DBFGetFieldCount(hDBF); i++)
+        {
+            /* -------------------------------------------------------------------- */
+            /*      Store the record according to the type and formatting           */
+            /*      information implicit in the DBF field description.              */
+            /* -------------------------------------------------------------------- */
+            if (pt[i] > -1) /* if the current field exists in output file */
             {
-                switch( DBFGetFieldInfo( hDBF, i, NULL, &iWidth, &iDecimals ) )
+                switch (DBFGetFieldInfo(hDBF, i, NULL, &iWidth, &iDecimals))
                 {
-                  case FTString:
-                  case FTLogical:
-                  case FTDate:
-                    DBFWriteStringAttribute(hDBFappend, jRecord, pt[i],
-                                            (DBFReadStringAttribute( hDBF, iRecord, i )) );
-                    break;
+                    case FTString:
+                    case FTLogical:
+                    case FTDate:
+                        DBFWriteStringAttribute(
+                            hDBFappend, jRecord, pt[i],
+                            (DBFReadStringAttribute(hDBF, iRecord, i)));
+                        break;
 
-                  case FTInteger:
-                    DBFWriteIntegerAttribute(hDBFappend, jRecord, pt[i],
-                                             (DBFReadIntegerAttribute( hDBF, iRecord, i )) );
-                    break;
+                    case FTInteger:
+                        DBFWriteIntegerAttribute(
+                            hDBFappend, jRecord, pt[i],
+                            (DBFReadIntegerAttribute(hDBF, iRecord, i)));
+                        break;
 
-                  case FTDouble:
-                    DBFWriteDoubleAttribute(hDBFappend, jRecord, pt[i],
-                                            (DBFReadDoubleAttribute( hDBF, iRecord, i )) );
-                    break;
+                    case FTDouble:
+                        DBFWriteDoubleAttribute(
+                            hDBFappend, jRecord, pt[i],
+                            (DBFReadDoubleAttribute(hDBF, iRecord, i)));
+                        break;
 
-                  case FTInvalid:
-                    break;
+                    case FTInvalid:
+                        break;
                 }
             }
-	}
-	jRecord++;
-/* -------------------------------------------------------------------- */
-/*      Change FACTOR and SHIFT coordinates of shapes if needed.        */
-/* -------------------------------------------------------------------- */
+        }
+        jRecord++;
+        /* -------------------------------------------------------------------- */
+        /*      Change FACTOR and SHIFT coordinates of shapes if needed.        */
+        /* -------------------------------------------------------------------- */
         if (iunit)
         {
-	    for( int j = 0; j < psCShape->nVertices; j++ )
-	    {
+            for (int j = 0; j < psCShape->nVertices; j++)
+            {
                 psCShape->padfX[j] = psCShape->padfX[j] * factor + xshift;
                 psCShape->padfY[j] = psCShape->padfY[j] * factor + yshift;
-	    }
+            }
         }
 
-/* -------------------------------------------------------------------- */
-/*      Write the Shape record after recomputing current extents.       */
-/* -------------------------------------------------------------------- */
-        SHPComputeExtents( psCShape );
-        SHPWriteObject( hSHPappend, -1, psCShape );
+        /* -------------------------------------------------------------------- */
+        /*      Write the Shape record after recomputing current extents.       */
+        /* -------------------------------------------------------------------- */
+        SHPComputeExtents(psCShape);
+        SHPWriteObject(hSHPappend, -1, psCShape);
 
-      SKIP_RECORD:
-        SHPDestroyObject( psCShape );
+    SKIP_RECORD:
+        SHPDestroyObject(psCShape);
         psCShape = NULL;
         // j=0;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Print out the # of Entities and the file bounds.                */
-/* -------------------------------------------------------------------- */
-    jRecord = DBFGetRecordCount( hDBFappend );
-    SHPGetInfo( hSHPappend, &nEntitiesAppend, &nShapeTypeAppend,
-                adfBoundsMin, adfBoundsMax );
+    /* -------------------------------------------------------------------- */
+    /*      Print out the # of Entities and the file bounds.                */
+    /* -------------------------------------------------------------------- */
+    jRecord = DBFGetRecordCount(hDBFappend);
+    SHPGetInfo(hSHPappend, &nEntitiesAppend, &nShapeTypeAppend, adfBoundsMin,
+               adfBoundsMax);
 
-    printf( "Output Bounds: (%lg,%lg) - (%lg,%lg)   Entities: %d  DBF: %d\n\n",
-	    adfBoundsMin[0], adfBoundsMin[1],
-            adfBoundsMax[0], adfBoundsMax[1],
-            nEntitiesAppend, jRecord );
-
+    printf("Output Bounds: (%lg,%lg) - (%lg,%lg)   Entities: %d  DBF: %d\n\n",
+           adfBoundsMin[0], adfBoundsMin[1], adfBoundsMax[0], adfBoundsMax[1],
+           nEntitiesAppend, jRecord);
 
     SHPClose(hSHP);
     SHPClose(hSHPappend);
     DBFClose(hDBF);
     DBFClose(hDBFappend);
 
-    if (nEntitiesAppend == 0) {
+    if (nEntitiesAppend == 0)
+    {
         puts("Remove the output files.");
         setext(outfile, "dbf");
         remove(outfile);


### PR DESCRIPTION
Apply GDAL code formatting rules, since GDAL has been the effective upstream of shapelib those recent years