### PR TITLE
Update CMake build dependencies: Remove include(CTest) (/w enable_testing() still set) and fix Google Benchmark 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,8 +292,6 @@ if(BUILD_TESTING)
   )
   declare_test_executable(test3 "dbfadd;dbfcreate;dbfdump;shpadd;shpcreate;shpdump")
 
-  include(CTest)
-
   add_subdirectory(tests)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# CMake configuration for SHP C++ unit tests
+# CMake configuration for C++ unit tests
 
 project(${CMAKE_PROJECT_NAME}Tests CXX)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,6 @@ FetchContent_Declare(
   benchmark
   GIT_REPOSITORY https://github.com/google/benchmark.git
   GIT_TAG c19cfee61e136effb05a7fc8a037b0db3b13bd4c
-  GIT_SHALLOW TRUE
 )
 
 FetchContent_Declare(


### PR DESCRIPTION
1. CTest dependency is not required and considered controversial because it introduces extra build targets
2. Google Benchmark can no longer be downloaded with shallow flag set