### PR TITLE
Ensure consistent definition and declaration of SHPRewindObject

### DIFF
--- a/shpopen.c
+++ b/shpopen.c
@@ -46,14 +46,6 @@
 #endif
 #endif
 
-#ifndef CPL_UNUSED
-#if defined(__GNUC__) && __GNUC__ >= 4
-#define CPL_UNUSED __attribute((__unused__))
-#else
-#define CPL_UNUSED
-#endif
-#endif
-
 #ifndef bBigEndian
 #if defined(CPL_LSB)
 #define bBigEndian false
@@ -2936,8 +2928,9 @@ static int SHPRewindIsInnerRing(const SHPObject *psObject, int iOpRing,
 /*      specification.                                                  */
 /************************************************************************/
 
-int SHPAPI_CALL SHPRewindObject(CPL_UNUSED SHPHandle hSHP, SHPObject *psObject)
+int SHPAPI_CALL SHPRewindObject(SHPHandle hSHP, SHPObject *psObject)
 {
+    (void)hSHP;
     /* -------------------------------------------------------------------- */
     /*      Do nothing if this is not a polygon object.                     */
     /* -------------------------------------------------------------------- */


### PR DESCRIPTION
CPL_UNUSED only was used in one place