### PR TITLE
CMake: add manual BUILD_TESTING option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ else()
   option(USE_RPATH "Use -rpath when linking libraries, executables" ON)
 endif()
 
+option(BUILD_TESTING "Build the testing tree." ON)
+
 # In windows all created dlls are gathered in the dll directory
 # if you add this directory to your PATH all shared libraries are available
 if(BUILD_SHARED_LIBS AND (WIN32 OR CYGWIN))


### PR DESCRIPTION
1f8573b4e979eeb4d5988ef79d24d11cdf221627 removed include(CTest) but that module was useful to define the BUILD_TESTING option. Manually define it