### PR TITLE
Fix format specifier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ target_include_directories(${PACKAGE}
 if(MSVC)
   target_compile_options(${PACKAGE} PRIVATE /W4)
 else()
-  target_compile_options(${PACKAGE} PRIVATE -Wall -Wextra -pedantic)
+  target_compile_options(${PACKAGE} PRIVATE -Wall -Wextra -Wformat-signedness -Wno-unknown-warning-option -pedantic)
 endif()
 
 if(WIN32 AND NOT CYGWIN)

--- a/shpopen.c
+++ b/shpopen.c
@@ -818,9 +818,9 @@ int SHPAPI_CALL SHPRestoreSHX(const char *pszLayer, const char *pszAccess,
                 char szErrorMsg[200];
                 snprintf(szErrorMsg, sizeof(szErrorMsg),
                          "Error parsing .shp to restore .shx. "
-                         "Invalid record length = %d at record starting at "
+                         "Invalid record length = %u at record starting at "
                          "offset %u",
-                         nSHPType, nCurrentSHPOffset);
+                         nRecordLength, nCurrentSHPOffset);
                 psHooks->Error(szErrorMsg);
 
                 nRetCode = FALSE;

--- a/shpopen.c
+++ b/shpopen.c
@@ -818,7 +818,7 @@ int SHPAPI_CALL SHPRestoreSHX(const char *pszLayer, const char *pszAccess,
                 char szErrorMsg[200];
                 snprintf(szErrorMsg, sizeof(szErrorMsg),
                          "Error parsing .shp to restore .shx. "
-                         "Invalid record length = %u at record starting at "
+                         "Invalid record length = %d at record starting at "
                          "offset %u",
                          nSHPType, nCurrentSHPOffset);
                 psHooks->Error(szErrorMsg);


### PR DESCRIPTION
It's already correct in the other place:

https://github.com/OSGeo/shapelib/blob/8cf92b255f282eeeb3580e84c6fe56257c9068f3/shpopen.c#L842

I wonder why this is not reported by GCC with -Wall set.

