### PR TITLE
Merge GDAL changes into upstream shapelib

### DIFF
--- a/dbfopen.c
+++ b/dbfopen.c
@@ -511,13 +511,16 @@ DBFHandle SHPAPI_CALL DBFOpenLL(const char *pszFilename, const char *pszAccess,
             psDBF->panFieldDecimals[iField] = 0;
 
             /*
-** The following seemed to be used sometimes to handle files with long
-** string fields, but in other cases (such as bug 1202) the decimals field
-** just seems to indicate some sort of preferred formatting, not very
-** wide fields.  So I have disabled this code.  FrankW.
-            psDBF->panFieldSize[iField] = pabyFInfo[16] + pabyFInfo[17]*256;
-            psDBF->panFieldDecimals[iField] = 0;
-*/
+            ** The following seemed to be used sometimes to handle files with
+            long
+            ** string fields, but in other cases (such as bug 1202) the decimals
+            field
+            ** just seems to indicate some sort of preferred formatting, not
+            very
+            ** wide fields.  So I have disabled this code.  FrankW.
+                    psDBF->panFieldSize[iField] = pabyFInfo[16] +
+            pabyFInfo[17]*256; psDBF->panFieldDecimals[iField] = 0;
+            */
         }
 
         psDBF->pachFieldType[iField] = STATIC_CAST(char, pabyFInfo[11]);
