### PR TITLE
Prefer builtin swap functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ set(lib_SRC
   shptree.c
   sbnsearch.c
   shapefil.h
+  shapefil_private.h
   shapelib.def
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ endif()
 if(MSVC)
   target_compile_options(${PACKAGE} PRIVATE /W4)
 else()
-  target_compile_options(${PACKAGE} PRIVATE -Wall -Wextra -Wformat-signedness -Wno-unknown-warning-option -pedantic)
+  target_compile_options(${PACKAGE} PRIVATE -Wall -Wextra -Wformat-signedness -pedantic -Wno-unknown-warning-option)
 endif()
 
 if(WIN32 AND NOT CYGWIN)

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@
 SUBDIRS = . contrib
 
 ACLOCAL_AMFLAGS = -I m4
-AUTOMAKE_OPTIONS =      dist-zip
+AUTOMAKE_OPTIONS = dist-zip
 
 if PLATFORM_WIN32
 no_undefined = -no-undefined
@@ -37,6 +37,7 @@ pkgconfig_DATA = shapelib.pc
 lib_LTLIBRARIES = libshp.la
 libshp_la_includedir = $(includedir)
 libshp_la_include_HEADERS = shapefil.h
+noinst_HEADERS = shapefil_private.h
 libshp_la_SOURCES = shpopen.c dbfopen.c safileio.c shptree.c sbnsearch.c
 libshp_la_LDFLAGS = -version-info $(SHAPELIB_SO_VERSION) $(no_undefined) $(LIBM)
 

--- a/dbfopen.c
+++ b/dbfopen.c
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
  ******************************************************************************/
 
-#include "shapefil.h"
+#include "shapefil_private.h"
 
 #include <math.h>
 #include <stdbool.h>
@@ -66,18 +66,6 @@ CPL_INLINE static void CPL_IGNORE_RET_VAL_INT(CPL_UNUSED int unused)
 }
 #else
 #define CPL_IGNORE_RET_VAL_INT(x) x
-#endif
-
-#ifdef __cplusplus
-#define STATIC_CAST(type, x) static_cast<type>(x)
-#define REINTERPRET_CAST(type, x) reinterpret_cast<type>(x)
-#define CONST_CAST(type, x) const_cast<type>(x)
-#define SHPLIB_NULLPTR nullptr
-#else
-#define STATIC_CAST(type, x) ((type)(x))
-#define REINTERPRET_CAST(type, x) ((type)(x))
-#define CONST_CAST(type, x) ((type)(x))
-#define SHPLIB_NULLPTR NULL
 #endif
 
 /************************************************************************/

--- a/sbnsearch.c
+++ b/sbnsearch.c
@@ -98,33 +98,6 @@ typedef struct
 } SearchStruct;
 
 /************************************************************************/
-/*                              SwapWord()                              */
-/*                                                                      */
-/*      Swap a 4 or 8 byte word.                                        */
-/************************************************************************/
-
-#if !defined(SHP_BIG_ENDIAN)
-#ifndef SwapWord_defined
-#define SwapWord_defined
-static void SwapWord(int length, void *wordP)
-{
-    if (4 == length)
-    {
-        SHP_SWAP32(STATIC_CAST(uint32_t *, wordP));
-    }
-    else if (8 == length)
-    {
-        SHP_SWAP64(STATIC_CAST(uint64_t *, wordP));
-    }
-    else
-    {
-        assert(4 == length || 8 == length);
-    }
-}
-#endif
-#endif
-
-/************************************************************************/
 /*                         SBNOpenDiskTree()                            */
 /************************************************************************/
 
