### PR TITLE
Detect byte order at compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,12 @@ target_include_directories(${PACKAGE}
     $<INSTALL_INTERFACE:include>
 )
 
+include(TestBigEndian)
+if(HAVE_BYTE_ORDER_BIG_ENDIAN)
+  # Define SHP_BIG_ENDIAN if the system is big-endian
+  add_definitions(-DSHP_BIG_ENDIAN=1)
+endif()
+
 if(MSVC)
   target_compile_options(${PACKAGE} PRIVATE /W4)
 else()
@@ -292,4 +298,4 @@ endif()
 
 include(cmake/contrib.cmake)
 
-add_subdirectory (cmake)
+add_subdirectory(cmake)

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,12 @@ AC_INIT(shapelib, shapelib_version_major.shapelib_version_minor.shapelib_version
 AC_CONFIG_MACRO_DIR(m4)
 AC_CONFIG_SRCDIR(shapefil.h)
 
+AC_C_BIGENDIAN
+if test "x$ac_cv_c_bigendian" = "xyes"; then
+  # Define SHP_BIG_ENDIAN if the system is big-endian
+  AC_DEFINE([SHP_BIG_ENDIAN], [1], [Define if the system is big-endian])
+fi
+
 AM_INIT_AUTOMAKE([foreign -Wall -Wextra])
 
 AM_SILENT_RULES([yes])

--- a/sbnsearch.c
+++ b/sbnsearch.c
@@ -137,18 +137,6 @@ SBNSearchHandle SBNOpenDiskTree(const char *pszSBNFilename,
                                 const SAHooks *psHooks)
 {
     /* -------------------------------------------------------------------- */
-    /*  Establish the byte order on this machine.                           */
-    /* -------------------------------------------------------------------- */
-    bool _bBigEndian;
-    {
-        int i = 1;
-        if (*REINTERPRET_CAST(unsigned char *, &i) == 1)
-            _bBigEndian = false;
-        else
-            _bBigEndian = true;
-    }
-
-    /* -------------------------------------------------------------------- */
     /*      Initialize the handle structure.                                */
     /* -------------------------------------------------------------------- */
     SBNSearchHandle hSBN =
@@ -191,13 +179,12 @@ SBNSearchHandle SBNOpenDiskTree(const char *pszSBNFilename,
     memcpy(&hSBN->dfMaxX, abyHeader + 48, 8);
     memcpy(&hSBN->dfMaxY, abyHeader + 56, 8);
 
-    if (!_bBigEndian)
-    {
-        SwapWord(8, &hSBN->dfMinX);
-        SwapWord(8, &hSBN->dfMinY);
-        SwapWord(8, &hSBN->dfMaxX);
-        SwapWord(8, &hSBN->dfMaxY);
-    }
+#if !defined(SHP_BIG_ENDIAN)
+    SwapWord(8, &hSBN->dfMinX);
+    SwapWord(8, &hSBN->dfMinY);
+    SwapWord(8, &hSBN->dfMaxX);
+    SwapWord(8, &hSBN->dfMaxY);
+#endif
 
     if (hSBN->dfMinX > hSBN->dfMaxX || hSBN->dfMinY > hSBN->dfMaxY)
     {

--- a/shapefil.h
+++ b/shapefil.h
@@ -22,6 +22,29 @@
 #include "cpl_conv.h"
 #endif
 
+#if !defined(SHP_BIG_ENDIAN)
+#if defined(CPL_MSB)
+#define SHP_BIG_ENDIAN 1
+#elif (defined(__GNUC__) && __GNUC__ >= 5) ||                                  \
+    (defined(__GNUC__) && defined(__GNUC_MINOR__) && __GNUC__ == 4 &&          \
+     __GNUC_MINOR__ >= 6)
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define SHP_BIG_ENDIAN 1
+#endif
+#elif defined(__GLIBC__)
+#if __BYTE_ORDER == __BIG_ENDIAN
+#define SHP_BIG_ENDIAN 1
+#endif
+#elif defined(_BIG_ENDIAN) && !defined(_LITTLE_ENDIAN)
+#define SHP_BIG_ENDIAN 1
+#elif defined(_LITTLE_ENDIAN) && !defined(_BIG_ENDIAN)
+#elif defined(__sparc) || defined(__sparc__) || defined(_POWER) ||             \
+    defined(__powerpc__) || defined(__ppc__) || defined(__hpux) ||             \
+    defined(_MIPSEB) || defined(_POWER) || defined(__s390__)
+#define SHP_BIG_ENDIAN 1
+#endif
+#endif
+
 #ifdef __cplusplus
 extern "C"
 {


### PR DESCRIPTION
This is a mix of both static (shapefil.h) and dynamic (CMake and autoconf) configuration to detect BIG endian architectures at compile time or configure time, respectively.

The static variable bBigEndian is removed,

Refactoring was not straight-forward since in some code locations Swap is called for big endian, in other locations for little endian. This looks kind of dangerous and error-prone to me. Edit: OK, it is mixed endianness by design.

Resolves #36