### PR TITLE
Prefer tagged version of Google Benchmark

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,8 @@ include(FetchContent)
 FetchContent_Declare(
   benchmark
   GIT_REPOSITORY https://github.com/google/benchmark.git
-  GIT_TAG c19cfee61e136effb05a7fc8a037b0db3b13bd4c
+  GIT_TAG v1.9.1
+  GIT_SHALLOW TRUE
 )
 
 FetchContent_Declare(


### PR DESCRIPTION
With Google Benchmark [v1.9.1](https://github.com/google/benchmark/releases/tag/v1.9.1) available we can switch to a released version and shallow clone again.