### PR TITLE
CMake: Add GTA Run Settings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,6 +16,7 @@ EXTRA_DIST = makefile.vc CMakeLists.txt autogen.sh \
 		cmake/contrib.cmake \
 		cmake/project-config-version.cmake.in \
 		cmake/project-config.cmake.in \
+		cmake/shapelib.gta.runsettings.in \
 		cmake/shapelib.pc.cmake.in \
 		tests/CMakeLists.txt \
 		tests/dbf_test.cc \

--- a/cmake/shapelib.gta.runsettings.in
+++ b/cmake/shapelib.gta.runsettings.in
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+	<GoogleTestAdapterSettings>
+		<SolutionSettings>
+			<Settings>
+				<WorkingDir>@PROJECT_SOURCE_DIR@</WorkingDir>
+			</Settings>
+		</SolutionSettings>
+	</GoogleTestAdapterSettings>
+</RunSettings>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,3 +33,9 @@ foreach(executable dbf_test sbn_test shp_test)
   target_compile_features(${executable} PUBLIC cxx_std_17)
   set_target_properties(${executable} PROPERTIES FOLDER "tests" CXX_EXTENSIONS OFF)
 endforeach()
+
+configure_file(
+  ${CMAKE_SOURCE_DIR}/cmake/shapelib.gta.runsettings.in
+  ${CMAKE_BINARY_DIR}/shapelib.gta.runsettings
+  @ONLY
+)


### PR DESCRIPTION
This PR generates the Run Settings file for the GoogleTestAdapter (GTA) with the expected working directory to run the GoogleTest based unit tests from Test Explorer in Visual Studio.

![image](https://github.com/user-attachments/assets/34cf9127-b724-4548-abd5-965413e87e3d)

Resolves #143