### PR TITLE
Prefer builtin swap functions (alternative PR)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ set(lib_SRC
   shptree.c
   sbnsearch.c
   shapefil.h
+  shapefil_private.h
   shapelib.def
 )
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@
 SUBDIRS = . contrib
 
 ACLOCAL_AMFLAGS = -I m4
-AUTOMAKE_OPTIONS =      dist-zip
+AUTOMAKE_OPTIONS = dist-zip
 
 if PLATFORM_WIN32
 no_undefined = -no-undefined
@@ -37,6 +37,7 @@ pkgconfig_DATA = shapelib.pc
 lib_LTLIBRARIES = libshp.la
 libshp_la_includedir = $(includedir)
 libshp_la_include_HEADERS = shapefil.h
+noinst_HEADERS = shapefil_private.h
 libshp_la_SOURCES = shpopen.c dbfopen.c safileio.c shptree.c sbnsearch.c
 libshp_la_LDFLAGS = -version-info $(SHAPELIB_SO_VERSION) $(no_undefined) $(LIBM)
 

--- a/dbfopen.c
+++ b/dbfopen.c
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
  ******************************************************************************/
 
-#include "shapefil.h"
+#include "shapefil_private.h"
 
 #include <math.h>
 #include <stdbool.h>
@@ -66,18 +66,6 @@ CPL_INLINE static void CPL_IGNORE_RET_VAL_INT(CPL_UNUSED int unused)
 }
 #else
 #define CPL_IGNORE_RET_VAL_INT(x) x
-#endif
-
-#ifdef __cplusplus
-#define STATIC_CAST(type, x) static_cast<type>(x)
-#define REINTERPRET_CAST(type, x) reinterpret_cast<type>(x)
-#define CONST_CAST(type, x) const_cast<type>(x)
-#define SHPLIB_NULLPTR nullptr
-#else
-#define STATIC_CAST(type, x) ((type)(x))
-#define REINTERPRET_CAST(type, x) ((type)(x))
-#define CONST_CAST(type, x) ((type)(x))
-#define SHPLIB_NULLPTR NULL
 #endif
 
 /************************************************************************/

--- a/sbnsearch.c
+++ b/sbnsearch.c
@@ -10,7 +10,7 @@
  * SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
  ******************************************************************************/
 
-#include "shapefil.h"
+#include "shapefil_private.h"
 
 #include <assert.h>
 #include <math.h>
@@ -32,18 +32,6 @@
 #endif
 
 #define CACHED_DEPTH_LIMIT 8
