### PR TITLE
CMake ≥ 3.21: Fix ctest paths for shared libs (MSVC and CygWin)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
             cd shapelib-*
             cmake .
             cmake --build . -j$(nproc)
-            ctest --test-dir . --verbose
+            ctest --no-tests=error --test-dir . --verbose
 
   build-cmake:
     name: ${{ matrix.toolchain }}
@@ -52,8 +52,7 @@ jobs:
         toolchain:
           - linux-gcc
           - macos-clang
-          - windows-msvc-shared
-          - windows-msvc-static
+          - windows-msvc
 
         configuration:
           - Release
@@ -67,11 +66,7 @@ jobs:
             os: macos-latest
             compiler: clang
 
-          - toolchain: windows-msvc-shared
-            os: windows-latest
-            compiler: msvc
-
-          - toolchain: windows-msvc-static
+          - toolchain: windows-msvc
             os: windows-latest
             compiler: msvc
 
@@ -81,10 +76,8 @@ jobs:
 
       - name: Configure (${{ matrix.configuration }})
         run: |
-          if [ "${{ matrix.toolchain }}" == "windows-msvc-shared" ]; then
-            cmake -S . -Bbuild -DCMAKE_UNITY_BUILD=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=~/install
-          elif [ "${{ matrix.toolchain }}" == "windows-msvc-static" ]; then
-            cmake -S . -Bbuild -DCMAKE_UNITY_BUILD=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DBUILD_TESTING=ON -DBASH_EXECUTABLE="C:/Program Files/Git/bin/bash.exe" -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=~/install
+          if [ "${{ matrix.toolchain }}" == "windows-msvc" ]; then
+            cmake -S . -Bbuild -DCMAKE_UNITY_BUILD=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DBUILD_TESTING=ON -DCMAKE_INSTALL_PREFIX=~/install
           else
             cmake -S . -Bbuild -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -DCMAKE_UNITY_BUILD=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DBUILD_TESTING=ON -DCMAKE_INSTALL_PREFIX=~/install
           fi
@@ -98,7 +91,7 @@ jobs:
           fi
 
       - name: Test
-        run: ctest --test-dir build --build-config ${{ matrix.configuration }} --verbose
+        run: ctest --no-tests=error --test-dir build --build-config ${{ matrix.configuration }} --verbose
 
       - name: Install
         run: |
@@ -143,9 +136,7 @@ jobs:
       - name: Test
         run: |
           export PATH=/usr/bin:/usr/local/bin:$PATH
-          cp ./build/*.dll ./build/tests/
-          cp ./build/bin/*.dll ./build/tests/
-          ctest --test-dir build --build-config Release --verbose
+          ctest --no-tests=error --test-dir build --build-config Release --verbose
         shell: C:\cygwin\bin\bash.exe -eo pipefail -o igncr '{0}'
 
   build-nmake:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,7 @@ if(BUILD_TESTING)
   foreach(executable shptest shputils)
     add_executable(${executable} ${executable}.c)
     target_link_libraries(${executable} PRIVATE ${PACKAGE})
-    if (WIN32 OR CYGWIN)
+    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.21" AND (WIN32 OR CYGWIN))
       add_custom_command(
         TARGET ${executable} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${executable}> $<TARGET_FILE_DIR:${executable}>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 
 # In windows all created dlls are gathered in the dll directory
 # if you add this directory to your PATH all shared libraries are available
-if(BUILD_SHARED_LIBS AND WIN32 AND NOT CYGWIN)
+if(BUILD_SHARED_LIBS AND (WIN32 OR CYGWIN))
   set(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/dll)
 endif()
 
@@ -250,6 +250,13 @@ if(BUILD_TESTING)
   foreach(executable shptest shputils)
     add_executable(${executable} ${executable}.c)
     target_link_libraries(${executable} PRIVATE ${PACKAGE})
+    if (WIN32 OR CYGWIN)
+      add_custom_command(
+        TARGET ${executable} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${executable}> $<TARGET_FILE_DIR:${executable}>
+        COMMAND_EXPAND_LISTS
+      )
+    endif()
   endforeach()
 
   # Set environment variables defining path to executables being used

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,13 @@ foreach(executable dbf_test sbn_test shp_test)
   )
   target_compile_features(${executable} PUBLIC cxx_std_17)
   set_target_properties(${executable} PROPERTIES FOLDER "tests" CXX_EXTENSIONS OFF)
+  if (WIN32 OR CYGWIN)
+    add_custom_command(
+      TARGET ${executable} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${executable}> $<TARGET_FILE_DIR:${executable}>
+      COMMAND_EXPAND_LISTS
+    )
+  endif()
 endforeach()
 
 configure_file(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ foreach(executable dbf_test sbn_test shp_test)
   )
   target_compile_features(${executable} PUBLIC cxx_std_17)
   set_target_properties(${executable} PROPERTIES FOLDER "tests" CXX_EXTENSIONS OFF)
-  if (WIN32 OR CYGWIN)
+  if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.21" AND (WIN32 OR CYGWIN))
     add_custom_command(
       TARGET ${executable} POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${executable}> $<TARGET_FILE_DIR:${executable}>


### PR DESCRIPTION
This PR fixes the DLL paths for the testsuite (both GoogleTest based unittests and script-based tests) when built with CMake shared libs for MSVC and CygWin.

I tried a lot actually. In the end the solution from https://stackoverflow.com/a/72341403/8520615 worked out.

Additionally

- the special cases and workarounds in the CMake CI builds are removed from the GitHub Actions.
- the ctest option [--no-tests](https://cmake.org/cmake/help/latest/manual/ctest.1.html#cmdoption-ctest-no-tests)=error was added to not silently accept CI builds with -DBUILD_TESTING=**OFF** (as I did by accident during refactoring).

Resolves #142