@@ -175,10 +148,10 @@ SBNSearchHandle SBNOpenDiskTree(const char *pszSBNFilename,
     memcpy(&hSBN->dfMaxY, abyHeader + 56, 8);
 
 #if !defined(SHP_BIG_ENDIAN)
-    SwapWord(8, &hSBN->dfMinX);
-    SwapWord(8, &hSBN->dfMinY);
-    SwapWord(8, &hSBN->dfMaxX);
-    SwapWord(8, &hSBN->dfMaxY);
+    SHP_SWAPDOUBLE(&hSBN->dfMinX);
+    SHP_SWAPDOUBLE(&hSBN->dfMinY);
+    SHP_SWAPDOUBLE(&hSBN->dfMaxX);
+    SHP_SWAPDOUBLE(&hSBN->dfMaxY);
 #endif
 
     if (hSBN->dfMinX > hSBN->dfMaxX || hSBN->dfMinY > hSBN->dfMaxY)

--- a/sbnsearch.c
+++ b/sbnsearch.c
@@ -10,7 +10,7 @@
  * SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
  ******************************************************************************/
 
-#include "shapefil.h"
+#include "shapefil_private.h"
 
 #include <assert.h>
 #include <math.h>
@@ -32,18 +32,6 @@
 #endif
 
 #define CACHED_DEPTH_LIMIT 8
-
-#ifdef __cplusplus
-#define STATIC_CAST(type, x) static_cast<type>(x)
-#define REINTERPRET_CAST(type, x) reinterpret_cast<type>(x)
-#define CONST_CAST(type, x) const_cast<type>(x)
-#define SHPLIB_NULLPTR nullptr
-#else
-#define STATIC_CAST(type, x) ((type)(x))
-#define REINTERPRET_CAST(type, x) ((type)(x))
-#define CONST_CAST(type, x) ((type)(x))
-#define SHPLIB_NULLPTR NULL
-#endif
 
 #define READ_MSB_INT(ptr)                                                      \
     STATIC_CAST(int, (((STATIC_CAST(unsigned, (ptr)[0])) << 24) |              \
@@ -112,21 +100,28 @@ typedef struct
 /************************************************************************/
 /*                              SwapWord()                              */
 /*                                                                      */
-/*      Swap a 2, 4 or 8 byte word.                                     */
+/*      Swap a 4 or 8 byte word.                                        */
 /************************************************************************/
 
+#if !defined(SHP_BIG_ENDIAN)
 #ifndef SwapWord_defined
 #define SwapWord_defined
 static void SwapWord(int length, void *wordP)
 {
-    for (int i = 0; i < length / 2; i++)
+    if (4 == length)
     {
-        const unsigned char temp = STATIC_CAST(unsigned char *, wordP)[i];
-        STATIC_CAST(unsigned char *, wordP)
-        [i] = STATIC_CAST(unsigned char *, wordP)[length - i - 1];
-        STATIC_CAST(unsigned char *, wordP)[length - i - 1] = temp;
+        SHP_SWAP32(STATIC_CAST(uint32_t *, wordP));
+    }
+    else if (8 == length)
+    {
+        SHP_SWAP64(STATIC_CAST(uint64_t *, wordP));
+    }
+    else
+    {
+        assert(4 == length || 8 == length);
     }
 }
+#endif
 #endif
 
 /************************************************************************/

--- a/sbnsearch.c
+++ b/sbnsearch.c
@@ -142,16 +142,16 @@ SBNSearchHandle SBNOpenDiskTree(const char *pszSBNFilename,
     /*      Read shapes bounding box.                                       */
     /* -------------------------------------------------------------------- */
 
+#if !defined(SHP_BIG_ENDIAN)
+    SHP_SWAPDOUBLE_CPY(&hSBN->dfMinX, abyHeader + 32);
+    SHP_SWAPDOUBLE_CPY(&hSBN->dfMinY, abyHeader + 40);
+    SHP_SWAPDOUBLE_CPY(&hSBN->dfMaxX, abyHeader + 48);
+    SHP_SWAPDOUBLE_CPY(&hSBN->dfMaxY, abyHeader + 56);
+#else
     memcpy(&hSBN->dfMinX, abyHeader + 32, 8);
     memcpy(&hSBN->dfMinY, abyHeader + 40, 8);
     memcpy(&hSBN->dfMaxX, abyHeader + 48, 8);
     memcpy(&hSBN->dfMaxY, abyHeader + 56, 8);
-
-#if !defined(SHP_BIG_ENDIAN)
-    SHP_SWAPDOUBLE(&hSBN->dfMinX);
-    SHP_SWAPDOUBLE(&hSBN->dfMinY);
-    SHP_SWAPDOUBLE(&hSBN->dfMaxX);
-    SHP_SWAPDOUBLE(&hSBN->dfMaxY);
 #endif
 
     if (hSBN->dfMinX > hSBN->dfMaxX || hSBN->dfMinY > hSBN->dfMaxY)

--- a/shapefil_private.h
+++ b/shapefil_private.h
@@ -1,0 +1,68 @@
+#ifndef SHAPEFILE_PRIVATE_H_INCLUDED
+#define SHAPEFILE_PRIVATE_H_INCLUDED
+
+/******************************************************************************
+ *
+ * Project:  Shapelib
+ * Purpose:  Private include file for Shapelib.
+ * Author:   Frank Warmerdam, warmerdam@pobox.com
+ *
+ ******************************************************************************
+ * Copyright (c) 1999, Frank Warmerdam
+ * Copyright (c) 2012-2016, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
+ ******************************************************************************
+ *
+ */
+
+#ifdef __cplusplus
+#define STATIC_CAST(type, x) static_cast<type>(x)
+#define REINTERPRET_CAST(type, x) reinterpret_cast<type>(x)
+#define CONST_CAST(type, x) const_cast<type>(x)
+#define SHPLIB_NULLPTR nullptr
+#else
+#define STATIC_CAST(type, x) ((type)(x))
+#define REINTERPRET_CAST(type, x) ((type)(x))
+#define CONST_CAST(type, x) ((type)(x))
+#define SHPLIB_NULLPTR NULL
+#endif
+
+#include "shapefil.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+/************************************************************************/
+/*        Little endian <==> big endian byte swap macros.               */
+/************************************************************************/
+
+#if (defined(__GNUC__) && __GNUC__ >= 5) ||                                    \
+    (defined(__GNUC__) && defined(__GNUC_MINOR__) && __GNUC__ == 4 &&          \
+     __GNUC_MINOR__ >= 8)
+#define _SHP_SWAP32(x)                                                         \
+    STATIC_CAST(uint32_t, __builtin_bswap32(STATIC_CAST(uint32_t, x)))
+#define _SHP_SWAP64(x)                                                         \
+    STATIC_CAST(uint64_t, __builtin_bswap64(STATIC_CAST(uint64_t, x)))
+#elif defined(_MSC_VER)
+#define _SHP_SWAP32(x)                                                         \
+    STATIC_CAST(uint32_t, _byteswap_ulong(STATIC_CAST(uint32_t, x)))
+#define _SHP_SWAP64(x)                                                         \
+    STATIC_CAST(uint64_t, _byteswap_uint64(STATIC_CAST(uint64_t, x)))
+#else
+#define _SHP_SWAP32(x)                                                         \
+    STATIC_CAST(uint32_t,                                                      \
+                ((STATIC_CAST(uint32_t, x) & 0x000000ffU) << 24) |             \
+                    ((STATIC_CAST(uint32_t, x) & 0x0000ff00U) << 8) |          \
+                    ((STATIC_CAST(uint32_t, x) & 0x00ff0000U) >> 8) |          \
+                    ((STATIC_CAST(uint32_t, x) & 0xff000000U) >> 24))
+#define _SHP_SWAP64(x)                                                         \
+    ((STATIC_CAST(uint64_t, _SHP_SWAP32(STATIC_CAST(uint32_t, x))) << 32) |    \
+     (STATIC_CAST(uint64_t, _SHP_SWAP32(STATIC_CAST(                           \
+                                uint32_t, STATIC_CAST(uint64_t, x) >> 32)))))
+
+#endif
+
+#define SHP_SWAP32(p) *STATIC_CAST(uint32_t *, p) = _SHP_SWAP32(*(p))
+#define SHP_SWAP64(p) *STATIC_CAST(uint64_t *, p) = _SHP_SWAP64(*(p))
+
+#endif /* ndef SHAPEFILE_PRIVATE_H_INCLUDED */

--- a/shapefil_private.h
+++ b/shapefil_private.h
@@ -62,7 +62,17 @@
 
 #endif
 
-#define SHP_SWAP32(p) *STATIC_CAST(uint32_t *, p) = _SHP_SWAP32(*(p))
-#define SHP_SWAP64(p) *STATIC_CAST(uint64_t *, p) = _SHP_SWAP64(*(p))
-
+#define SHP_SWAP32(p)                                                          \
+    *STATIC_CAST(uint32_t *, p) = _SHP_SWAP32(*STATIC_CAST(uint32_t *, p))
+#define SHP_SWAP64(p)                                                          \
+    *STATIC_CAST(uint64_t *, p) = _SHP_SWAP64(*STATIC_CAST(uint64_t *, p))
+#define SHP_SWAPDOUBLE(x)                                                      \
+    do                                                                         \
+    {                                                                          \
+        uint64_t _n64;                                                         \
+        void *_lx = x;                                                         \
+        memcpy(&_n64, _lx, 8);                                                 \
+        _n64 = _SHP_SWAP64(_n64);                                              \
+        memcpy(_lx, &_n64, 8);                                                 \
+    } while (0)
 #endif /* ndef SHAPEFILE_PRIVATE_H_INCLUDED */

--- a/shapefil_private.h
+++ b/shapefil_private.h
@@ -62,10 +62,13 @@
 
 #endif
 
+/* in-place uint32_t* swap */
 #define SHP_SWAP32(p)                                                          \
     *STATIC_CAST(uint32_t *, p) = _SHP_SWAP32(*STATIC_CAST(uint32_t *, p))
+/* in-place uint64_t* swap */
 #define SHP_SWAP64(p)                                                          \
     *STATIC_CAST(uint64_t *, p) = _SHP_SWAP64(*STATIC_CAST(uint64_t *, p))
+/* in-place double* swap */
 #define SHP_SWAPDOUBLE(x)                                                      \
     do                                                                         \
     {                                                                          \
@@ -74,5 +77,16 @@
         memcpy(&_n64, _lx, 8);                                                 \
         _n64 = _SHP_SWAP64(_n64);                                              \
         memcpy(_lx, &_n64, 8);                                                 \
+    } while (0)
+/* copy double* swap*/
+#define SHP_SWAPDOUBLE_CPY(dst, src)                                           \
+    do                                                                         \
+    {                                                                          \
+        uint64_t _n64;                                                         \
+        const void *_ls = src;                                                 \
+        void *_ld = dst;                                                       \
+        memcpy(&_n64, _ls, 8);                                                 \
+        _n64 = _SHP_SWAP64(_n64);                                              \
+        memcpy(_ld, &_n64, 8);                                                 \
     } while (0)
 #endif /* ndef SHAPEFILE_PRIVATE_H_INCLUDED */

--- a/shpopen.c
+++ b/shpopen.c
@@ -2145,16 +2145,16 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
         /* -------------------------------------------------------------------- */
         /*      Get the X/Y bounds.                                             */
         /* -------------------------------------------------------------------- */
+#if defined(SHP_BIG_ENDIAN)
+        SHP_SWAPDOUBLE_CPY(&psShape->dfXMin, psSHP->pabyRec + 8 + 4);
+        SHP_SWAPDOUBLE_CPY(&psShape->dfYMin, psSHP->pabyRec + 8 + 12);
+        SHP_SWAPDOUBLE_CPY(&psShape->dfXMax, psSHP->pabyRec + 8 + 20);
+        SHP_SWAPDOUBLE_CPY(&psShape->dfYMax, psSHP->pabyRec + 8 + 28);
+#else
         memcpy(&psShape->dfXMin, psSHP->pabyRec + 8 + 4, 8);
         memcpy(&psShape->dfYMin, psSHP->pabyRec + 8 + 12, 8);
         memcpy(&psShape->dfXMax, psSHP->pabyRec + 8 + 20, 8);
         memcpy(&psShape->dfYMax, psSHP->pabyRec + 8 + 28, 8);
-
-#if defined(SHP_BIG_ENDIAN)
-        SHP_SWAPDOUBLE(&psShape->dfXMin);
-        SHP_SWAPDOUBLE(&psShape->dfYMin);
-        SHP_SWAPDOUBLE(&psShape->dfXMax);
-        SHP_SWAPDOUBLE(&psShape->dfYMax);
 #endif
 
         /* -------------------------------------------------------------------- */
@@ -2327,14 +2327,15 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
         /* -------------------------------------------------------------------- */
         for (int i = 0; STATIC_CAST(uint32_t, i) < nPoints; i++)
         {
+#if defined(SHP_BIG_ENDIAN)
+            SHP_SWAPDOUBLE_CPY(psShape->padfX + i,
+                               psSHP->pabyRec + nOffset + i * 16);
+            SHP_SWAPDOUBLE_CPY(psShape->padfY + i,
+                               psSHP->pabyRec + nOffset + i * 16 + 8);
+#else
             memcpy(psShape->padfX + i, psSHP->pabyRec + nOffset + i * 16, 8);
-
             memcpy(psShape->padfY + i, psSHP->pabyRec + nOffset + i * 16 + 8,
                    8);
-
-#if defined(SHP_BIG_ENDIAN)
-            SHP_SWAPDOUBLE(psShape->padfX + i);
-            SHP_SWAPDOUBLE(psShape->padfY + i);
 #endif
         }
 
@@ -2347,20 +2348,23 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
             psShape->nSHPType == SHPT_ARCZ ||
             psShape->nSHPType == SHPT_MULTIPATCH)
         {
+#if defined(SHP_BIG_ENDIAN)
+            SHP_SWAPDOUBLE_CPY(&psShape->dfZMin, psSHP->pabyRec + nOffset);
+            SHP_SWAPDOUBLE_CPY(&psShape->dfZMax, psSHP->pabyRec + nOffset + 8);
+#else
             memcpy(&psShape->dfZMin, psSHP->pabyRec + nOffset, 8);
             memcpy(&psShape->dfZMax, psSHP->pabyRec + nOffset + 8, 8);
 
-#if defined(SHP_BIG_ENDIAN)
-            SHP_SWAPDOUBLE(&psShape->dfZMin);
-            SHP_SWAPDOUBLE(&psShape->dfZMax);
 #endif
 
             for (int i = 0; STATIC_CAST(uint32_t, i) < nPoints; i++)
             {
+#if defined(SHP_BIG_ENDIAN)
+                SHP_SWAPDOUBLE_CPY(psShape->padfZ + i,
+                                   psSHP->pabyRec + nOffset + 16 + i * 8);
+#else
                 memcpy(psShape->padfZ + i,
                        psSHP->pabyRec + nOffset + 16 + i * 8, 8);
-#if defined(SHP_BIG_ENDIAN)
-                SHP_SWAPDOUBLE(psShape->padfZ + i);
 #endif
             }
 
@@ -2379,20 +2383,22 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
         /* -------------------------------------------------------------------- */
         if (nEntitySize >= STATIC_CAST(int, nOffset + 16 + 8 * nPoints))
         {
+#if defined(SHP_BIG_ENDIAN)
+            SHP_SWAPDOUBLE_CPY(&psShape->dfMMin, psSHP->pabyRec + nOffset);
+            SHP_SWAPDOUBLE_CPY(&psShape->dfMMax, psSHP->pabyRec + nOffset + 8);
+#else
             memcpy(&psShape->dfMMin, psSHP->pabyRec + nOffset, 8);
             memcpy(&psShape->dfMMax, psSHP->pabyRec + nOffset + 8, 8);
-
-#if defined(SHP_BIG_ENDIAN)
-            SHP_SWAPDOUBLE(&psShape->dfMMin);
-            SHP_SWAPDOUBLE(&psShape->dfMMax);
 #endif
 
             for (int i = 0; STATIC_CAST(uint32_t, i) < nPoints; i++)
             {
+#if defined(SHP_BIG_ENDIAN)
+                SHP_SWAPDOUBLE_CPY(psShape->padfM + i,
+                                   psSHP->pabyRec + nOffset + 16 + i * 8);
+#else
                 memcpy(psShape->padfM + i,
                        psSHP->pabyRec + nOffset + 16 + i * 8, 8);
-#if defined(SHP_BIG_ENDIAN)
-                SHP_SWAPDOUBLE(psShape->padfM + i);
 #endif
             }
             psShape->bMeasureIsUsed = TRUE;
@@ -2499,12 +2505,14 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
 
         for (int i = 0; STATIC_CAST(uint32_t, i) < nPoints; i++)
         {
+#if defined(SHP_BIG_ENDIAN)
+            SHP_SWAPDOUBLE_CPY(psShape->padfX + i,
+                               psSHP->pabyRec + 48 + 16 * i);
+            SHP_SWAPDOUBLE_CPY(psShape->padfY + i,
+                               psSHP->pabyRec + 48 + 16 * i + 8);
+#else
             memcpy(psShape->padfX + i, psSHP->pabyRec + 48 + 16 * i, 8);
             memcpy(psShape->padfY + i, psSHP->pabyRec + 48 + 16 * i + 8, 8);
-
-#if defined(SHP_BIG_ENDIAN)
-            SHP_SWAPDOUBLE(psShape->padfX + i);
-            SHP_SWAPDOUBLE(psShape->padfY + i);
 #endif
         }
 
@@ -2513,16 +2521,16 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
         /* -------------------------------------------------------------------- */
         /*      Get the X/Y bounds.                                             */
         /* -------------------------------------------------------------------- */
+#if defined(SHP_BIG_ENDIAN)
+        SHP_SWAPDOUBLE_CPY(&psShape->dfXMin, psSHP->pabyRec + 8 + 4);
+        SHP_SWAPDOUBLE_CPY(&psShape->dfYMin, psSHP->pabyRec + 8 + 12);
+        SHP_SWAPDOUBLE_CPY(&psShape->dfXMax, psSHP->pabyRec + 8 + 20);
+        SHP_SWAPDOUBLE_CPY(&psShape->dfYMax, psSHP->pabyRec + 8 + 28);
+#else
         memcpy(&psShape->dfXMin, psSHP->pabyRec + 8 + 4, 8);
         memcpy(&psShape->dfYMin, psSHP->pabyRec + 8 + 12, 8);
         memcpy(&psShape->dfXMax, psSHP->pabyRec + 8 + 20, 8);
         memcpy(&psShape->dfYMax, psSHP->pabyRec + 8 + 28, 8);
-
-#if defined(SHP_BIG_ENDIAN)
-        SHP_SWAPDOUBLE(&psShape->dfXMin);
-        SHP_SWAPDOUBLE(&psShape->dfYMin);
-        SHP_SWAPDOUBLE(&psShape->dfXMax);
-        SHP_SWAPDOUBLE(&psShape->dfYMax);
 #endif
 
         /* -------------------------------------------------------------------- */
@@ -2530,20 +2538,22 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
         /* -------------------------------------------------------------------- */
         if (psShape->nSHPType == SHPT_MULTIPOINTZ)
         {
+#if defined(SHP_BIG_ENDIAN)
+            SHP_SWAPDOUBLE_CPY(&psShape->dfZMin, psSHP->pabyRec + nOffset);
+            SHP_SWAPDOUBLE_CPY(&psShape->dfZMax, psSHP->pabyRec + nOffset + 8);
+#else
             memcpy(&psShape->dfZMin, psSHP->pabyRec + nOffset, 8);
             memcpy(&psShape->dfZMax, psSHP->pabyRec + nOffset + 8, 8);
-
-#if defined(SHP_BIG_ENDIAN)
-            SHP_SWAPDOUBLE(&psShape->dfZMin);
-            SHP_SWAPDOUBLE(&psShape->dfZMax);
 #endif
 
             for (int i = 0; STATIC_CAST(uint32_t, i) < nPoints; i++)
             {
+#if defined(SHP_BIG_ENDIAN)
+                SHP_SWAPDOUBLE_CPY(psShape->padfZ + i,
+                                   psSHP->pabyRec + nOffset + 16 + i * 8);
+#else
                 memcpy(psShape->padfZ + i,
                        psSHP->pabyRec + nOffset + 16 + i * 8, 8);
-#if defined(SHP_BIG_ENDIAN)
-                SHP_SWAPDOUBLE(psShape->padfZ + i);
 #endif
             }
 
@@ -2560,20 +2570,22 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
         /* -------------------------------------------------------------------- */
         if (nEntitySize >= STATIC_CAST(int, nOffset + 16 + 8 * nPoints))
         {
+#if defined(SHP_BIG_ENDIAN)
+            SHP_SWAPDOUBLE_CPY(&psShape->dfMMin, psSHP->pabyRec + nOffset);
+            SHP_SWAPDOUBLE_CPY(&psShape->dfMMax, psSHP->pabyRec + nOffset + 8);
+#else
             memcpy(&psShape->dfMMin, psSHP->pabyRec + nOffset, 8);
             memcpy(&psShape->dfMMax, psSHP->pabyRec + nOffset + 8, 8);
-
-#if defined(SHP_BIG_ENDIAN)
-            SHP_SWAPDOUBLE(&psShape->dfMMin);
-            SHP_SWAPDOUBLE(&psShape->dfMMax);
 #endif
 
             for (int i = 0; STATIC_CAST(uint32_t, i) < nPoints; i++)
             {
+#if defined(SHP_BIG_ENDIAN)
+                SHP_SWAPDOUBLE_CPY(psShape->padfM + i,
+                                   psSHP->pabyRec + nOffset + 16 + i * 8);
+#else
                 memcpy(psShape->padfM + i,
                        psSHP->pabyRec + nOffset + 16 + i * 8, 8);
-#if defined(SHP_BIG_ENDIAN)
-                SHP_SWAPDOUBLE(psShape->padfM + i);
 #endif
             }
             psShape->bMeasureIsUsed = TRUE;
@@ -2618,12 +2630,12 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
             SHPDestroyObject(psShape);
             return SHPLIB_NULLPTR;
         }
+#if defined(SHP_BIG_ENDIAN)
+        SHP_SWAPDOUBLE_CPY(psShape->padfX, psSHP->pabyRec + 12);
+        SHP_SWAPDOUBLE_CPY(psShape->padfY, psSHP->pabyRec + 20);
+#else
         memcpy(psShape->padfX, psSHP->pabyRec + 12, 8);
         memcpy(psShape->padfY, psSHP->pabyRec + 20, 8);
-
-#if defined(SHP_BIG_ENDIAN)
-        SHP_SWAPDOUBLE(psShape->padfX);
-        SHP_SWAPDOUBLE(psShape->padfY);
 #endif
 
         int nOffset = 20 + 8;
@@ -2633,10 +2645,10 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
         /* -------------------------------------------------------------------- */
         if (psShape->nSHPType == SHPT_POINTZ)
         {
-            memcpy(psShape->padfZ, psSHP->pabyRec + nOffset, 8);
-
 #if defined(SHP_BIG_ENDIAN)
-            SHP_SWAPDOUBLE(psShape->padfZ);
+            SHP_SWAPDOUBLE_CPY(psShape->padfZ, psSHP->pabyRec + nOffset);
+#else
+            memcpy(psShape->padfZ, psSHP->pabyRec + nOffset, 8);
 #endif
 
             nOffset += 8;
@@ -2650,10 +2662,10 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
         /* -------------------------------------------------------------------- */
         if (nEntitySize >= nOffset + 8)
         {
-            memcpy(psShape->padfM, psSHP->pabyRec + nOffset, 8);
-
 #if defined(SHP_BIG_ENDIAN)
-            SHP_SWAPDOUBLE(psShape->padfM);
+            SHP_SWAPDOUBLE_CPY(psShape->padfM, psSHP->pabyRec + nOffset);
+#else
+            memcpy(psShape->padfM, psSHP->pabyRec + nOffset, 8);
 #endif
             psShape->bMeasureIsUsed = TRUE;
         }

--- a/shpopen.c
+++ b/shpopen.c
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
  ******************************************************************************/
 
-#include "shapefil.h"
+#include "shapefil_private.h"
 
 #include <assert.h>
 #include <errno.h>
@@ -46,30 +46,27 @@
 #endif
 #endif
 
-#ifdef __cplusplus
-#define STATIC_CAST(type, x) static_cast<type>(x)
-#define SHPLIB_NULLPTR nullptr
-#else
-#define STATIC_CAST(type, x) ((type)(x))
-#define SHPLIB_NULLPTR NULL
-#endif
-
 /************************************************************************/
 /*                              SwapWord()                              */
 /*                                                                      */
-/*      Swap a 2, 4 or 8 byte word.                                     */
+/*      Swap a 4 or 8 byte word.                                        */
 /************************************************************************/
 
 #ifndef SwapWord_defined
 #define SwapWord_defined
 static void SwapWord(int length, void *wordP)
 {
-    for (int i = 0; i < length / 2; i++)
+    if (4 == length)
     {
-        const unsigned char temp = STATIC_CAST(unsigned char *, wordP)[i];
-        STATIC_CAST(unsigned char *, wordP)
-        [i] = STATIC_CAST(unsigned char *, wordP)[length - i - 1];
-        STATIC_CAST(unsigned char *, wordP)[length - i - 1] = temp;
+        SHP_SWAP32(STATIC_CAST(uint32_t *, wordP));
+    }
+    else if (8 == length)
+    {
+        SHP_SWAP64(STATIC_CAST(uint64_t *, wordP));
+    }
+    else
+    {
+        assert(4 == length || 8 == length);
     }
 }
 #endif

--- a/shpopen.c
+++ b/shpopen.c
@@ -47,31 +47,6 @@
 #endif
 
 /************************************************************************/
-/*                              SwapWord()                              */
-/*                                                                      */
-/*      Swap a 4 or 8 byte word.                                        */
-/************************************************************************/
-
-#ifndef SwapWord_defined
-#define SwapWord_defined
-static void SwapWord(int length, void *wordP)
-{
-    if (4 == length)
-    {
-        SHP_SWAP32(STATIC_CAST(uint32_t *, wordP));
-    }
-    else if (8 == length)
-    {
-        SHP_SWAP64(STATIC_CAST(uint64_t *, wordP));
-    }
-    else
-    {
-        assert(4 == length || 8 == length);
-    }
-}
-#endif
-
-/************************************************************************/
 /*                          SHPWriteHeader()                            */
 /*                                                                      */
 /*      Write out a header for the .shp and .shx files as well as the   */
@@ -97,65 +72,65 @@ void SHPAPI_CALL SHPWriteHeader(SHPHandle psSHP)
     uint32_t i32 = psSHP->nFileSize / 2; /* file size */
     ByteCopy(&i32, abyHeader + 24, 4);
 #if !defined(SHP_BIG_ENDIAN)
-    SwapWord(4, abyHeader + 24);
+    SHP_SWAP32(abyHeader + 24);
 #endif
 
     i32 = 1000; /* version */
     ByteCopy(&i32, abyHeader + 28, 4);
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(4, abyHeader + 28);
+    SHP_SWAP32(abyHeader + 28);
 #endif
 
     i32 = psSHP->nShapeType; /* shape type */
     ByteCopy(&i32, abyHeader + 32, 4);
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(4, abyHeader + 32);
+    SHP_SWAP32(abyHeader + 32);
 #endif
 
     double dValue = psSHP->adBoundsMin[0]; /* set bounds */
     ByteCopy(&dValue, abyHeader + 36, 8);
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(8, abyHeader + 36);
+    SHP_SWAP64(abyHeader + 36);
 #endif
     dValue = psSHP->adBoundsMin[1];
     ByteCopy(&dValue, abyHeader + 44, 8);
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(8, abyHeader + 44);
+    SHP_SWAP64(abyHeader + 44);
 #endif
     dValue = psSHP->adBoundsMax[0];
     ByteCopy(&dValue, abyHeader + 52, 8);
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(8, abyHeader + 52);
+    SHP_SWAP64(abyHeader + 52);
 #endif
 
     dValue = psSHP->adBoundsMax[1];
     ByteCopy(&dValue, abyHeader + 60, 8);
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(8, abyHeader + 60);
+    SHP_SWAP64(abyHeader + 60);
 #endif
 
     dValue = psSHP->adBoundsMin[2]; /* z */
     ByteCopy(&dValue, abyHeader + 68, 8);
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(8, abyHeader + 68);
+    SHP_SWAP64(abyHeader + 68);
 #endif
 
     dValue = psSHP->adBoundsMax[2];
     ByteCopy(&dValue, abyHeader + 76, 8);
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(8, abyHeader + 76);
+    SHP_SWAP64(abyHeader + 76);
 #endif
 
     dValue = psSHP->adBoundsMin[3]; /* m */
     ByteCopy(&dValue, abyHeader + 84, 8);
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(8, abyHeader + 84);
+    SHP_SWAP64(abyHeader + 84);
 #endif
 
     dValue = psSHP->adBoundsMax[3];
     ByteCopy(&dValue, abyHeader + 92, 8);
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(8, abyHeader + 92);
+    SHP_SWAP64(abyHeader + 92);
 #endif
 
     /* -------------------------------------------------------------------- */
@@ -179,7 +154,7 @@ void SHPAPI_CALL SHPWriteHeader(SHPHandle psSHP)
     i32 = (psSHP->nRecords * 2 * sizeof(uint32_t) + 100) / 2; /* file size */
     ByteCopy(&i32, abyHeader + 24, 4);
 #if !defined(SHP_BIG_ENDIAN)
-    SwapWord(4, abyHeader + 24);
+    SHP_SWAP32(abyHeader + 24);
 #endif
 
     if (psSHP->sHooks.FSeek(psSHP->fpSHX, 0, 0) != 0 ||
@@ -211,8 +186,8 @@ void SHPAPI_CALL SHPWriteHeader(SHPHandle psSHP)
         panSHX[i * 2] = psSHP->panRecOffset[i] / 2;
         panSHX[i * 2 + 1] = psSHP->panRecSize[i] / 2;
 #if !defined(SHP_BIG_ENDIAN)
-        SwapWord(4, panSHX + i * 2);
-        SwapWord(4, panSHX + i * 2 + 1);
+        SHP_SWAP32(panSHX + i * 2);
+        SHP_SWAP32(panSHX + i * 2 + 1);
 #endif
     }
 
@@ -450,49 +425,49 @@ SHPHandle SHPAPI_CALL SHPOpenLL(const char *pszLayer, const char *pszAccess,
     double dValue;
 
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(8, pabyBuf + 36);
+    SHP_SWAP64(pabyBuf + 36);
 #endif
     memcpy(&dValue, pabyBuf + 36, 8);
     psSHP->adBoundsMin[0] = dValue;
 
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(8, pabyBuf + 44);
+    SHP_SWAP64(pabyBuf + 44);
 #endif
     memcpy(&dValue, pabyBuf + 44, 8);
     psSHP->adBoundsMin[1] = dValue;
 
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(8, pabyBuf + 52);
+    SHP_SWAP64(pabyBuf + 52);
 #endif
     memcpy(&dValue, pabyBuf + 52, 8);
     psSHP->adBoundsMax[0] = dValue;
 
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(8, pabyBuf + 60);
+    SHP_SWAP64(pabyBuf + 60);
 #endif
     memcpy(&dValue, pabyBuf + 60, 8);
     psSHP->adBoundsMax[1] = dValue;
 
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(8, pabyBuf + 68); /* z */
+    SHP_SWAP64(pabyBuf + 68); /* z */
 #endif
     memcpy(&dValue, pabyBuf + 68, 8);
     psSHP->adBoundsMin[2] = dValue;
 
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(8, pabyBuf + 76);
+    SHP_SWAP64(pabyBuf + 76);
 #endif
     memcpy(&dValue, pabyBuf + 76, 8);
     psSHP->adBoundsMax[2] = dValue;
 
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(8, pabyBuf + 84); /* z */
+    SHP_SWAP64(pabyBuf + 84); /* z */
 #endif
     memcpy(&dValue, pabyBuf + 84, 8);
     psSHP->adBoundsMin[3] = dValue;
 
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(8, pabyBuf + 92);
+    SHP_SWAP64(pabyBuf + 92);
 #endif
     memcpy(&dValue, pabyBuf + 92, 8);
     psSHP->adBoundsMax[3] = dValue;
@@ -586,13 +561,13 @@ SHPHandle SHPAPI_CALL SHPOpenLL(const char *pszLayer, const char *pszAccess,
         unsigned int nOffset;
         memcpy(&nOffset, pabyBuf + i * 8, 4);
 #if !defined(SHP_BIG_ENDIAN)
-        SwapWord(4, &nOffset);
+        SHP_SWAP32(&nOffset);
 #endif
 
         unsigned int nLength;
         memcpy(&nLength, pabyBuf + i * 8 + 4, 4);
 #if !defined(SHP_BIG_ENDIAN)
-        SwapWord(4, &nLength);
+        SHP_SWAP32(&nLength);
 #endif
 
         if (nOffset > STATIC_CAST(unsigned int, INT_MAX))
@@ -779,16 +754,16 @@ int SHPAPI_CALL SHPRestoreSHX(const char *pszLayer, const char *pszAccess,
             unsigned int nRecordOffsetBE = nRecordOffset;
 
 #if !defined(SHP_BIG_ENDIAN)
-            SwapWord(4, &nRecordOffsetBE);
+            SHP_SWAP32(&nRecordOffsetBE);
 #endif
             memcpy(abyReadRecord, &nRecordOffsetBE, 4);
             memcpy(abyReadRecord + 4, &nRecordLength, 4);
 
 #if !defined(SHP_BIG_ENDIAN)
-            SwapWord(4, &nRecordLength);
+            SHP_SWAP32(&nRecordLength);
 #endif
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(4, &nSHPType);
+            SHP_SWAP32(&nSHPType);
 #endif
 
             // Sanity check on record length
@@ -861,7 +836,7 @@ int SHPAPI_CALL SHPRestoreSHX(const char *pszLayer, const char *pszAccess,
 
     nRealSHXContentSize /= 2;  // Bytes counted -> WORDs
 #if !defined(SHP_BIG_ENDIAN)
-    SwapWord(4, &nRealSHXContentSize);
+    SHP_SWAP32(&nRealSHXContentSize);
 #endif
 
     psHooks->FSeek(fpSHX, 24, 0);
@@ -1044,19 +1019,19 @@ SHPHandle SHPAPI_CALL SHPCreateLL(const char *pszLayer, int nShapeType,
     uint32_t i32 = 50; /* file size */
     ByteCopy(&i32, abyHeader + 24, 4);
 #if !defined(SHP_BIG_ENDIAN)
-    SwapWord(4, abyHeader + 24);
+    SHP_SWAP32(abyHeader + 24);
 #endif
 
     i32 = 1000; /* version */
     ByteCopy(&i32, abyHeader + 28, 4);
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(4, abyHeader + 28);
+    SHP_SWAP32(abyHeader + 28);
 #endif
 
     i32 = nShapeType; /* shape type */
     ByteCopy(&i32, abyHeader + 32, 4);
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(4, abyHeader + 32);
+    SHP_SWAP32(abyHeader + 32);
 #endif
 
     double dValue = 0.0; /* set bounds */
@@ -1089,7 +1064,7 @@ SHPHandle SHPAPI_CALL SHPCreateLL(const char *pszLayer, int nShapeType,
     i32 = 50; /* file size */
     ByteCopy(&i32, abyHeader + 24, 4);
 #if !defined(SHP_BIG_ENDIAN)
-    SwapWord(4, abyHeader + 24);
+    SHP_SWAP32(abyHeader + 24);
 #endif
 
     if (psHooks->FWrite(abyHeader, 100, 1, fpSHX) != 1)
@@ -1153,10 +1128,10 @@ static void _SHPSetBounds(unsigned char *pabyRec, const SHPObject *psShape)
     ByteCopy(&(psShape->dfYMax), pabyRec + 24, 8);
 
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(8, pabyRec + 0);
-    SwapWord(8, pabyRec + 8);
-    SwapWord(8, pabyRec + 16);
-    SwapWord(8, pabyRec + 24);
+    SHP_SWAP64(pabyRec + 0);
+    SHP_SWAP64(pabyRec + 8);
+    SHP_SWAP64(pabyRec + 16);
+    SHP_SWAP64(pabyRec + 24);
 #endif
 }
 
@@ -1437,8 +1412,8 @@ int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
         _SHPSetBounds(pabyRec + 12, psObject);
 
 #if defined(SHP_BIG_ENDIAN)
-        SwapWord(4, &nPoints);
-        SwapWord(4, &nParts);
+        SHP_SWAP32(&nPoints);
+        SHP_SWAP32(&nParts);
 #endif
 
         ByteCopy(&nPoints, pabyRec + 40 + 8, 4);
@@ -1454,7 +1429,7 @@ int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
         for (int i = 0; i < psObject->nParts; i++)
         {
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(4, pabyRec + 44 + 8 + 4 * i);
+            SHP_SWAP32(pabyRec + 44 + 8 + 4 * i);
 #endif
             nRecordSize += 4;
         }
@@ -1469,7 +1444,7 @@ int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
             for (int i = 0; i < psObject->nParts; i++)
             {
 #if defined(SHP_BIG_ENDIAN)
-                SwapWord(4, pabyRec + nRecordSize);
+                SHP_SWAP32(pabyRec + nRecordSize);
 #endif
                 nRecordSize += 4;
             }
@@ -1484,8 +1459,8 @@ int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
             ByteCopy(psObject->padfY + i, pabyRec + nRecordSize + 8, 8);
 
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, pabyRec + nRecordSize);
-            SwapWord(8, pabyRec + nRecordSize + 8);
+            SHP_SWAP64(pabyRec + nRecordSize);
+            SHP_SWAP64(pabyRec + nRecordSize + 8);
 #endif
 
             nRecordSize += 2 * 8;
@@ -1500,13 +1475,13 @@ int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
         {
             ByteCopy(&(psObject->dfZMin), pabyRec + nRecordSize, 8);
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, pabyRec + nRecordSize);
+            SHP_SWAP64(pabyRec + nRecordSize);
 #endif
             nRecordSize += 8;
 
             ByteCopy(&(psObject->dfZMax), pabyRec + nRecordSize, 8);
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, pabyRec + nRecordSize);
+            SHP_SWAP64(pabyRec + nRecordSize);
 #endif
             nRecordSize += 8;
 
@@ -1514,7 +1489,7 @@ int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
             {
                 ByteCopy(psObject->padfZ + i, pabyRec + nRecordSize, 8);
 #if defined(SHP_BIG_ENDIAN)
-                SwapWord(8, pabyRec + nRecordSize);
+                SHP_SWAP64(pabyRec + nRecordSize);
 #endif
                 nRecordSize += 8;
             }
@@ -1534,13 +1509,13 @@ int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
         {
             ByteCopy(&(psObject->dfMMin), pabyRec + nRecordSize, 8);
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, pabyRec + nRecordSize);
+            SHP_SWAP64(pabyRec + nRecordSize);
 #endif
             nRecordSize += 8;
 
             ByteCopy(&(psObject->dfMMax), pabyRec + nRecordSize, 8);
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, pabyRec + nRecordSize);
+            SHP_SWAP64(pabyRec + nRecordSize);
 #endif
             nRecordSize += 8;
 
@@ -1548,7 +1523,7 @@ int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
             {
                 ByteCopy(psObject->padfM + i, pabyRec + nRecordSize, 8);
 #if defined(SHP_BIG_ENDIAN)
-                SwapWord(8, pabyRec + nRecordSize);
+                SHP_SWAP64(pabyRec + nRecordSize);
 #endif
                 nRecordSize += 8;
             }
@@ -1567,7 +1542,7 @@ int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
         _SHPSetBounds(pabyRec + 12, psObject);
 
 #if defined(SHP_BIG_ENDIAN)
-        SwapWord(4, &nPoints);
+        SHP_SWAP32(&nPoints);
 #endif
         ByteCopy(&nPoints, pabyRec + 44, 4);
 
@@ -1577,8 +1552,8 @@ int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
             ByteCopy(psObject->padfY + i, pabyRec + 48 + i * 16 + 8, 8);
 
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, pabyRec + 48 + i * 16);
-            SwapWord(8, pabyRec + 48 + i * 16 + 8);
+            SHP_SWAP64(pabyRec + 48 + i * 16);
+            SHP_SWAP64(pabyRec + 48 + i * 16 + 8);
 #endif
         }
 
@@ -1588,13 +1563,13 @@ int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
         {
             ByteCopy(&(psObject->dfZMin), pabyRec + nRecordSize, 8);
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, pabyRec + nRecordSize);
+            SHP_SWAP64(pabyRec + nRecordSize);
 #endif
             nRecordSize += 8;
 
             ByteCopy(&(psObject->dfZMax), pabyRec + nRecordSize, 8);
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, pabyRec + nRecordSize);
+            SHP_SWAP64(pabyRec + nRecordSize);
 #endif
             nRecordSize += 8;
 
@@ -1602,7 +1577,7 @@ int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
             {
                 ByteCopy(psObject->padfZ + i, pabyRec + nRecordSize, 8);
 #if defined(SHP_BIG_ENDIAN)
-                SwapWord(8, pabyRec + nRecordSize);
+                SHP_SWAP64(pabyRec + nRecordSize);
 #endif
                 nRecordSize += 8;
             }
@@ -1614,13 +1589,13 @@ int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
         {
             ByteCopy(&(psObject->dfMMin), pabyRec + nRecordSize, 8);
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, pabyRec + nRecordSize);
+            SHP_SWAP64(pabyRec + nRecordSize);
 #endif
             nRecordSize += 8;
 
             ByteCopy(&(psObject->dfMMax), pabyRec + nRecordSize, 8);
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, pabyRec + nRecordSize);
+            SHP_SWAP64(pabyRec + nRecordSize);
 #endif
             nRecordSize += 8;
 
@@ -1628,7 +1603,7 @@ int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
             {
                 ByteCopy(psObject->padfM + i, pabyRec + nRecordSize, 8);
 #if defined(SHP_BIG_ENDIAN)
-                SwapWord(8, pabyRec + nRecordSize);
+                SHP_SWAP64(pabyRec + nRecordSize);
 #endif
                 nRecordSize += 8;
             }
@@ -1646,8 +1621,8 @@ int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
         ByteCopy(psObject->padfY, pabyRec + 20, 8);
 
 #if defined(SHP_BIG_ENDIAN)
-        SwapWord(8, pabyRec + 12);
-        SwapWord(8, pabyRec + 20);
+        SHP_SWAP64(pabyRec + 12);
+        SHP_SWAP64(pabyRec + 20);
 #endif
 
         nRecordSize = 28;
@@ -1656,7 +1631,7 @@ int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
         {
             ByteCopy(psObject->padfZ, pabyRec + nRecordSize, 8);
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, pabyRec + nRecordSize);
+            SHP_SWAP64(pabyRec + nRecordSize);
 #endif
             nRecordSize += 8;
         }
@@ -1666,7 +1641,7 @@ int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
         {
             ByteCopy(psObject->padfM, pabyRec + nRecordSize, 8);
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, pabyRec + nRecordSize);
+            SHP_SWAP64(pabyRec + nRecordSize);
 #endif
             nRecordSize += 8;
         }
@@ -1732,19 +1707,19 @@ int SHPAPI_CALL SHPWriteObject(SHPHandle psSHP, int nShapeId,
     uint32_t i32 =
         (nShapeId < 0) ? psSHP->nRecords + 1 : nShapeId + 1; /* record # */
 #if !defined(SHP_BIG_ENDIAN)
-    SwapWord(4, &i32);
+    SHP_SWAP32(&i32);
 #endif
     ByteCopy(&i32, pabyRec, 4);
 
     i32 = (nRecordSize - 8) / 2; /* record size */
 #if !defined(SHP_BIG_ENDIAN)
-    SwapWord(4, &i32);
+    SHP_SWAP32(&i32);
 #endif
     ByteCopy(&i32, pabyRec + 4, 4);
 
     i32 = psObject->nSHPType; /* shape type */
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(4, &i32);
+    SHP_SWAP32(&i32);
 #endif
     ByteCopy(&i32, pabyRec + 8, 4);
 
@@ -1938,8 +1913,8 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
             return SHPLIB_NULLPTR;
         }
 #if !defined(SHP_BIG_ENDIAN)
-        SwapWord(4, &nOffset);
-        SwapWord(4, &nLength);
+        SHP_SWAP32(&nOffset);
+        SHP_SWAP32(&nLength);
 #endif
 
         if (nOffset > STATIC_CAST(unsigned int, INT_MAX))
@@ -2073,7 +2048,7 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
         int nSHPContentLength;
         memcpy(&nSHPContentLength, psSHP->pabyRec + 4, 4);
 #if !defined(SHP_BIG_ENDIAN)
-        SwapWord(4, &(nSHPContentLength));
+        SHP_SWAP32(&(nSHPContentLength));
 #endif
         if (nSHPContentLength < 0 || nSHPContentLength > INT_MAX / 2 - 4 ||
             2 * nSHPContentLength + 8 != nBytesRead)
@@ -2120,7 +2095,7 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
     memcpy(&nSHPType, psSHP->pabyRec + 8, 4);
 
 #if defined(SHP_BIG_ENDIAN)
-    SwapWord(4, &(nSHPType));
+    SHP_SWAP32(&(nSHPType));
 #endif
 
     /* -------------------------------------------------------------------- */
@@ -2170,16 +2145,16 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
         /* -------------------------------------------------------------------- */
         /*      Get the X/Y bounds.                                             */
         /* -------------------------------------------------------------------- */
-        memcpy(&(psShape->dfXMin), psSHP->pabyRec + 8 + 4, 8);
-        memcpy(&(psShape->dfYMin), psSHP->pabyRec + 8 + 12, 8);
-        memcpy(&(psShape->dfXMax), psSHP->pabyRec + 8 + 20, 8);
-        memcpy(&(psShape->dfYMax), psSHP->pabyRec + 8 + 28, 8);
+        memcpy(&psShape->dfXMin, psSHP->pabyRec + 8 + 4, 8);
+        memcpy(&psShape->dfYMin, psSHP->pabyRec + 8 + 12, 8);
+        memcpy(&psShape->dfXMax, psSHP->pabyRec + 8 + 20, 8);
+        memcpy(&psShape->dfYMax, psSHP->pabyRec + 8 + 28, 8);
 
 #if defined(SHP_BIG_ENDIAN)
-        SwapWord(8, &(psShape->dfXMin));
-        SwapWord(8, &(psShape->dfYMin));
-        SwapWord(8, &(psShape->dfXMax));
-        SwapWord(8, &(psShape->dfYMax));
+        SHP_SWAPDOUBLE(&psShape->dfXMin);
+        SHP_SWAPDOUBLE(&psShape->dfYMin);
+        SHP_SWAPDOUBLE(&psShape->dfXMax);
+        SHP_SWAPDOUBLE(&psShape->dfYMax);
 #endif
 
         /* -------------------------------------------------------------------- */
@@ -2192,8 +2167,8 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
         memcpy(&nParts, psSHP->pabyRec + 36 + 8, 4);
 
 #if defined(SHP_BIG_ENDIAN)
-        SwapWord(4, &nPoints);
-        SwapWord(4, &nParts);
+        SHP_SWAP32(&nPoints);
+        SHP_SWAP32(&nParts);
 #endif
 
         /* nPoints and nParts are unsigned */
@@ -2293,7 +2268,7 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
         for (int i = 0; STATIC_CAST(uint32_t, i) < nParts; i++)
         {
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(4, psShape->panPartStart + i);
+            SHP_SWAP32(psShape->panPartStart + i);
 #endif
 
             /* We check that the offset is inside the vertex array */
@@ -2340,7 +2315,7 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
             for (int i = 0; STATIC_CAST(uint32_t, i) < nParts; i++)
             {
 #if defined(SHP_BIG_ENDIAN)
-                SwapWord(4, psShape->panPartType + i);
+                SHP_SWAP32(psShape->panPartType + i);
 #endif
             }
 
@@ -2358,8 +2333,8 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
                    8);
 
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, psShape->padfX + i);
-            SwapWord(8, psShape->padfY + i);
+            SHP_SWAPDOUBLE(psShape->padfX + i);
+            SHP_SWAPDOUBLE(psShape->padfY + i);
 #endif
         }
 
@@ -2372,12 +2347,12 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
             psShape->nSHPType == SHPT_ARCZ ||
             psShape->nSHPType == SHPT_MULTIPATCH)
         {
-            memcpy(&(psShape->dfZMin), psSHP->pabyRec + nOffset, 8);
-            memcpy(&(psShape->dfZMax), psSHP->pabyRec + nOffset + 8, 8);
+            memcpy(&psShape->dfZMin, psSHP->pabyRec + nOffset, 8);
+            memcpy(&psShape->dfZMax, psSHP->pabyRec + nOffset + 8, 8);
 
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, &(psShape->dfZMin));
-            SwapWord(8, &(psShape->dfZMax));
+            SHP_SWAPDOUBLE(&psShape->dfZMin);
+            SHP_SWAPDOUBLE(&psShape->dfZMax);
 #endif
 
             for (int i = 0; STATIC_CAST(uint32_t, i) < nPoints; i++)
