### PR TITLE
remove SHP_CVSID.

### DIFF
--- a/dbfadd.c
+++ b/dbfadd.c
@@ -40,8 +40,6 @@
 
 #include "shapefil.h"
 
-SHP_CVSID("$Id$")
-
 int main(int argc, char ** argv) {
     if (argc < 3) {
         printf("dbfadd xbase_file field_values\n");

--- a/dbfcreate.c
+++ b/dbfcreate.c
@@ -39,8 +39,6 @@
 #include <string.h>
 #include "shapefil.h"
 
-SHP_CVSID("$Id$")
-
 int main(int argc, char ** argv) {
     // Display a usage message.
     if( argc < 2 ) {

--- a/dbfdump.c
+++ b/dbfdump.c
@@ -40,8 +40,6 @@
 #include <string.h>
 #include "shapefil.h"
 
-SHP_CVSID("$Id$")
-
 int main( int argc, char ** argv ) {
 /* -------------------------------------------------------------------- */
 /*      Handle arguments.                                               */

--- a/dbfopen.c
+++ b/dbfopen.c
@@ -67,8 +67,6 @@
 #define CPLsnprintf snprintf
 #endif
 
-SHP_CVSID("$Id$")
-
 #ifndef FALSE
 #  define FALSE		0
 #  define TRUE		1

--- a/safileio.c
+++ b/safileio.c
@@ -43,8 +43,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-SHP_CVSID("$Id$");
-
 #ifdef SHPAPI_UTF8_HOOKS
 #   ifdef SHPAPI_WINDOWS
 #       define WIN32_LEAN_AND_MEAN

--- a/sbnsearch.c
+++ b/sbnsearch.c
@@ -41,8 +41,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-SHP_CVSID("$Id$")
-
 #ifndef USE_CPL
 #if defined(_MSC_VER)
 # if _MSC_VER < 1900

--- a/shapefil.h
+++ b/shapefil.h
@@ -117,21 +117,6 @@ extern "C" {
 #endif
 
 /* -------------------------------------------------------------------- */
-/*      Macros for controlling CVSID and ensuring they don't appear     */
-/*      as unreferenced variables resulting in lots of warnings.        */
-/* -------------------------------------------------------------------- */
-#ifndef DISABLE_CVSID
-#  if defined(__GNUC__) && __GNUC__ >= 4
-#    define SHP_CVSID(string)     static const char cpl_cvsid[] __attribute__((used)) = string;
-#  else
-#    define SHP_CVSID(string)     static const char cpl_cvsid[] = string; \
-static const char *cvsid_aw() { return( cvsid_aw() ? NULL : cpl_cvsid ); }
-#  endif
-#else
-#  define SHP_CVSID(string)
-#endif
-
-/* -------------------------------------------------------------------- */
 /*      On some platforms, additional file IO hooks are defined that    */
 /*      UTF-8 encoded filenames Unicode filenames                       */
 /* -------------------------------------------------------------------- */

--- a/shpadd.c
+++ b/shpadd.c
@@ -40,8 +40,6 @@
 #include <string.h>
 #include "shapefil.h"
 
-SHP_CVSID("$Id$")
-
 int main( int argc, char ** argv ) {
 /* -------------------------------------------------------------------- */
 /*      Display a usage message.                                        */

--- a/shpcreate.c
+++ b/shpcreate.c
@@ -39,8 +39,6 @@
 #include <string.h>
 #include "shapefil.h"
 
-SHP_CVSID("$Id$")
-
 int main( int argc, char ** argv ) {
 /* -------------------------------------------------------------------- */
 /*      Display a usage message.                                        */

--- a/shpdump.c
+++ b/shpdump.c
@@ -41,8 +41,6 @@
 #include <string.h>
 #include "shapefil.h"
 
-SHP_CVSID("$Id$")
-
 int main( int argc, char ** argv ) {
     bool bValidate = false;
     if( argc > 1 && strcmp(argv[1],"-validate") == 0 )

--- a/shpopen.c
+++ b/shpopen.c
@@ -44,8 +44,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-SHP_CVSID("$Id$")
-
 typedef unsigned char uchar;
 
 #if UINT_MAX == 65535

--- a/shptest.c
+++ b/shptest.c
@@ -40,8 +40,6 @@
 #include <string.h>
 #include "shapefil.h"
 
-SHP_CVSID("$Id$")
-
 /************************************************************************/
 /*                          Test_WritePoints()                          */
 /*                                                                      */

--- a/shptree.c
+++ b/shptree.c
@@ -48,8 +48,6 @@
 #include "cpl_error.h"
 #endif
 
-SHP_CVSID("$Id$")
-
 #ifndef TRUE
 #  define TRUE 1
 #  define FALSE 0

--- a/shptreedump.c
+++ b/shptreedump.c
@@ -44,8 +44,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-SHP_CVSID("$Id$")
-
 static void SHPTreeNodeDump( SHPTree *, SHPTreeNode *, const char *, int );
 static void SHPTreeNodeSearchAndDump( SHPTree *, double *, double * );
 

--- a/shputils.c
+++ b/shputils.c
@@ -59,8 +59,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-SHP_CVSID("$Id$")
-
 char            infile[80], outfile[80], temp[400];
 
 /* Variables for shape files */


### PR DESCRIPTION
This is causing problems with visual studio and clang.  I believe it is unused as the git doesn't support keyword substitution.

For example:
```
C:\PROGRA~1\MICROS~4\2022\COMMUN~1\VC\Tools\Llvm\x64\bin\clang-cl.exe   -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -IC:\Users\user1\source\repos\whit2\out\build\x64-Clang-Debug -IC:\Users\user1\source\repos\whit2 -IC:\Users\user1\source\repos\whit2\shape -m64 -fdiagnostics-absolute-paths  /DWIN32 /D_WINDOWS /W3 /MDd /Zi /Ob0 /Od /RTC1 /std:c17 -Wno-unused-but-set-variable /showIncludes /FoCMakeFiles\shp.dir\shapelib\safileio.c.obj /FdCMakeFiles\shp.dir\shp.pdb -c -- C:\Users\user1\source\repos\whit2\shapelib\safileio.c
C:\Users\user1\source\repos\whit2\shapelib\safileio.c(77,1): warning : all paths through this function will call itself [-Winfinite-recursion]
  SHP_CVSID("$Id: safileio.c,v 1.6 2018-06-15 19:56:32 erouault Exp $");
  ^
  C:\Users\user1\source\repos\whit2\shapelib\shapefil.h(265,31): note: expanded from macro 'SHP_CVSID'
  static const char *cvsid_aw() { return( cvsid_aw() ? NULL : cpl_cvsid ); }
                                ^
C:\Users\user1\source\repos\whit2\shapelib\safileio.c(77,1): warning : function 'cvsid_aw' is not needed and will not be emitted [-Wunneeded-internal-declaration]
  C:\Users\user1\source\repos\whit2\shapelib\shapefil.h(265,20): note: expanded from macro 'SHP_CVSID'
  static const char *cvsid_aw() { return( cvsid_aw() ? NULL : cpl_cvsid ); }
                     ^
  2 warnings generated.
```