-
-#ifdef __cplusplus
-#define STATIC_CAST(type, x) static_cast<type>(x)
-#define REINTERPRET_CAST(type, x) reinterpret_cast<type>(x)
-#define CONST_CAST(type, x) const_cast<type>(x)
-#define SHPLIB_NULLPTR nullptr
-#else
-#define STATIC_CAST(type, x) ((type)(x))
-#define REINTERPRET_CAST(type, x) ((type)(x))
-#define CONST_CAST(type, x) ((type)(x))
-#define SHPLIB_NULLPTR NULL
-#endif
 
 #define READ_MSB_INT(ptr)                                                      \
     STATIC_CAST(int, (((STATIC_CAST(unsigned, (ptr)[0])) << 24) |              \
@@ -112,21 +100,28 @@ typedef struct
 /************************************************************************/
 /*                              SwapWord()                              */
 /*                                                                      */
-/*      Swap a 2, 4 or 8 byte word.                                     */
+/*      Swap a 4 or 8 byte word.                                        */
 /************************************************************************/
 
+#if !defined(SHP_BIG_ENDIAN)
 #ifndef SwapWord_defined
 #define SwapWord_defined
 static void SwapWord(int length, void *wordP)
 {
-    for (int i = 0; i < length / 2; i++)
+    if (4 == length)
     {
-        const unsigned char temp = STATIC_CAST(unsigned char *, wordP)[i];
-        STATIC_CAST(unsigned char *, wordP)
-        [i] = STATIC_CAST(unsigned char *, wordP)[length - i - 1];
-        STATIC_CAST(unsigned char *, wordP)[length - i - 1] = temp;
+        SHP_SWAP32(STATIC_CAST(uint32_t *, wordP));
+    }
+    else if (8 == length)
+    {
+        SHP_SWAP64(STATIC_CAST(uint64_t *, wordP));
+    }
+    else
+    {
+        assert(4 == length || 8 == length);
     }
 }
+#endif
 #endif
 
 /************************************************************************/

--- a/shapefil_private.h
+++ b/shapefil_private.h
@@ -1,0 +1,68 @@
+#ifndef SHAPEFILE_PRIVATE_H_INCLUDED
+#define SHAPEFILE_PRIVATE_H_INCLUDED
+
+/******************************************************************************
+ *
+ * Project:  Shapelib
+ * Purpose:  Private include file for Shapelib.
+ * Author:   Frank Warmerdam, warmerdam@pobox.com
+ *
+ ******************************************************************************
+ * Copyright (c) 1999, Frank Warmerdam
+ * Copyright (c) 2012-2016, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
+ ******************************************************************************
+ *
+ */
+
+#ifdef __cplusplus
+#define STATIC_CAST(type, x) static_cast<type>(x)
+#define REINTERPRET_CAST(type, x) reinterpret_cast<type>(x)
+#define CONST_CAST(type, x) const_cast<type>(x)
+#define SHPLIB_NULLPTR nullptr
+#else
+#define STATIC_CAST(type, x) ((type)(x))
+#define REINTERPRET_CAST(type, x) ((type)(x))
+#define CONST_CAST(type, x) ((type)(x))
+#define SHPLIB_NULLPTR NULL
+#endif
+
+#include "shapefil.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+/************************************************************************/
+/*        Little endian <==> big endian byte swap macros.               */
+/************************************************************************/
+
+#if (defined(__GNUC__) && __GNUC__ >= 5) ||                                    \
+    (defined(__GNUC__) && defined(__GNUC_MINOR__) && __GNUC__ == 4 &&          \
+     __GNUC_MINOR__ >= 8)
+#define _SHP_SWAP32(x)                                                         \
+    STATIC_CAST(uint32_t, __builtin_bswap32(STATIC_CAST(uint32_t, x)))
+#define _SHP_SWAP64(x)                                                         \
+    STATIC_CAST(uint64_t, __builtin_bswap64(STATIC_CAST(uint64_t, x)))
+#elif defined(_MSC_VER)
+#define _SHP_SWAP32(x)                                                         \
+    STATIC_CAST(uint32_t, _byteswap_ulong(STATIC_CAST(uint32_t, x)))
+#define _SHP_SWAP64(x)                                                         \
+    STATIC_CAST(uint64_t, _byteswap_uint64(STATIC_CAST(uint64_t, x)))
+#else
+#define _SHP_SWAP32(x)                                                         \
+    STATIC_CAST(uint32_t,                                                      \
+                ((STATIC_CAST(uint32_t, x) & 0x000000ffU) << 24) |             \
+                    ((STATIC_CAST(uint32_t, x) & 0x0000ff00U) << 8) |          \
+                    ((STATIC_CAST(uint32_t, x) & 0x00ff0000U) >> 8) |          \
+                    ((STATIC_CAST(uint32_t, x) & 0xff000000U) >> 24))
+#define _SHP_SWAP64(x)                                                         \
+    ((STATIC_CAST(uint64_t, _SHP_SWAP32(STATIC_CAST(uint32_t, x))) << 32) |    \
+     (STATIC_CAST(uint64_t, _SHP_SWAP32(STATIC_CAST(                           \
+                                uint32_t, STATIC_CAST(uint64_t, x) >> 32)))))
+
+#endif
+
+#define SHP_SWAP32(p) *STATIC_CAST(uint32_t *, p) = _SHP_SWAP32(*(p))
+#define SHP_SWAP64(p) *STATIC_CAST(uint64_t *, p) = _SHP_SWAP64(*(p))
+
+#endif /* ndef SHAPEFILE_PRIVATE_H_INCLUDED */

--- a/shpopen.c
+++ b/shpopen.c
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
  ******************************************************************************/
 
-#include "shapefil.h"
+#include "shapefil_private.h"
 
 #include <assert.h>
 #include <errno.h>
@@ -46,30 +46,27 @@
 #endif
 #endif
 
-#ifdef __cplusplus
-#define STATIC_CAST(type, x) static_cast<type>(x)
-#define SHPLIB_NULLPTR nullptr
-#else
-#define STATIC_CAST(type, x) ((type)(x))
-#define SHPLIB_NULLPTR NULL
-#endif
-
 /************************************************************************/
 /*                              SwapWord()                              */
 /*                                                                      */
-/*      Swap a 2, 4 or 8 byte word.                                     */
+/*      Swap a 4 or 8 byte word.                                        */
 /************************************************************************/
 
 #ifndef SwapWord_defined
 #define SwapWord_defined
 static void SwapWord(int length, void *wordP)
 {
-    for (int i = 0; i < length / 2; i++)
+    if (4 == length)
     {
-        const unsigned char temp = STATIC_CAST(unsigned char *, wordP)[i];
-        STATIC_CAST(unsigned char *, wordP)
-        [i] = STATIC_CAST(unsigned char *, wordP)[length - i - 1];
-        STATIC_CAST(unsigned char *, wordP)[length - i - 1] = temp;
+        SHP_SWAP32(STATIC_CAST(uint32_t *, wordP));
+    }
+    else if (8 == length)
+    {
+        SHP_SWAP64(STATIC_CAST(uint64_t *, wordP));
+    }
+    else
+    {
+        assert(4 == length || 8 == length);
     }
 }
 #endif

--- a/shptree.c
+++ b/shptree.c
@@ -13,7 +13,7 @@
  *
  */
 
-#include "shapefil.h"
+#include "shapefil_private.h"
 
 #include <math.h>
 #include <assert.h>
@@ -40,18 +40,6 @@
 /* -------------------------------------------------------------------- */
 
 #define SHP_SPLIT_RATIO 0.55
-
-#ifdef __cplusplus
-#define STATIC_CAST(type, x) static_cast<type>(x)
-#define REINTERPRET_CAST(type, x) reinterpret_cast<type>(x)
-#define CONST_CAST(type, x) const_cast<type>(x)
-#define SHPLIB_NULLPTR nullptr
-#else
-#define STATIC_CAST(type, x) ((type)(x))
-#define REINTERPRET_CAST(type, x) ((type)(x))
-#define CONST_CAST(type, x) ((type)(x))
-#define SHPLIB_NULLPTR NULL
-#endif
 
 /************************************************************************/
 /*                          SHPTreeNodeInit()                           */
@@ -677,22 +665,24 @@ void SHPAPI_CALL SHPTreeTrimExtraNodes(SHPTree *hTree)
 /************************************************************************/
 /*                              SwapWord()                              */
 /*                                                                      */
-/*      Swap a 2, 4 or 8 byte word.                                     */
+/*      Swap a 4 or 8 byte word.                                        */
 /************************************************************************/
 
 #ifndef SwapWord_defined
 #define SwapWord_defined
 static void SwapWord(int length, void *wordP)
-
 {
-    int i;
-
-    for (i = 0; i < length / 2; i++)
+    if (4 == length)
     {
-        unsigned char temp = STATIC_CAST(unsigned char *, wordP)[i];
-        STATIC_CAST(unsigned char *, wordP)
-        [i] = STATIC_CAST(unsigned char *, wordP)[length - i - 1];
-        STATIC_CAST(unsigned char *, wordP)[length - i - 1] = temp;
+        SHP_SWAP32(STATIC_CAST(uint32_t *, wordP));
+    }
+    else if (8 == length)
+    {
+        SHP_SWAP64(STATIC_CAST(uint64_t *, wordP));
+    }
+    else
+    {
+        assert(4 == length || 8 == length);
     }
 }
 #endif


### PR DESCRIPTION
This is an alternative PR for #94 to hopefully branch off from a working code base (instead of trying to fix the broken code of #94). It uses the builtin swap functions while keeping the SwapWord interface.

This is not meant for merging, just for getting some feedback how the libshp behaves in GDAL.