### PR TITLE
add userdata ptr to SAHooks, available during file open/removal

### DIFF
--- a/dbfopen.c
+++ b/dbfopen.c
@@ -370,21 +370,22 @@ DBFHandle SHPAPI_CALL DBFOpenLL(const char *pszFilename, const char *pszAccess,
     memcpy(pszFullname + nLenWithoutExtension, ".dbf", 5);
 
     DBFHandle psDBF = STATIC_CAST(DBFHandle, calloc(1, sizeof(DBFInfo)));
-    psDBF->fp = psHooks->FOpen(pszFullname, pszAccess);
+    psDBF->fp = psHooks->FOpen(pszFullname, pszAccess, psHooks->pvUserData);
     memcpy(&(psDBF->sHooks), psHooks, sizeof(SAHooks));
 
     if (psDBF->fp == SHPLIB_NULLPTR)
     {
         memcpy(pszFullname + nLenWithoutExtension, ".DBF", 5);
-        psDBF->fp = psDBF->sHooks.FOpen(pszFullname, pszAccess);
+        psDBF->fp =
+            psDBF->sHooks.FOpen(pszFullname, pszAccess, psHooks->pvUserData);
     }
 
     memcpy(pszFullname + nLenWithoutExtension, ".cpg", 5);
-    SAFile pfCPG = psHooks->FOpen(pszFullname, "r");
+    SAFile pfCPG = psHooks->FOpen(pszFullname, "r", psHooks->pvUserData);
     if (pfCPG == SHPLIB_NULLPTR)
     {
         memcpy(pszFullname + nLenWithoutExtension, ".CPG", 5);
-        pfCPG = psHooks->FOpen(pszFullname, "r");
+        pfCPG = psHooks->FOpen(pszFullname, "r", psHooks->pvUserData);
     }
 
     free(pszFullname);
@@ -643,7 +644,7 @@ DBFHandle SHPAPI_CALL DBFCreateLL(const char *pszFilename,
     /* -------------------------------------------------------------------- */
     /*      Create the file.                                                */
     /* -------------------------------------------------------------------- */
-    SAFile fp = psHooks->FOpen(pszFullname, "wb+");
+    SAFile fp = psHooks->FOpen(pszFullname, "wb+", psHooks->pvUserData);
     if (fp == SHPLIB_NULLPTR)
     {
         free(pszFullname);
@@ -663,7 +664,8 @@ DBFHandle SHPAPI_CALL DBFCreateLL(const char *pszFilename,
         }
         if (ldid < 0)
         {
-            SAFile fpCPG = psHooks->FOpen(pszFullname, "w");
+            SAFile fpCPG =
+                psHooks->FOpen(pszFullname, "w", psHooks->pvUserData);
             psHooks->FWrite(
                 CONST_CAST(void *, STATIC_CAST(const void *, pszCodePage)),
                 strlen(pszCodePage), 1, fpCPG);
@@ -672,7 +674,7 @@ DBFHandle SHPAPI_CALL DBFCreateLL(const char *pszFilename,
     }
     if (pszCodePage == SHPLIB_NULLPTR || ldid >= 0)
     {
-        psHooks->Remove(pszFullname);
+        psHooks->Remove(pszFullname, psHooks->pvUserData);
     }
 
     free(pszFullname);

--- a/safileio.c
+++ b/safileio.c
@@ -30,7 +30,8 @@
 #endif
 #endif
 
-static SAFile SADFOpen(const char *pszFilename, const char *pszAccess)
+static SAFile SADFOpen(const char *pszFilename, const char *pszAccess,
+                       void *pvUserData)
 {
     return (SAFile)fopen(pszFilename, pszAccess);
 }
@@ -74,7 +75,7 @@ static int SADFClose(SAFile file)
     return fclose((FILE *)file);
 }
 
-static int SADRemove(const char *filename)
+static int SADRemove(const char *filename, void *pvUserData)
 {
     return remove(filename);
 }
@@ -97,6 +98,7 @@ void SASetupDefaultHooks(SAHooks *psHooks)
 
     psHooks->Error = SADError;
     psHooks->Atof = atof;
+    psHooks->pvUserData = NULL;
 }
 
 #ifdef SHPAPI_WINDOWS

--- a/sbnsearch.c
+++ b/sbnsearch.c
@@ -159,7 +159,8 @@ SBNSearchHandle SBNOpenDiskTree(const char *pszSBNFilename,
     else
         memcpy(&(hSBN->sHooks), psHooks, sizeof(SAHooks));
 
-    hSBN->fpSBN = hSBN->sHooks.FOpen(pszSBNFilename, "rb");
+    hSBN->fpSBN =
+        hSBN->sHooks.FOpen(pszSBNFilename, "rb", hSBN->sHooks.pvUserData);
     if (hSBN->fpSBN == SHPLIB_NULLPTR)
     {
         free(hSBN);
@@ -626,7 +627,7 @@ static bool SBNSearchDiskInternal(SearchStruct *psSearch, int nDepth,
 
                 if (!psNode->bBBoxInit)
                 {
-/* clang-format off */
+                    /* clang-format off */
 #ifdef sanity_checks
                     /* -------------------------------------------------------------------- */
                     /*      Those tests only check that the shape bounding box in the bin   */

--- a/shapefil.h
+++ b/shapefil.h
@@ -115,7 +115,8 @@ extern "C"
 
     typedef struct
     {
-        SAFile (*FOpen)(const char *filename, const char *access);
+        SAFile (*FOpen)(const char *filename, const char *access,
+                        void *pvUserData);
         SAOffset (*FRead)(void *p, SAOffset size, SAOffset nmemb, SAFile file);
         SAOffset (*FWrite)(const void *p, SAOffset size, SAOffset nmemb,
                            SAFile file);
@@ -123,10 +124,11 @@ extern "C"
         SAOffset (*FTell)(SAFile file);
         int (*FFlush)(SAFile file);
         int (*FClose)(SAFile file);
-        int (*Remove)(const char *filename);
+        int (*Remove)(const char *filename, void *pvUserData);
 
         void (*Error)(const char *message);
         double (*Atof)(const char *str);
+        void *pvUserData;
     } SAHooks;
 
     void SHPAPI_CALL SASetupDefaultHooks(SAHooks *psHooks);

--- a/shpopen.c
+++ b/shpopen.c
@@ -338,11 +338,13 @@ SHPHandle SHPAPI_CALL SHPOpenLL(const char *pszLayer, const char *pszAccess,
     char *pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
     memcpy(pszFullname, pszLayer, nLenWithoutExtension);
     memcpy(pszFullname + nLenWithoutExtension, ".shp", 5);
-    psSHP->fpSHP = psSHP->sHooks.FOpen(pszFullname, pszAccess);
+    psSHP->fpSHP =
+        psSHP->sHooks.FOpen(pszFullname, pszAccess, psSHP->sHooks.pvUserData);
     if (psSHP->fpSHP == SHPLIB_NULLPTR)
     {
         memcpy(pszFullname + nLenWithoutExtension, ".SHP", 5);
-        psSHP->fpSHP = psSHP->sHooks.FOpen(pszFullname, pszAccess);
+        psSHP->fpSHP = psSHP->sHooks.FOpen(pszFullname, pszAccess,
+                                           psSHP->sHooks.pvUserData);
     }
 
     if (psSHP->fpSHP == SHPLIB_NULLPTR)
@@ -363,11 +365,13 @@ SHPHandle SHPAPI_CALL SHPOpenLL(const char *pszLayer, const char *pszAccess,
     }
 
     memcpy(pszFullname + nLenWithoutExtension, ".shx", 5);
-    psSHP->fpSHX = psSHP->sHooks.FOpen(pszFullname, pszAccess);
+    psSHP->fpSHX =
+        psSHP->sHooks.FOpen(pszFullname, pszAccess, psSHP->sHooks.pvUserData);
     if (psSHP->fpSHX == SHPLIB_NULLPTR)
     {
         memcpy(pszFullname + nLenWithoutExtension, ".SHX", 5);
-        psSHP->fpSHX = psSHP->sHooks.FOpen(pszFullname, pszAccess);
+        psSHP->fpSHX = psSHP->sHooks.FOpen(pszFullname, pszAccess,
+                                           psSHP->sHooks.pvUserData);
     }
 
     if (psSHP->fpSHX == SHPLIB_NULLPTR)
@@ -708,11 +712,11 @@ int SHPAPI_CALL SHPRestoreSHX(const char *pszLayer, const char *pszAccess,
     char *pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
     memcpy(pszFullname, pszLayer, nLenWithoutExtension);
     memcpy(pszFullname + nLenWithoutExtension, ".shp", 5);
-    SAFile fpSHP = psHooks->FOpen(pszFullname, pszAccess);
+    SAFile fpSHP = psHooks->FOpen(pszFullname, pszAccess, psHooks->pvUserData);
     if (fpSHP == SHPLIB_NULLPTR)
     {
         memcpy(pszFullname + nLenWithoutExtension, ".SHP", 5);
-        fpSHP = psHooks->FOpen(pszFullname, pszAccess);
+        fpSHP = psHooks->FOpen(pszFullname, pszAccess, psHooks->pvUserData);
     }
 
     if (fpSHP == SHPLIB_NULLPTR)
@@ -756,7 +760,8 @@ int SHPAPI_CALL SHPRestoreSHX(const char *pszLayer, const char *pszAccess,
 
     memcpy(pszFullname + nLenWithoutExtension, ".shx", 5);
     const char pszSHXAccess[] = "w+b";
-    SAFile fpSHX = psHooks->FOpen(pszFullname, pszSHXAccess);
+    SAFile fpSHX =
+        psHooks->FOpen(pszFullname, pszSHXAccess, psHooks->pvUserData);
     if (fpSHX == SHPLIB_NULLPTR)
     {
         size_t nMessageLen = strlen(pszFullname) * 2 + 256;
@@ -1037,7 +1042,7 @@ SHPHandle SHPAPI_CALL SHPCreateLL(const char *pszLayer, int nShapeType,
     char *pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
     memcpy(pszFullname, pszLayer, nLenWithoutExtension);
     memcpy(pszFullname + nLenWithoutExtension, ".shp", 5);
-    SAFile fpSHP = psHooks->FOpen(pszFullname, "w+b");
+    SAFile fpSHP = psHooks->FOpen(pszFullname, "w+b", psHooks->pvUserData);
     if (fpSHP == SHPLIB_NULLPTR)
     {
         char szErrorMsg[200];
@@ -1050,7 +1055,7 @@ SHPHandle SHPAPI_CALL SHPCreateLL(const char *pszLayer, int nShapeType,
     }
 
     memcpy(pszFullname + nLenWithoutExtension, ".shx", 5);
-    SAFile fpSHX = psHooks->FOpen(pszFullname, "w+b");
+    SAFile fpSHX = psHooks->FOpen(pszFullname, "w+b", psHooks->pvUserData);
     if (fpSHX == SHPLIB_NULLPTR)
     {
         char szErrorMsg[200];

--- a/shptree.c
+++ b/shptree.c
@@ -733,7 +733,8 @@ SHPTreeDiskHandle SHPOpenDiskTree(const char *pszQIXFilename,
     else
         memcpy(&(hDiskTree->sHooks), psHooks, sizeof(SAHooks));
 
-    hDiskTree->fpQIX = hDiskTree->sHooks.FOpen(pszQIXFilename, "rb");
+    hDiskTree->fpQIX = hDiskTree->sHooks.FOpen(pszQIXFilename, "rb",
+                                               hDiskTree->sHooks.pvUserData);
     if (hDiskTree->fpQIX == SHPLIB_NULLPTR)
     {
         free(hDiskTree);
@@ -1125,7 +1126,7 @@ int SHPWriteTreeLL(SHPTree *tree, const char *filename, const SAHooks *psHooks)
     /* -------------------------------------------------------------------- */
     /*      Open the output file.                                           */
     /* -------------------------------------------------------------------- */
-    fp = psHooks->FOpen(filename, "wb");
+    fp = psHooks->FOpen(filename, "wb", psHooks->pvUserData);
     if (fp == SHPLIB_NULLPTR)
     {
         return FALSE;


### PR DESCRIPTION
This PR adds an additional `void*` to the `SAHooks` struct and passes it along to the file open/close hooks. It is set to a `NULL` pointer by default, but enables opening/closing files with additional context, e.g. a filesystem abstraction or thread-local state.