### PR TITLE
Fix build failure with GCC 15 (bool is keyword).

### DIFF
--- a/dbfadd.c
+++ b/dbfadd.c
@@ -45,7 +45,7 @@ int main(int argc, char **argv)
     const int iRecord = DBFGetRecordCount(hDBF);
 
     SHPDate date;
-    char bool;
+    char boolean;
 
     // Loop assigning the new field values.
     for (int i = 0; i < DBFGetFieldCount(hDBF); i++)
@@ -64,9 +64,9 @@ int main(int argc, char **argv)
         }
         else if (DBFGetFieldInfo(hDBF, i, NULL, NULL, NULL) == FTLogical)
         {
-            if (1 == sscanf(argv[i + 2], "%c", &bool))
+            if (1 == sscanf(argv[i + 2], "%c", &boolean))
             {
-                DBFWriteLogicalAttribute(hDBF, iRecord, i, bool);
+                DBFWriteLogicalAttribute(hDBF, iRecord, i, boolean);
             }
         }
         else


### PR DESCRIPTION
> C23 added various new keywords, including `bool`, `true`, `false`, `nullptr`, and `thread_local`.

https://gcc.gnu.org/gcc-15/porting_to.html#c23-new-keywords