@@ -2385,7 +2360,7 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
                 memcpy(psShape->padfZ + i,
                        psSHP->pabyRec + nOffset + 16 + i * 8, 8);
 #if defined(SHP_BIG_ENDIAN)
-                SwapWord(8, psShape->padfZ + i);
+                SHP_SWAPDOUBLE(psShape->padfZ + i);
 #endif
             }
 
@@ -2404,12 +2379,12 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
         /* -------------------------------------------------------------------- */
         if (nEntitySize >= STATIC_CAST(int, nOffset + 16 + 8 * nPoints))
         {
-            memcpy(&(psShape->dfMMin), psSHP->pabyRec + nOffset, 8);
-            memcpy(&(psShape->dfMMax), psSHP->pabyRec + nOffset + 8, 8);
+            memcpy(&psShape->dfMMin, psSHP->pabyRec + nOffset, 8);
+            memcpy(&psShape->dfMMax, psSHP->pabyRec + nOffset + 8, 8);
 
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, &(psShape->dfMMin));
-            SwapWord(8, &(psShape->dfMMax));
+            SHP_SWAPDOUBLE(&psShape->dfMMin);
+            SHP_SWAPDOUBLE(&psShape->dfMMax);
 #endif
 
             for (int i = 0; STATIC_CAST(uint32_t, i) < nPoints; i++)