@@ -640,18 +643,7 @@ DBFHandle SHPAPI_CALL DBFCreateLL(const char *pszFilename,
     /* -------------------------------------------------------------------- */
     /*      Create the file.                                                */
     /* -------------------------------------------------------------------- */
-    SAFile fp = psHooks->FOpen(pszFullname, "wb");
-    if (fp == SHPLIB_NULLPTR)
-    {
-        free(pszFullname);
-        return SHPLIB_NULLPTR;
-    }
-
-    char chZero = '\0';
-    psHooks->FWrite(&chZero, 1, 1, fp);
-    psHooks->FClose(fp);
-
-    fp = psHooks->FOpen(pszFullname, "rb+");
+    SAFile fp = psHooks->FOpen(pszFullname, "wb+");
     if (fp == SHPLIB_NULLPTR)
     {
         free(pszFullname);
@@ -666,8 +658,8 @@ DBFHandle SHPAPI_CALL DBFCreateLL(const char *pszFilename,
         {
             ldid = atoi(pszCodePage + 5);
             if (ldid > 255)
-                ldid =
-                    -1;  // don't use 0 to indicate out of range as LDID/0 is a valid one
+                ldid = -1;  // don't use 0 to indicate out of range as LDID/0 is
+                            // a valid one
         }
         if (ldid < 0)
         {
@@ -1119,10 +1111,10 @@ static bool DBFIsValueNULL(char chType, const char *pszValue)
         case 'N':
         case 'F':
             /*
-        ** We accept all asterisks or all blanks as NULL
-        ** though according to the spec I think it should be all
-        ** asterisks.
-        */
+            ** We accept all asterisks or all blanks as NULL
+            ** though according to the spec I think it should be all
+            ** asterisks.
+            */
             if (pszValue[0] == '*')
                 return true;
 
@@ -1414,25 +1406,29 @@ int SHPAPI_CALL DBFWriteAttributeDirectly(DBFHandle psDBF, int hEntity,
     if (!DBFLoadRecord(psDBF, hEntity))
         return FALSE;
 
-    unsigned char *pabyRec =
-        REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
-
-    /* -------------------------------------------------------------------- */
-    /*      Assign all the record fields.                                   */
-    /* -------------------------------------------------------------------- */
-    int j;
-    if (STATIC_CAST(int, strlen(STATIC_CAST(char *, pValue))) >
-        psDBF->panFieldSize[iField])
-        j = psDBF->panFieldSize[iField];
-    else
+    if (iField >= 0)
     {
-        memset(pabyRec + psDBF->panFieldOffset[iField], ' ',
-               psDBF->panFieldSize[iField]);
-        j = STATIC_CAST(int, strlen(STATIC_CAST(char *, pValue)));
-    }
+        unsigned char *pabyRec =
+            REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
 
-    strncpy(REINTERPRET_CAST(char *, pabyRec + psDBF->panFieldOffset[iField]),
+        /* -------------------------------------------------------------------- */
+        /*      Assign all the record fields.                                   */
+        /* -------------------------------------------------------------------- */
+        int j;
+        if (STATIC_CAST(int, strlen(STATIC_CAST(char *, pValue))) >
+            psDBF->panFieldSize[iField])
+            j = psDBF->panFieldSize[iField];
+        else
+        {
+            memset(pabyRec + psDBF->panFieldOffset[iField], ' ',
+                   psDBF->panFieldSize[iField]);
+            j = STATIC_CAST(int, strlen(STATIC_CAST(char *, pValue)));
+        }
+
+        strncpy(
+            REINTERPRET_CAST(char *, pabyRec + psDBF->panFieldOffset[iField]),
             STATIC_CAST(const char *, pValue), j);
+    }
 
     psDBF->bCurrentRecordModified = TRUE;
     psDBF->bUpdated = TRUE;
@@ -1895,7 +1891,8 @@ int SHPAPI_CALL DBFReorderFields(DBFHandle psDBF, const int *panMap)
     if (!DBFFlushRecord(psDBF))
         return FALSE;
 
-    /* a simple malloc() would be enough, but calloc() helps clang static analyzer */
+    /* a simple malloc() would be enough, but calloc() helps clang static
+     * analyzer */
     int *panFieldOffsetNew =
         STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
     int *panFieldSizeNew =

--- a/sbnsearch.c
+++ b/sbnsearch.c
@@ -56,12 +56,14 @@ typedef int coord;
 
 typedef struct
 {
-    uchar *
-        pabyShapeDesc; /* Cache of (nShapeCount * 8) bytes of the bins. May be NULL. */
-    int nBinStart;   /* Index of first bin for this node. */
-    int nShapeCount; /* Number of shapes attached to this node. */
-    int nBinCount; /* Number of bins for this node. May be 0 if node is empty. */
-    int nBinOffset; /* Offset in file of the start of the first bin. May be 0 if node is empty. */
+    uchar *pabyShapeDesc; /* Cache of (nShapeCount * 8) bytes of the bins. May
+                             be NULL. */
+    int nBinStart;        /* Index of first bin for this node. */
+    int nShapeCount;      /* Number of shapes attached to this node. */
+    int nBinCount;  /* Number of bins for this node. May be 0 if node is empty.
+                     */
+    int nBinOffset; /* Offset in file of the start of the first bin. May be 0 if
+                       node is empty. */
 
     bool bBBoxInit; /* true if the following bounding box has been computed. */
     coord
@@ -621,6 +623,7 @@ static bool SBNSearchDiskInternal(SearchStruct *psSearch, int nDepth,
 
                 if (!psNode->bBBoxInit)
                 {
+/* clang-format off */
 #ifdef sanity_checks
                     /* -------------------------------------------------------------------- */
                     /*      Those tests only check that the shape bounding box in the bin   */
@@ -644,6 +647,7 @@ static bool SBNSearchDiskInternal(SearchStruct *psSearch, int nDepth,
                         return false;
                     }
 #endif
+                    /* clang-format on */
                     if (bMinX < psNode->bMinX)
                         psNode->bMinX = bMinX;
                     if (bMinY < psNode->bMinY)

--- a/shapefil.h
+++ b/shapefil.h
@@ -18,10 +18,6 @@
 
 #include <stdio.h>
 
-#ifdef USE_DBMALLOC
-#include <dbmalloc.h>
-#endif
-
 #ifdef USE_CPL
 #include "cpl_conv.h"
 #endif
@@ -311,7 +307,7 @@ extern "C"
         double adfBoundsMax[4];
 
         /* list of shapes stored at this node.  The papsShapeObj pointers
-       or the whole list can be NULL */
+           or the whole list can be NULL */
         int nShapeCount;
         int *panShapeIds;
         SHPObject **papsShapeObj;
@@ -402,8 +398,8 @@ extern "C"
 
         int nRecordLength; /* Must fit on uint16 */
         int nHeaderLength; /* File header length (32) + field
-                                  descriptor length + spare space.
-                                  Must fit on uint16 */
+                              descriptor length + spare space.
+                              Must fit on uint16 */
         int nFields;
         int *panFieldOffset;
         int *panFieldSize;


### PR DESCRIPTION
- Polygon writing: avoid considering rings slightly overlapping as inner-outer
  rings of others (refs OSGeo/gdal#5315)
  https://github.com/OSGeo/gdal/commit/a41e0a2b163b8c4b33ecf0f93f7cc487b9902b61
- Polygon writing: consider rings at non-constant Z as outer rings
  (fixes OSGeo/gdal#5315)
  As noted in code comments, this is an approximation of more complicated
  tests we'd likely have to do, that would take into account real
  co-planar testing, to allow detecting inner rings of outer rings in an
  oblique plane.
  https://github.com/OSGeo/gdal/commit/702b19f91ba8065df2fa5d74f31fcdf798e0a838
- shpopen.c: Communicate why the file size cannot be reached when appending
  features (OSGeo/gdal#4140)
  Clearly state why the file size cannot be reached. This is important in order
  to correctly inform the user and prevent him/her from looking for other reasons.
  Related to https://github.com/qgis/QGIS/issues/44202
  https://github.com/OSGeo/gdal/commit/91988f809f8b4357416f79832f68d01fdb6209b5
- SHPWriteObject(): prevent potential overflows on 64-bit
  platforms on huge geometries:
  https://github.com/OSGeo/gdal/commit/454e5ed672153fdd292d1145ee97726a2a6e019f
- SHPRestoreSHX: update SHX content length even if error occurred:
  https://github.com/OSGeo/gdal/commit/998c91d75466b02242fe87b1b91772c51b99bcc4
- in creation, uses w+b file opening mode instead of wb followed by r+b,
  to support network file systems having sequential write only and when
  using CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE=YES (fixes OSGeo/gdal#7801):
  https://github.com/OSGeo/gdal/commit/e9f9842b34e4b471e3670f013a83d843f5c3bd5b
- fix adding features in a .dbf without columns (fixes qgis/qgis#51247):
  https://github.com/OSGeo/gdal/commit/17c0b0bd00f4f68ae6c4407e25895f7aec6923a1

With this PR, shapelib and GDAL (https://github.com/OSGeo/gdal/pull/8749) will be sync'ed again