### PR TITLE
API doc: Fix const-correctness

### DIFF
--- a/web/dbf_api.html
+++ b/web/dbf_api.html
@@ -54,7 +54,7 @@ DBFHandle DBFCreate( const char * pszDBFFile );
 <h2>DBFGetFieldCount()</h2>
 
 <pre>
-int DBFGetFieldCount( DBFHandle hDBF );
+int DBFGetFieldCount( const DBFHandle hDBF );
 
   hDBF:		The access handle for the file to be queried, as returned
                 by DBFOpen(), or DBFCreate().
@@ -68,7 +68,7 @@ int DBFGetFieldCount( DBFHandle hDBF );
 <h2>DBFGetRecordCount()</h2>
 
 <pre>
-int DBFGetRecordCount( DBFHandle hDBF );
+int DBFGetRecordCount( const DBFHandle hDBF );
 
   hDBF:		The access handle for the file to be queried, as returned by
 		DBFOpen(), or DBFCreate().
@@ -83,7 +83,7 @@ int DBFGetRecordCount( DBFHandle hDBF );
 <h2>DBFGetFieldIndex()</h2>
 
 <pre>
-int DBFGetFieldIndex( DBFHandle hDBF, const char *pszFieldName );
+int DBFGetFieldIndex( const DBFHandle hDBF, const char *pszFieldName );
 
   hDBF:		The access handle for the file to be queried, as returned by
 		DBFOpen(), or DBFCreate().
@@ -99,7 +99,8 @@ int DBFGetFieldIndex( DBFHandle hDBF, const char *pszFieldName );
 <h2>DBFGetFieldInfo()</h2>
 
 <pre>
-DBFFieldType DBFGetFieldInfo( DBFHandle hDBF, int iField, char * pszFieldName,
+DBFFieldType DBFGetFieldInfo( const  DBFHandle hDBF, int iField,
+                              char * pszFieldName,
                               int * pnWidth, int * pnDecimals );
 
   hDBF:		The access handle for the file to be queried, as returned by
@@ -127,16 +128,16 @@ DBFFieldType DBFGetFieldInfo( DBFHandle hDBF, int iField, char * pszFieldName,
   The DBFGetFieldInfo() returns the type of the requested field, which is
   one of the DBFFieldType enumerated values.  As well, the field name, and
   field width information can optionally be returned.  The field type returned
-  does not correspond one to one with the xBase field types.  For instance
-  the xBase field type for Date will just be returned as being FTInteger.  <p>
+  does not correspond one to one with the xBase field types.  <p>
 
 <pre>
     typedef enum {
-      FTString,			/* fixed length string field 		*/
-      FTInteger,		/* numeric field with no decimals 	*/
-      FTDouble,			/* numeric field with decimals 		*/
-      FTLogical,		/* logical field.                       */
-      FTInvalid                 /* not a recognised field type 		*/
+      FTString,			/* fixed length string field        */
+      FTInteger,		/* numeric field with no decimals   */
+      FTDouble,			/* numeric field with decimals      */
+      FTLogical,		/* logical field                    */
+      FTDate,			/* date field                       */
+      FTInvalid			/* not a recognised field type      */
     } DBFFieldType;
 </pre>
 
@@ -251,7 +252,7 @@ const char *DBFReadStringAttribute( DBFHandle hDBF, int iShape, int iField );
 <h2>DBFIsAttributeNULL()</h2>
 
 <pre>
-int DBFIsAttributeNULL( DBFHandle hDBF, int iShape, int iField );
+int DBFIsAttributeNULL( const DBFHandle hDBF, int iShape, int iField );
 
   hDBF:		The access handle for the file to be queried, as returned by
 		DBFOpen(), or DBFCreate().
@@ -382,7 +383,7 @@ void DBFClose( DBFHandle hDBF );
 <h2>DBFIsRecordDeleted()</h2>
 
 <pre>
-int DBFIsRecordDeleted( DBFHandle hDBF, int iShape );
+int DBFIsRecordDeleted( const DBFHandle hDBF, int iShape );
 
   hDBF:		The access handle for the file to be checked.
   iShape:       The record index to check.
@@ -410,7 +411,7 @@ int DBFMarkRecordDeleted( DBFHandle hDBF, int iShape, int bIsDeleted );
 <h2>DBFGetNativeFieldType()</h2>
 
 <pre>
-char DBFGetNativeFieldType( DBFHandle hDBF, int iField );
+char DBFGetNativeFieldType( const DBFHandle hDBF, int iField );
 
   hDBF:		The access handle for the file.
   iField:       The field index to query.

--- a/web/shp_api.html
+++ b/web/shp_api.html
@@ -82,6 +82,9 @@ should be disposed of with SHPDestroyObject().<p>
     double	dfYMax;
     double	dfZMax;
     double	dfMMax;
+
+    int bMeasureIsUsed;
+    int bFastModeReadObject;
   } SHPObject;
 </pre>
 
@@ -113,7 +116,7 @@ SHPHandle SHPOpen( const char * pszShapeFile, const char * pszAccess );
 <h2>SHPGetInfo()</h2>
 
 <pre>
-void SHPGetInfo( SHPHandle hSHP, int * pnEntities, int * pnShapeType,
+void SHPGetInfo( const SHPHandle hSHP, int * pnEntities, int * pnShapeType,
                  double * padfMinBound, double * padfMaxBound );
 
   hSHP:			The handle previously returned by SHPOpen()
@@ -143,7 +146,7 @@ void SHPGetInfo( SHPHandle hSHP, int * pnEntities, int * pnShapeType,
 <h2>SHPReadObject()</h2>
 
 <pre>
-SHPObject *SHPReadObject( SHPHandle hSHP, int iShape );
+SHPObject *SHPReadObject( const SHPHandle hSHP, int iShape );
 
   hSHP:			The handle previously returned by SHPOpen()
 			or SHPCreate().
@@ -210,7 +213,8 @@ SHPHandle SHPCreate( const char * pszShapeFile, int nShapeType );
 <pre>
 SHPObject *
      SHPCreateSimpleObject( int nSHPType, int nVertices,
-			    double *padfX, double * padfY, double *padfZ, );
+			    const double *padfX, const double * padfY,
+			    const double *padfZ );
 
   nSHPType:		The SHPT_ type of the object to be created, such
                         as SHPT_POINT, or SHPT_POLYGON.
@@ -250,9 +254,10 @@ SHPObject *
 <pre>
 SHPObject *
      SHPCreateObject( int nSHPType, int iShape,
-                      int nParts, int * panPartStart, int * panPartType,
-                      int nVertices, double *padfX, double * padfY,
-                      double *padfZ, double *padfM );
+                      int nParts, const int * panPartStart,
+                      const int * panPartType,
+                      int nVertices, const double *padfX, const double * padfY,
+                      const double *padfZ, const double *padfM );
 
   nSHPType:		The SHPT_ type of the object to be created, such
                         as SHPT_POINT, or SHPT_POLYGON.
@@ -321,7 +326,7 @@ void SHPComputeExtents( SHPObject * psObject );
 <h2>SHPWriteObject()</h2>
 
 <pre>
-int SHPWriteObject( SHPHandle hSHP, int iShape, SHPObject *psObject );
+int SHPWriteObject( SHPHandle hSHP, int iShape, const SHPObject *psObject );
 
   hSHP:			The handle previously returned by SHPOpen("r+")
 			or SHPCreate().


### PR DESCRIPTION
I only touched the existing functions (to gain at least consistency) but won't add the missing API functions.