@@ -2417,7 +2392,7 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
                 memcpy(psShape->padfM + i,
                        psSHP->pabyRec + nOffset + 16 + i * 8, 8);
 #if defined(SHP_BIG_ENDIAN)
-                SwapWord(8, psShape->padfM + i);
+                SHP_SWAPDOUBLE(psShape->padfM + i);
 #endif
             }
             psShape->bMeasureIsUsed = TRUE;
@@ -2450,7 +2425,7 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
         memcpy(&nPoints, psSHP->pabyRec + 44, 4);
 
 #if defined(SHP_BIG_ENDIAN)
-        SwapWord(4, &nPoints);
+        SHP_SWAP32(&nPoints);
 #endif
 
         /* nPoints is unsigned */
@@ -2528,8 +2503,8 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
             memcpy(psShape->padfY + i, psSHP->pabyRec + 48 + 16 * i + 8, 8);
 
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, psShape->padfX + i);
-            SwapWord(8, psShape->padfY + i);
+            SHP_SWAPDOUBLE(psShape->padfX + i);
+            SHP_SWAPDOUBLE(psShape->padfY + i);
 #endif
         }
 
@@ -2538,16 +2513,16 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
         /* -------------------------------------------------------------------- */
         /*      Get the X/Y bounds.                                             */
         /* -------------------------------------------------------------------- */
