### PR TITLE
Add MSVC quick fix for LFS

### DIFF
--- a/safileio.c
+++ b/safileio.c
@@ -69,12 +69,20 @@ static SAOffset SADFWrite(void *p, SAOffset size, SAOffset nmemb, SAFile file)
 
 static SAOffset SADFSeek(SAFile file, SAOffset offset, int whence)
 {
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+    return (SAOffset)_fseeki64((FILE *)file, (__int64)offset, whence);
+#else
     return (SAOffset)fseek((FILE *)file, (long)offset, whence);
+#endif
 }
 
 static SAOffset SADFTell(SAFile file)
 {
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+    return (SAOffset)_ftelli64((FILE *)file);
+#else
     return (SAOffset)ftell((FILE *)file);
+#endif
 }
 
 static int SADFFlush(SAFile file)

--- a/shapefil.h
+++ b/shapefil.h
@@ -132,7 +132,11 @@ extern "C"
     typedef int *SAFile;
 
 #ifndef SAOffset
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+    typedef unsigned __int64 SAOffset;
+#else
     typedef unsigned long SAOffset;
+#endif
 #endif
 
     typedef struct


### PR DESCRIPTION
This is a quick fix to add support for 64-bit file I/O on Windows for MSVC. Let me know if I should do better.