### PR TITLE
Run benchmark on SHPSetFastModeReadObject

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,7 @@ EXTRA_DIST = makefile.vc CMakeLists.txt autogen.sh \
 		tests/CMakeLists.txt \
 		tests/dbf_test.cc \
 		tests/sbn_test.cc \
+		tests/shp_bench.cc \
 		tests/shp_test.cc \
 		tests/test1.sh tests/test2.sh tests/test3.sh \
 		tests/expect1.out tests/expect2.out tests/expect3.out \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,14 +2,29 @@
 
 project(${CMAKE_PROJECT_NAME}Tests CXX)
 
-# Set up GoogleTest
+# Set up GoogleTest and Benchmark
 include(FetchContent)
+
+FetchContent_Declare(
+  benchmark
+  GIT_REPOSITORY https://github.com/google/benchmark.git
+  GIT_TAG c19cfee61e136effb05a7fc8a037b0db3b13bd4c
+  GIT_SHALLOW TRUE
+)
 
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
   GIT_TAG v1.15.2
+  GIT_SHALLOW TRUE
 )
+
+set(BENCHMARK_DOWNLOAD_DEPENDENCIES OFF CACHE BOOL "" FORCE)
+set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
+set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+set(BENCHMARK_INSTALL_DOCS OFF CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(benchmark)
 
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
@@ -22,16 +37,23 @@ set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(googletest)
 
-foreach(executable dbf_test sbn_test shp_test)
+set_target_properties(gtest gtest_main benchmark benchmark_main PROPERTIES FOLDER "tests/third-party")
+
+foreach(executable dbf_test sbn_test shp_test shp_bench)
   add_executable(${executable} ${PROJECT_SOURCE_DIR}/${executable}.cc)
-  target_link_libraries(${executable} PRIVATE ${PACKAGE} gtest)
+  target_link_libraries(${executable} PRIVATE ${PACKAGE} gtest benchmark)
   add_test(
     NAME ${executable}
     COMMAND ${executable}
     WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
   )
   target_compile_features(${executable} PUBLIC cxx_std_17)
-  set_target_properties(${executable} PROPERTIES FOLDER "tests" CXX_EXTENSIONS OFF)
+  if("${executable}" MATCHES ".*_bench$")
+    set(exec_folder "tests/bench")
+  else()
+    set(exec_folder "tests")
+  endif()  
+  set_target_properties(${executable} PROPERTIES FOLDER ${exec_folder} CXX_EXTENSIONS OFF)
   if (BUILD_SHARED_LIBS AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.21" AND (WIN32 OR CYGWIN))
     add_custom_command(
       TARGET ${executable} POST_BUILD

--- a/tests/shp_bench.cc
+++ b/tests/shp_bench.cc
@@ -1,0 +1,39 @@
+#include <filesystem>
+
+#include <benchmark/benchmark.h>
+#include "shapefil.h"
+
+namespace fs = std::filesystem;
+
+namespace
+{
+
+static const auto kTestData = fs::path{"shape_eg_data"};
+
+template <int fastMode> static void Benchmark_ReadAll(benchmark::State &state)
+{
+    const auto filename = kTestData / "mpatch3.shp";
+    const auto handle = SHPOpen(filename.string().c_str(), "rb");
+    SHPSetFastModeReadObject(handle, fastMode);
+    int nEntities;
+    SHPGetInfo(handle, &nEntities, nullptr, nullptr, nullptr);
+    for (auto _ : state)
+    {
+        for (int i = 0; i < nEntities; ++i)
+        {
+            auto obj = SHPReadObject(handle, i);
+            SHPDestroyObject(obj);
+        }
+    }
+    SHPClose(handle);
+}
+
+constexpr auto Benchmark_ReadAllSlow = Benchmark_ReadAll<0>;
+constexpr auto Benchmark_ReadAllFast = Benchmark_ReadAll<1>;
+
+BENCHMARK(Benchmark_ReadAllSlow);
+BENCHMARK(Benchmark_ReadAllFast);
+
+}  // namespace
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
This PR demonstrates the advantage of SHPSetFastModeReadObject (for serial iteration of shape objects) because I wanted to see some actual bench mark numbers.

It adds Google Benchmark as another test dependency. I needed very latest HEAD https://github.com/google/benchmark/commit/c19cfee61e136effb05a7fc8a037b0db3b13bd4c of today to work around a Win compiler warning (treated as error).