-        memcpy(&(psShape->dfXMin), psSHP->pabyRec + 8 + 4, 8);
-        memcpy(&(psShape->dfYMin), psSHP->pabyRec + 8 + 12, 8);
-        memcpy(&(psShape->dfXMax), psSHP->pabyRec + 8 + 20, 8);
-        memcpy(&(psShape->dfYMax), psSHP->pabyRec + 8 + 28, 8);
+        memcpy(&psShape->dfXMin, psSHP->pabyRec + 8 + 4, 8);
+        memcpy(&psShape->dfYMin, psSHP->pabyRec + 8 + 12, 8);
+        memcpy(&psShape->dfXMax, psSHP->pabyRec + 8 + 20, 8);
+        memcpy(&psShape->dfYMax, psSHP->pabyRec + 8 + 28, 8);
 
 #if defined(SHP_BIG_ENDIAN)
-        SwapWord(8, &(psShape->dfXMin));
-        SwapWord(8, &(psShape->dfYMin));
-        SwapWord(8, &(psShape->dfXMax));
-        SwapWord(8, &(psShape->dfYMax));
+        SHP_SWAPDOUBLE(&psShape->dfXMin);
+        SHP_SWAPDOUBLE(&psShape->dfYMin);
+        SHP_SWAPDOUBLE(&psShape->dfXMax);
+        SHP_SWAPDOUBLE(&psShape->dfYMax);
 #endif
 
         /* -------------------------------------------------------------------- */
