### PR TITLE
Build: cmake polish, notably BUILD_TESTING option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,8 +206,9 @@ endif()
 
 find_program(BASH_EXECUTABLE bash)
 if(BASH_EXECUTABLE)
-  set(BUILD_TESTING ON CACHE BOOL "Build the testing tree.")
+  option(BUILD_TESTING "Build tests"  ON)
 else()
+  set(BUILD_TESTING OFF CACHE BOOL "Disable tests")
   message(STATUS "WARNING: bash not available so disabling testing")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@
 #
 # See README.CMake
 
+set(PACKAGE shp)
+if (TARGET ${PACKAGE})
+  return ()
+endif ()
+
 # Version 3.11 or above of cmake is currently required for all platforms.
 cmake_minimum_required(VERSION 3.11)
 project(shapelib C CXX)
@@ -49,7 +54,6 @@ if(BUILD_SHARED_LIBS AND (WIN32 OR CYGWIN))
   set(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/dll)
 endif()
 
-set(PACKAGE shp)
 
 # Set up install locations.
 set(


### PR DESCRIPTION
Two minor cmake tweaks:
1. Add a guard against multiple inclusions which might happen when part of larger builds.
2. Make the BUILD_TESTING variable an option which can be set by user.

These changes should AFAICT be backwards compatible.

Exported from the opencpn project at github.com://opencpn/opencpn (Well, not really now, but soon).