### PR TITLE
Make building executables optional with CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(PROJECT_VERSION_MAJOR 1)
 set(PROJECT_VERSION_MINOR 6)
 set(PROJECT_VERSION_PATCH 0)
 set(shp_LIB_VERSIONINFO "4:0:0")
-set(PROJECT_VERSION 
+set(PROJECT_VERSION
   "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -26,6 +26,8 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # libraries are all shared by default.
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
+# Option to build executables
+option(BUILD_SHAPELIB_EXECUTABLES "Build executables" ON)
 # Option to build contributed utilities
 option(BUILD_SHAPELIB_CONTRIB "Build utilities (from contrib)" ON)
 
@@ -154,16 +156,18 @@ install(TARGETS ${PACKAGE}
 )
 
 # executables to be built and installed.
-set(executables
-  shpcreate
-  shpadd
-  shpdump
-  shprewind
-  dbfcreate
-  dbfadd
-  dbfdump
-  shptreedump
-)
+if(BUILD_SHAPELIB_EXECUTABLES)
+  set(executables
+    shpcreate
+    shpadd
+    shpdump
+    shprewind
+    dbfcreate
+    dbfadd
+    dbfdump
+    shptreedump
+  )
+endif()
 
 if(MSVC)
   # TODO(schwehr): How to test on Windows?

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,12 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 # Option to build executables
-option(BUILD_SHAPELIB_EXECUTABLES "Build executables" ON)
+option(BUILD_APPS "Build executables" ON)
 # Option to build contributed utilities
-option(BUILD_SHAPELIB_CONTRIB "Build utilities (from contrib)" ON)
+# Defaults to ${BUILD_APPS}. If you reconfigure with a different BUILD_APPS
+# value, be aware that you have to explicitly change BUILD_SHAPELIB_CONTRIB,
+# otherwise the previous value from the cache will be used.
+option(BUILD_SHAPELIB_CONTRIB "Build utilities (from contrib)" ${BUILD_APPS})
 
 # Use rpath?
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
@@ -156,7 +159,7 @@ install(TARGETS ${PACKAGE}
 )
 
 # executables to be built and installed.
-if(BUILD_SHAPELIB_EXECUTABLES)
+if(BUILD_APPS)
   set(executables
     shpcreate
     shpadd


### PR DESCRIPTION
If you don't want to build the executables, set BUILD_SHAPELIB_EXECUTABLES to OFF when configuring with CMake.