@@ -2555,12 +2530,12 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
         /* -------------------------------------------------------------------- */
         if (psShape->nSHPType == SHPT_MULTIPOINTZ)
         {
-            memcpy(&(psShape->dfZMin), psSHP->pabyRec + nOffset, 8);
-            memcpy(&(psShape->dfZMax), psSHP->pabyRec + nOffset + 8, 8);
+            memcpy(&psShape->dfZMin, psSHP->pabyRec + nOffset, 8);
+            memcpy(&psShape->dfZMax, psSHP->pabyRec + nOffset + 8, 8);
 
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, &(psShape->dfZMin));
-            SwapWord(8, &(psShape->dfZMax));
+            SHP_SWAPDOUBLE(&psShape->dfZMin);
+            SHP_SWAPDOUBLE(&psShape->dfZMax);
 #endif
 
             for (int i = 0; STATIC_CAST(uint32_t, i) < nPoints; i++)
@@ -2568,7 +2543,7 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
                 memcpy(psShape->padfZ + i,
                        psSHP->pabyRec + nOffset + 16 + i * 8, 8);
 #if defined(SHP_BIG_ENDIAN)
-                SwapWord(8, psShape->padfZ + i);
+                SHP_SWAPDOUBLE(psShape->padfZ + i);
 #endif
             }
 
