### PR TITLE
Fix UTF8 hook functions

### DIFF
--- a/safileio.c
+++ b/safileio.c
@@ -132,8 +132,10 @@ static wchar_t *Utf8ToWideChar(const char *pszFilename)
 /*                           SAUtf8WFOpen                               */
 /************************************************************************/
 
-SAFile SAUtf8WFOpen(const char *pszFilename, const char *pszAccess)
+static SAFile SAUtf8WFOpen(const char *pszFilename, const char *pszAccess,
+                           void *pvUserData)
 {
+    (void)pvUserData;
     SAFile file = NULL;
     wchar_t *pwszFileName = Utf8ToWideChar(pszFilename);
     wchar_t *pwszAccess = Utf8ToWideChar(pszAccess);
@@ -146,8 +148,9 @@ SAFile SAUtf8WFOpen(const char *pszFilename, const char *pszAccess)
     return file;
 }
 
-int SAUtf8WRemove(const char *pszFilename)
+static int SAUtf8WRemove(const char *pszFilename, void *pvUserData)
 {
+    (void)pvUserData;
     wchar_t *pwszFileName = Utf8ToWideChar(pszFilename);
     int rc = -1;
     if (pwszFileName != NULL)


### PR DESCRIPTION
This got "broken" by 01ee129f7d53b2619b2a1e8e5e5ea2553caaaf67.

You can see these warnings in https://github.com/OSGeo/shapelib/actions/runs/7152273225/job/19477427836. 

> D:/a/shapelib/shapelib/safileio.c(168,20): warning C4113: 'SAFile (__cdecl *)(const char *,const char *)' differs in parameter lists from 'SAFile (__cdecl *)(const char *,const char *,void *)' [D:\a\shapelib\shapelib\build\shp.vcxproj]
D:/a/shapelib/shapelib/safileio.c(169,21): warning C4113: 'int (__cdecl *)(const char *)' differs in parameter lists from 'int (__cdecl *)(const char *,void *)' [D:\a\shapelib\shapelib\build\shp.vcxproj]