### PR TITLE
Fix diff command to only set --strip-trailing-cr if available

### DIFF
--- a/contrib/tests/shpproj.sh
+++ b/contrib/tests/shpproj.sh
@@ -21,12 +21,12 @@ readonly SCRIPTDIR=$(dirname "$0")
 
 "${SHPDUMP:-$top_builddir/shpdump}" -precision 8 "test" > "test.out"
 
-is_windows() {
-	[ -n "$WINDIR" ] || uname | grep -q "MINGW"
+supports_strip_trailing_cr() {
+	diff --help 2>/dev/null | grep -q -- '--strip-trailing-cr'
 }
 
 run_diff() {
-	if is_windows; then
+	if supports_strip_trailing_cr; then
 		diff --strip-trailing-cr "$SCRIPTDIR/expect.out" "test.out"
 	else
 		diff "$SCRIPTDIR/expect.out" "test.out"

--- a/contrib/tests/shpproj.sh
+++ b/contrib/tests/shpproj.sh
@@ -21,8 +21,19 @@ readonly SCRIPTDIR=$(dirname "$0")
 
 "${SHPDUMP:-$top_builddir/shpdump}" -precision 8 "test" > "test.out"
 
+is_windows() {
+	[ -n "$WINDIR" ] || uname | grep -q "MINGW"
+}
 
-if result=$(diff --strip-trailing-cr "$SCRIPTDIR/expect.out" "test.out"); then
+run_diff() {
+	if is_windows; then
+		diff --strip-trailing-cr "$SCRIPTDIR/expect.out" "test.out"
+	else
+		diff "$SCRIPTDIR/expect.out" "test.out"
+	fi
+}
+
+if result=$(run_diff); then
 	echo "******* Test Succeeded *********"
 	exit 0
 else


### PR DESCRIPTION
As reported by https://github.com/OSGeo/shapelib/pull/111#issuecomment-2286097239.