@@ -2585,12 +2560,12 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
         /* -------------------------------------------------------------------- */
         if (nEntitySize >= STATIC_CAST(int, nOffset + 16 + 8 * nPoints))
         {
-            memcpy(&(psShape->dfMMin), psSHP->pabyRec + nOffset, 8);
-            memcpy(&(psShape->dfMMax), psSHP->pabyRec + nOffset + 8, 8);
+            memcpy(&psShape->dfMMin, psSHP->pabyRec + nOffset, 8);
+            memcpy(&psShape->dfMMax, psSHP->pabyRec + nOffset + 8, 8);
 
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, &(psShape->dfMMin));
-            SwapWord(8, &(psShape->dfMMax));
+            SHP_SWAPDOUBLE(&psShape->dfMMin);
+            SHP_SWAPDOUBLE(&psShape->dfMMax);
 #endif
 
             for (int i = 0; STATIC_CAST(uint32_t, i) < nPoints; i++)
@@ -2598,7 +2573,7 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
                 memcpy(psShape->padfM + i,
                        psSHP->pabyRec + nOffset + 16 + i * 8, 8);
 #if defined(SHP_BIG_ENDIAN)
-                SwapWord(8, psShape->padfM + i);
+                SHP_SWAPDOUBLE(psShape->padfM + i);
 #endif
             }
             psShape->bMeasureIsUsed = TRUE;
@@ -2647,8 +2622,8 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
         memcpy(psShape->padfY, psSHP->pabyRec + 20, 8);
 
 #if defined(SHP_BIG_ENDIAN)
-        SwapWord(8, psShape->padfX);
-        SwapWord(8, psShape->padfY);
+        SHP_SWAPDOUBLE(psShape->padfX);
+        SHP_SWAPDOUBLE(psShape->padfY);
 #endif
 
         int nOffset = 20 + 8;
@@ -2661,7 +2636,7 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
             memcpy(psShape->padfZ, psSHP->pabyRec + nOffset, 8);
 
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, psShape->padfZ);
+            SHP_SWAPDOUBLE(psShape->padfZ);
 #endif
 
             nOffset += 8;
@@ -2678,7 +2653,7 @@ SHPObject SHPAPI_CALL1(*) SHPReadObject(SHPHandle psSHP, int hEntity)
             memcpy(psShape->padfM, psSHP->pabyRec + nOffset, 8);
 
 #if defined(SHP_BIG_ENDIAN)
-            SwapWord(8, psShape->padfM);
+            SHP_SWAPDOUBLE(psShape->padfM);
 #endif
             psShape->bMeasureIsUsed = TRUE;
         }

--- a/shptree.c
+++ b/shptree.c
@@ -13,7 +13,7 @@
  *
  */
 
-#include "shapefil.h"
+#include "shapefil_private.h"
 
 #include <math.h>
 #include <assert.h>
@@ -40,18 +40,6 @@
 /* -------------------------------------------------------------------- */
 
 #define SHP_SPLIT_RATIO 0.55
-
-#ifdef __cplusplus
-#define STATIC_CAST(type, x) static_cast<type>(x)
-#define REINTERPRET_CAST(type, x) reinterpret_cast<type>(x)
-#define CONST_CAST(type, x) const_cast<type>(x)
-#define SHPLIB_NULLPTR nullptr
-#else
-#define STATIC_CAST(type, x) ((type)(x))
-#define REINTERPRET_CAST(type, x) ((type)(x))
-#define CONST_CAST(type, x) ((type)(x))
-#define SHPLIB_NULLPTR NULL
-#endif
 
 /************************************************************************/
 /*                          SHPTreeNodeInit()                           */
@@ -677,22 +665,24 @@ void SHPAPI_CALL SHPTreeTrimExtraNodes(SHPTree *hTree)
 /************************************************************************/
 /*                              SwapWord()                              */
 /*                                                                      */
-/*      Swap a 2, 4 or 8 byte word.                                     */
+/*      Swap a 4 or 8 byte word.                                        */
 /************************************************************************/
 
 #ifndef SwapWord_defined
 #define SwapWord_defined
 static void SwapWord(int length, void *wordP)
-
 {
-    int i;
-
-    for (i = 0; i < length / 2; i++)
+    if (4 == length)
     {
-        unsigned char temp = STATIC_CAST(unsigned char *, wordP)[i];
-        STATIC_CAST(unsigned char *, wordP)
-        [i] = STATIC_CAST(unsigned char *, wordP)[length - i - 1];
-        STATIC_CAST(unsigned char *, wordP)[length - i - 1] = temp;
+        SHP_SWAP32(STATIC_CAST(uint32_t *, wordP));
+    }
+    else if (8 == length)
+    {
+        SHP_SWAP64(STATIC_CAST(uint64_t *, wordP));
+    }
+    else
+    {
+        assert(4 == length || 8 == length);
     }
 }
 #endif

--- a/shptree.c
+++ b/shptree.c
@@ -662,31 +662,6 @@ void SHPAPI_CALL SHPTreeTrimExtraNodes(SHPTree *hTree)
     SHPTreeNodeTrim(hTree->psRoot);
 }
 
-/************************************************************************/
-/*                              SwapWord()                              */
-/*                                                                      */
-/*      Swap a 4 or 8 byte word.                                        */
-/************************************************************************/
-
-#ifndef SwapWord_defined
-#define SwapWord_defined
-static void SwapWord(int length, void *wordP)
-{
-    if (4 == length)
-    {
-        SHP_SWAP32(STATIC_CAST(uint32_t *, wordP));
-    }
-    else if (8 == length)
-    {
-        SHP_SWAP64(STATIC_CAST(uint64_t *, wordP));
-    }
-    else
-    {
-        assert(4 == length || 8 == length);
-    }
-}
-#endif
-
 struct SHPDiskTreeInfo
 {
     SAHooks sHooks;
@@ -757,7 +732,7 @@ static bool SHPSearchDiskTreeNode(SHPTreeDiskHandle hDiskTree,
     nFReadAcc = STATIC_CAST(
         int, hDiskTree->sHooks.FRead(&offset, 4, 1, hDiskTree->fpQIX));
     if (bNeedSwap)
-        SwapWord(4, &offset);
+        SHP_SWAP32(&offset);
 
     nFReadAcc += STATIC_CAST(int, hDiskTree->sHooks.FRead(adfNodeBoundsMin,
                                                           sizeof(double), 2,
@@ -767,16 +742,16 @@ static bool SHPSearchDiskTreeNode(SHPTreeDiskHandle hDiskTree,
                                                           hDiskTree->fpQIX));
     if (bNeedSwap)
     {
-        SwapWord(8, adfNodeBoundsMin + 0);
-        SwapWord(8, adfNodeBoundsMin + 1);
-        SwapWord(8, adfNodeBoundsMax + 0);
-        SwapWord(8, adfNodeBoundsMax + 1);
+        SHP_SWAPDOUBLE(adfNodeBoundsMin + 0);
+        SHP_SWAPDOUBLE(adfNodeBoundsMin + 1);
+        SHP_SWAPDOUBLE(adfNodeBoundsMax + 0);
+        SHP_SWAPDOUBLE(adfNodeBoundsMax + 1);
     }
 
     nFReadAcc += STATIC_CAST(
         int, hDiskTree->sHooks.FRead(&numshapes, 4, 1, hDiskTree->fpQIX));
     if (bNeedSwap)
-        SwapWord(4, &numshapes);
+        SHP_SWAP32(&numshapes);
 
     /* Check that we could read all previous values */
     if (nFReadAcc != 1 + 2 + 2 + 1)
@@ -849,7 +824,7 @@ static bool SHPSearchDiskTreeNode(SHPTreeDiskHandle hDiskTree,
         if (bNeedSwap)
         {
             for (i = 0; i < numshapes; i++)
-                SwapWord(4, *ppanResultBuffer + *pnResultCount + i);
+                SHP_SWAP32(*ppanResultBuffer + *pnResultCount + i);
         }
 
         *pnResultCount += numshapes;
@@ -864,7 +839,7 @@ static bool SHPSearchDiskTreeNode(SHPTreeDiskHandle hDiskTree,
         return false;
     }
     if (bNeedSwap)
-        SwapWord(4, &numsubnodes);
+        SHP_SWAP32(&numsubnodes);
     if (numsubnodes > 0 && nRecLevel == 32)
     {
         hDiskTree->sHooks.Error("Shape tree is too deep");


### PR DESCRIPTION
Get rid of multiple definitions of SwapWord in favour of built-in swap functions.